### PR TITLE
Formspec: Fix crash on exit with open settings menu

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -122,7 +122,6 @@ bool GUIChatConsole::isOpenInhibited() const
 void GUIChatConsole::closeConsole()
 {
 	m_open = false;
-	Environment->removeFocus(this);
 	m_menumgr->deletingMenu(this);
 	m_scrollbar->setVisible(false);
 }

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -52,8 +52,6 @@ public:
 		guienv->setFocus(m_stack.back());
 	}
 
-	/// This function may delete the provided element. Do hold a reference
-	/// (`::grab()`) manually if an instantaneous deletion is undesired.
 	/// Note that it may be called multiple times on GUIModalMenu (or GUIFormSpecMenu):
 	///   1x Explicit close request
 	///   1x Destructor
@@ -71,10 +69,6 @@ public:
 			if (g_touchcontrols)
 				g_touchcontrols->show();
 		}
-
-		// Reference count reduction (-1) by removing from the root node
-		// This is likely to call the destructor (if we're not already inside).
-		menu->remove();
 	}
 
 	// Returns true to prevent further processing
@@ -101,8 +95,10 @@ public:
 	void deleteFront()
 	{
 		assert(!m_stack.empty());
-		m_stack.front()->setVisible(false);
-		deletingMenu(m_stack.front());
+		gui::IGUIElement *e = m_stack.front();
+		e->setVisible(false);
+		deletingMenu(e);
+		e->remove();
 	}
 
 	bool pausesGame()

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -90,6 +90,7 @@ void GUIModalMenu::quitMenu()
 {
 	allowFocusRemoval(true);
 	m_menumgr->deletingMenu(this);
+	this->remove();
 }
 
 static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)


### PR DESCRIPTION
Improper cleanup of *non-tracked* GUIModelMenu instances caused a crash upon exit due to dereferencing 'guienv' (a nullptr) on exit. This happened because GUIEnvironment still held a (child) reference to a GUIFormSpecMenu instance.

This commit changes the destruction order such that the first call to 'deletingMenu' removes it not just from the opened menu lists but also from GUIEnvironment.
This results in an immediate destruction unless a reference is held by e.g. GameFormSpec (essentially all GUIFormSpec instances).


This fixes the following crash:
```C++
0x00005555556f3333 in MainMenuManager::deletingMenu (this=0x5555562af440 <g_menumgr>, menu=0x555559a922c0)
    at XXXX/src/gui/mainmenumanager.h:73
73				guienv->removeFocus(menu);
#0  0x00005555556f3333 in MainMenuManager::deletingMenu (this=0x5555562af440 <g_menumgr>, menu=0x555559a922c0)
    at XXXX/src/gui/mainmenumanager.h:73
#1  0x0000555555959ed8 in GUIModalMenu::~GUIModalMenu (this=0x555559a922c0, __vtt_parm=0x55555627c078 <VTT for GUIFormSpecMenu+8>, 
    __in_chrg=<optimized out>) at XXXX/src/gui/modalMenu.cpp:54
#2  0x00005555558ce0ca in GUIFormSpecMenu::~GUIFormSpecMenu (this=0x555559a922c0, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at XXXX/src/gui/guiFormSpecMenu.cpp:123

#13 0x00005555556ef108 in ClientLauncher::~ClientLauncher (this=0x7fffffffd910, __in_chrg=<optimized out>)
    at XXXX/src/client/clientlauncher.cpp:71
```

Add compact, short information about your PR for easier understanding:

*No LLM was consulted or harmed in any way during this debugging session.*

## To do

This PR is Ready for Review.

## How to test

1. With `master`: Join a world, open the settings menu and close the game. It crashes on exit.
2. With this PR: do the same. It must not crash. Open a few formspecs from various origins (server, local, CSM) and ensure it still works. It really should because `m_formspec` holds a separate reference.
3. Ensure the touch controls are shown correctly. **I did not test this. Feedback is welcome.**
