### PR TITLE
Add 'curl_proxy' setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2387,7 +2387,7 @@ curl_timeout (cURL interactive timeout) int 20000 1000 2147483647
 
 #    Set proxy to use by cURL. This is an URI just like the *_proxy environment variables.
 #    Note that this will not apply to Luanti's in-game protocol.
-curl_proxy (cURL proxy address) string
+secure.curl_proxy (cURL proxy address) string
 
 #    Limits number of parallel HTTP requests. Affects:
 #    -    Media fetch if server uses remote_media setting.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -116,7 +116,7 @@ void set_default_settings()
 	settings->setDefault("client_mapblock_limit", "7500"); // about 120 MB
 	settings->setDefault("enable_build_where_you_stand", "false");
 	settings->setDefault("curl_timeout", "20000");
-	settings->setDefault("curl_proxy", "");
+	settings->setDefault("secure.curl_proxy", "");
 	settings->setDefault("curl_parallel_limit", "8");
 	settings->setDefault("curl_file_download_timeout", "300000");
 	settings->setDefault("curl_verify_cert", "true");

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -228,7 +228,7 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 	curl_easy_setopt(curl, CURLOPT_INTERFACE,
 		bind_address.empty() ? nullptr : bind_address.c_str());
 
-	std::string proxy = g_settings->get("curl_proxy");
+	std::string proxy = g_settings->get("secure.curl_proxy");
 	curl_easy_setopt(curl, CURLOPT_PROXY, proxy.empty() ? nullptr : proxy.c_str());
 
 	bool enable_ipv6 = g_settings->getBool("enable_ipv6");


### PR DESCRIPTION
Useful if there is no easy access to environment variables, e.g. on Android.

## Goal of the PR

Fixes #8343 (access to ContentDB by HTTP proxy) for systems that can't easily set the corresponding curl env variables.

## How does the PR work?

Adds a new setting to configure a curl proxy string

## Does it resolve any reported issue?

#8343 (other proxy related issues don't seem to be concerned with only the HTTP traffic). Tangentially related to #15981.

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?

Could be seen as UI improvement

## If not a bug fix, why is this PR needed? What usecases does it solve?

Accessing the ContentDB from a firewalled network using an existing HTTP proxy. 

## If you have used an LLM/AI to help with code or assets, you must disclose this.

I guess an LLM would have come up with more or less the exact same change, but I didn't try one.

## To do

This PR is Ready for Review.

## How to test

1. Configure your network to prevent outbound TCP traffic to the ContentDB server
2. add a proxy to your network that allows proxy requests to the ContentDB server (or allow traffic to an open proxy on the internet)
3. open Luanti
4. notice that no package information can be retrieved
5. set the curl_proxy setting introduced by this PR to the correct proxy string
6. notice that the package browser now works