### PR TITLE
Don't frame as error when player is disconnected using `core.disconnect_player`

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -86,7 +86,7 @@ function ui.update()
 		if string.find(gamedata.errormessage, "ModError") then
 			error_title = fgettext("An error occurred in a Lua script:")
 		else
-			error_title = fgettext("An error occurred:")
+			error_title = fgettext("The server has denied access:")
 		end
 		formspec = {ui.get_message_formspec(error_title, error_message, "btn_error_confirm")}
 		ui.overridden = true


### PR DESCRIPTION
Fixes #14986 

Simply changes the form when a player is disconnected using `core.disconnect_player` to say "The server has denied access" rather than the misleading "An error occurred"

## To do

idk

## How to test

<!-- Example code or instructions -->

1. run `/lua core.disconnect_player(me:get_player_name(), "some reason text")`
2. observe that an error does _not_ occur, and it shows "The server has denied access"

<img width="555" height="371" alt="Screenshot From 2026-01-07 10-21-42" src="https://github.com/user-attachments/assets/cd827ee1-4359-4eef-bd91-df802a216149" />

