### PR TITLE
OpenGL: don't use alpha test for GLSL materials

### DIFF
--- a/irr/src/COpenGLSLMaterialRenderer.cpp
+++ b/irr/src/COpenGLSLMaterialRenderer.cpp
@@ -40,7 +40,7 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(video::COpenGLDriver *drive
 		E_MATERIAL_TYPE baseMaterial,
 		s32 userData) :
 		Driver(driver),
-		CallBack(callback), Alpha(false), Blending(false), AlphaTest(false), Program(0), Program2(0), UserData(userData)
+		CallBack(callback), Alpha(false), Blending(false), Program(0), Program2(0), UserData(userData)
 {
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
@@ -49,9 +49,6 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(video::COpenGLDriver *drive
 		break;
 	case EMT_ONETEXTURE_BLEND:
 		Blending = true;
-		break;
-	case EMT_TRANSPARENT_ALPHA_CHANNEL_REF:
-		AlphaTest = true;
 		break;
 	default:
 		break;
@@ -72,7 +69,7 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(COpenGLDriver *driver,
 		IShaderConstantSetCallBack *callback,
 		E_MATERIAL_TYPE baseMaterial, s32 userData) :
 		Driver(driver),
-		CallBack(callback), Alpha(false), Blending(false), AlphaTest(false), Program(0), Program2(0), UserData(userData)
+		CallBack(callback), Alpha(false), Blending(false), Program(0), Program2(0), UserData(userData)
 {
 	switch (baseMaterial) {
 	case EMT_TRANSPARENT_VERTEX_ALPHA:
@@ -81,9 +78,6 @@ COpenGLSLMaterialRenderer::COpenGLSLMaterialRenderer(COpenGLDriver *driver,
 		break;
 	case EMT_ONETEXTURE_BLEND:
 		Blending = true;
-		break;
-	case EMT_TRANSPARENT_ALPHA_CHANNEL_REF:
-		AlphaTest = true;
 		break;
 	default:
 		break;
@@ -210,11 +204,11 @@ void COpenGLSLMaterialRenderer::OnSetMaterial(const video::SMaterial &material,
 
 	Driver->setBasicRenderStates(material, lastMaterial, resetAllRenderstates);
 
+	cacheHandler->setAlphaTest(false);
+
 	if (Alpha) {
 		cacheHandler->setBlend(true);
 		cacheHandler->setBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-		cacheHandler->setAlphaTest(true);
-		cacheHandler->setAlphaFunc(GL_GREATER, 0.f);
 	} else if (Blending) {
 		E_BLEND_FACTOR srcRGBFact, dstRGBFact, srcAlphaFact, dstAlphaFact;
 		E_MODULATE_FUNC modulate;
@@ -229,9 +223,6 @@ void COpenGLSLMaterialRenderer::OnSetMaterial(const video::SMaterial &material,
 		}
 
 		cacheHandler->setBlend(true);
-	} else if (AlphaTest) {
-		cacheHandler->setAlphaTest(true);
-		cacheHandler->setAlphaFunc(GL_GREATER, 0.5f);
 	}
 
 	if (CallBack)
@@ -248,9 +239,6 @@ void COpenGLSLMaterialRenderer::OnUnsetMaterial()
 	COpenGLCacheHandler *cacheHandler = Driver->getCacheHandler();
 	if (Alpha || Blending) {
 		cacheHandler->setBlend(false);
-	}
-	if (Alpha || AlphaTest) {
-		cacheHandler->setAlphaTest(false);
 	}
 }
 

--- a/irr/src/COpenGLSLMaterialRenderer.h
+++ b/irr/src/COpenGLSLMaterialRenderer.h
@@ -96,7 +96,6 @@ protected:
 
 	bool Alpha;
 	bool Blending;
-	bool AlphaTest;
 
 	struct SUniformInfo
 	{

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -790,14 +790,7 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 
 	ShaderConstants constants = input_const;
 
-	bool use_discard = m_fully_programmable;
-	if (!use_discard) {
-		// workaround for a certain OpenGL implementation lacking GL_ALPHA_TEST
-		const char *renderer = reinterpret_cast<const char*>(GL.GetString(GL.RENDERER));
-		if (strstr(renderer, "GC7000"))
-			use_discard = true;
-	}
-	if (use_discard) {
+	{
 		if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL)
 			constants["USE_DISCARD"] = 1;
 		else if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF)


### PR DESCRIPTION
this may look risky but it just makes the OpenGL2 driver act like the OpenGL3 one, and is also the straightforward way to fix this issue sustainably without adding special legacy handling.

fixes #16825

## To do

This PR is Ready for Review.

## How to test

1. use `video_driver=opengl`
2. make sure all kind of transparent thing still look correct
3. follow the test instructions in the linked issue