### PR TITLE
Fix unit test use after return

### DIFF
--- a/src/dummygamedef.h
+++ b/src/dummygamedef.h
@@ -7,6 +7,7 @@
 
 #include "gamedef.h"
 #include "itemdef.h"
+#include <memory>
 #include "nodedef.h"
 #include "craftdef.h"
 #include "content/mods.h"
@@ -67,6 +68,16 @@ protected:
 	ModStorageDatabase *m_mod_storage_database = nullptr;
 
 #if CHECK_CLIENT_BUILD()
-	static NodeVisuals *constructNodeVisuals(ContentFeatures *f) { return new NodeVisuals(f); }
+	static std::unique_ptr<NodeVisuals> constructNodeVisuals(ContentFeatures *f)
+	{
+		return std::unique_ptr<NodeVisuals>(new NodeVisuals(f));
+	}
+	static void setNodeVisuals(ContentFeatures &f, std::unique_ptr<NodeVisuals> v = nullptr)
+	{
+		if (v == nullptr)
+			v = constructNodeVisuals(&f);
+		v->f = &f;
+		f.visuals = v.release(); // Destructed by ~ContentFeatures
+	}
 #endif
 };

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -970,6 +970,10 @@ content_t NodeDefManager::set(const std::string &name, const ContentFeatures &de
 	assert(!name.empty());
 	assert(name != "ignore");
 	assert(name == def.name);
+#if CHECK_CLIENT_BUILD()
+	// The ContentFeatures default copy constructor is only valid if visuals is null
+	assert(!def.visuals);
+#endif
 
 	content_t id = CONTENT_IGNORE;
 	if (!m_name_id_mapping.getId(name, id)) { // ignore aliases

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -4,9 +4,6 @@
 
 #include "test.h"
 
-#include <algorithm>
-#include <numeric>
-
 #include "gamedef.h"
 #include "inventory.h" // ItemStack
 #include "dummygamedef.h"
@@ -14,6 +11,7 @@
 #include "client/mapblock_mesh.h"
 #include "client/meshgen/collector.h"
 #include "client/node_visuals.h"
+#include <memory>
 #include "mesh_compare.h"
 
 namespace {
@@ -28,17 +26,19 @@ public:
 		return const_cast<NodeDefManager *>(m_nodedef);
 	}
 
-	// ContentFeatures that doesn't destroy the visuals
-	// Needed because nodedef.set(feature) creates a copy of the ContentFeatures and since
-	// the NodeDefManager destructs its ContentFeatures, this prevents double free.
-	// Should only be used if the visuals get freed somewhere else.
-	struct CContentFeatures : public ContentFeatures {
-		~CContentFeatures() { visuals = nullptr; }
-	};
-
-	content_t registerNode(ItemDefinition itemdef, const CContentFeatures &nodedef) {
+	content_t registerNode(const ItemDefinition &itemdef, const ContentFeatures &nodedef,
+			std::unique_ptr<NodeVisuals> visuals) {
 		item_mgr()->registerItem(itemdef);
-		return node_mgr()->set(nodedef.name, nodedef);
+
+		NodeDefManager *mgr = node_mgr();
+		content_t id = mgr->set(nodedef.name, nodedef);
+
+		// mgr->set cannot add ContentFeatures that already contain visuals
+		// We set them manually instead of calling NodeVisuals::fillNodeVisuals
+		ContentFeatures &f = const_cast<ContentFeatures&>(mgr->get(id));
+		setNodeVisuals(f, std::move(visuals));
+
+		return id;
 	}
 
 	void finalize() {
@@ -47,7 +47,7 @@ public:
 		// Need to fill node visuals for predefined nodes
 		node_mgr()->applyFunction([] (ContentFeatures &f) {
 			if (!f.visuals)
-				f.visuals = constructNodeVisuals(&f);
+				setNodeVisuals(f);
 		});
 	}
 
@@ -72,18 +72,18 @@ public:
 		itemdef.name = "test:" + name;
 		itemdef.description = name;
 
-		CContentFeatures f;
-		f.visuals = constructNodeVisuals(&f);
+		ContentFeatures f;
+		auto visuals = constructNodeVisuals(&f);
 		f.name = itemdef.name;
 		f.drawtype = NDT_NORMAL;
-		f.visuals->solidness = 2;
+		visuals->solidness = 2;
 		f.alpha = ALPHAMODE_OPAQUE;
 		for (TileDef &tiledef : f.tiledef)
 			tiledef.name = name + ".png";
-		for (TileSpec &tile : f.visuals->tiles)
+		for (TileSpec &tile : visuals->tiles)
 			tile.layers[0].texture_id = texture;
 
-		return registerNode(itemdef, f);
+		return registerNode(itemdef, f, std::move(visuals));
 	}
 
 	content_t addLiquidSource(std::string name, u32 texture)
@@ -93,11 +93,11 @@ public:
 		itemdef.name = "test:" + name + "_source";
 		itemdef.description = name;
 
-		CContentFeatures f;
-		f.visuals = constructNodeVisuals(&f);
+		ContentFeatures f;
+		auto visuals = constructNodeVisuals(&f);
 		f.name = itemdef.name;
 		f.drawtype = NDT_LIQUID;
-		f.visuals->solidness = 1;
+		visuals->solidness = 1;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;
@@ -108,10 +108,10 @@ public:
 		f.liquid_alternative_flowing = "test:" + name + "_flowing";
 		for (TileDef &tiledef : f.tiledef)
 			tiledef.name = name + ".png";
-		for (TileSpec &tile : f.visuals->tiles)
+		for (TileSpec &tile : visuals->tiles)
 			tile.layers[0].texture_id = texture;
 
-		return registerNode(itemdef, f);
+		return registerNode(itemdef, f, std::move(visuals));
 	}
 
 	content_t addLiquidFlowing(std::string name, u32 texture_top, u32 texture_side)
@@ -121,11 +121,11 @@ public:
 		itemdef.name = "test:" + name + "_flowing";
 		itemdef.description = name;
 
-		CContentFeatures f;
-		f.visuals = constructNodeVisuals(&f);
+		ContentFeatures f;
+		auto visuals = constructNodeVisuals(&f);
 		f.name = itemdef.name;
 		f.drawtype = NDT_FLOWINGLIQUID;
-		f.visuals->solidness = 0;
+		visuals->solidness = 0;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;
@@ -136,10 +136,10 @@ public:
 		f.liquid_alternative_flowing = "test:" + name + "_flowing";
 		f.tiledef_special[0].name = name + "_top.png";
 		f.tiledef_special[1].name = name + "_side.png";
-		f.visuals->special_tiles[0].layers[0].texture_id = texture_top;
-		f.visuals->special_tiles[1].layers[0].texture_id = texture_side;
+		visuals->special_tiles[0].layers[0].texture_id = texture_top;
+		visuals->special_tiles[1].layers[0].texture_id = texture_side;
 
-		return registerNode(itemdef, f);
+		return registerNode(itemdef, f, std::move(visuals));
 	}
 };
 


### PR DESCRIPTION
Fixes a use after return, when using the `MockGameDef`.

Like sfan5 suggested `NodeDefManager::set` does no longer accept content features that contain visuals.

## To do

Ready for Review.

## How to test

Compile with address sanitizers 
`CMAKE_CXX_FLAGS:STRING=-fsanitize=address`
Execute unittests
`luanti --run-unittests`
