### PR TITLE
Avoid inVertexColor name collision

### DIFF
--- a/client/shaders/Irrlicht/Renderer2D.vsh
+++ b/client/shaders/Irrlicht/Renderer2D.vsh
@@ -3,7 +3,7 @@
 /* Attributes */
 
 attribute vec4 inVertexPosition;
-attribute vec4 inVertexColor;
+attribute vec4 inVertexColor_raw;
 attribute vec2 inTexCoord0;
 
 /* Uniforms */
@@ -24,5 +24,5 @@ void main()
 	gl_Position = uProjection * (inVertexPosition + vec4(0.375, 0.375, 0.0, 0.0));
 	gl_PointSize = uThickness;
 	vTextureCoord = inTexCoord0;
-	vVertexColor = inVertexColor.bgra;
+	vVertexColor = inVertexColor_raw.bgra;
 }

--- a/client/shaders/Irrlicht/Solid.vsh
+++ b/client/shaders/Irrlicht/Solid.vsh
@@ -4,7 +4,7 @@
 
 attribute vec3 inVertexPosition;
 attribute vec3 inVertexNormal;
-attribute vec4 inVertexColor;
+attribute vec4 inVertexColor_raw;
 attribute vec2 inTexCoord0;
 
 /* Uniforms */
@@ -29,7 +29,7 @@ void main()
 	vec4 TextureCoord0 = vec4(inTexCoord0.x, inTexCoord0.y, 1.0, 1.0);
 	vTextureCoord0 = vec4(uTMatrix0 * TextureCoord0).xy;
 
-	vVertexColor = inVertexColor.bgra;
+	vVertexColor = inVertexColor_raw.bgra;
 
 	vec3 Position = (uWVMatrix * vec4(inVertexPosition, 1.0)).xyz;
 

--- a/irr/include/EVertexAttributes.h
+++ b/irr/include/EVertexAttributes.h
@@ -21,7 +21,7 @@ enum E_VERTEX_ATTRIBUTES
 const char *const sBuiltInVertexAttributeNames[] = {
 		"inVertexPosition",
 		"inVertexNormal",
-		"inVertexColor",
+		"inVertexColor_raw", // (BGRA <-> RGBA swapped)
 		"inVertexAux",
 		"inTexCoord0",
 		"inTexCoord1",

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -720,7 +720,7 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 
 			ATTRIBUTE_(0) highp vec4 inVertexPosition;
 			ATTRIBUTE_(1) mediump vec3 inVertexNormal;
-			ATTRIBUTE_(2) lowp vec4 inVertexColor;
+			ATTRIBUTE_(2) lowp vec4 inVertexColor_raw;
 			ATTRIBUTE_(3) mediump float inVertexAux;
 			ATTRIBUTE_(4) mediump vec2 inTexCoord0;
 			ATTRIBUTE_(5) mediump vec2 inTexCoord1;
@@ -734,7 +734,7 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 		}
 		// Our vertex color has components reversed compared to what OpenGL
 		// normally expects, so we need to take that into account.
-		vertex_header += "#define inVertexColor (inVertexColor.bgra)\n";
+		vertex_header += "#define inVertexColor (inVertexColor_raw.bgra)\n";
 
 		fragment_header = "";
 		if (use_glsl3) {


### PR DESCRIPTION
some(?) Intel drivers do not like it
should fix #16836

## To do

This PR is Ready for Review.

## How to test

1. try it :hammer: 
2. colors should be ok :purple_circle: 
3. no errors :checkered_flag: 