### PR TITLE
Fix joystick button toggle actions repeating indefinitely

### DIFF
--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -266,6 +266,11 @@ bool JoystickController::handleEvent(const SEvent::SJoystickEvent &ev)
 
 		if (keys_pressed[i] && !(m_keys_down[i]))
 			m_keys_pressed[i] = true;
+		else
+			// HACK: Reset to avoid toggle actions repeating every frame.
+			// The proper fix would be to not accumulate m_keys_pressed
+			// across frames in the first place.
+			m_keys_pressed[i] = false;
 
 		m_keys_down[i] = keys_pressed[i];
 	}

--- a/src/client/joystick_controller.cpp
+++ b/src/client/joystick_controller.cpp
@@ -264,13 +264,14 @@ bool JoystickController::handleEvent(const SEvent::SJoystickEvent &ev)
 			m_keys_released[i] = true;
 		}
 
-		if (keys_pressed[i] && !(m_keys_down[i]))
+		if (keys_pressed[i] && !(m_keys_down[i])) {
 			m_keys_pressed[i] = true;
-		else
+		} else {
 			// HACK: Reset to avoid toggle actions repeating every frame.
 			// The proper fix would be to not accumulate m_keys_pressed
 			// across frames in the first place.
 			m_keys_pressed[i] = false;
+		}
 
 		m_keys_down[i] = keys_pressed[i];
 	}


### PR DESCRIPTION
## Summary

Fix joystick button toggle actions repeating indefinitely

When a joystick button was pressed, toggle actions (like minimap, camera mode) would repeat continuously instead of triggering once.

The issue was that `m_keys_pressed[i]` was set to true when a button was pressed, but was never reset to false when the button state remained unchanged or was released. This caused toggle actions to be re-triggered every frame.

Now properly reset `m_keys_pressed[i]` to false when the button is not in a "just pressed" state, ensuring toggle actions only fire once per button press.

## Details

**Goal:** Fix joystick toggle button behavior to match keyboard behavior (single activation per press)

**How it works:** 
- Added `else` branch to reset `m_keys_pressed[i] = false` when button is not in "just pressed" state
- This ensures the flag is only true for exactly one frame when transitioning from unpressed to pressed

**Issue resolved:** Fixes unreported bug where any joystick button mapped to a toggle action (MINIMAP, CAMERA_MODE, FREEMOVE, etc.) would continuously trigger every frame instead of once per press

**Why needed:** 
- Makes joystick controls usable for toggle actions
- Brings joystick behavior in line with keyboard input handling
- Essential for proper gamepad support

**AI disclosure:** Claude (Anthropic) was used to help identify the root cause and suggest the fix during debugging session

## To do

This PR is Ready for Review.

- [x] Fix identified and implemented
- [x] Tested with joystick/gamepad controllers (PS5 DualSense support is in a separate PR)
- [x] Verified toggle actions (minimap, camera mode, fly mode) now trigger once per button press

## How to test

1. Connect a joystick/gamepad to your system
2. Map any button to a toggle action (e.g., MINIMAP on D-pad, CAMERA_MODE on face button)
3. **Before fix:** Press and release the button → action toggles rapidly multiple times
4. **After fix:** Press and release the button → action toggles exactly once
5. Test with multiple toggle actions: MINIMAP, CAMERA_MODE, FREEMOVE, TOGGLE_HUD, etc.

Example config to test:
```ini
joystick_type = xbox  # or auto
# Map button to a toggle action in settings
```

Press the mapped button and verify the action toggles once, not continuously.