### PR TITLE
Windows: Fix user directory opening in the wrong place

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -890,7 +890,7 @@ static bool open_uri(const std::string &uri)
 	verbosestream << "Opening URI: " << uri << std::endl;
 
 #if defined(_WIN32)
-	return (intptr_t)ShellExecuteA(NULL, "open", uri.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
+	return (intptr_t)ShellExecuteA(NULL, NULL, uri.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
 #elif defined(__ANDROID__)
 	openURIAndroid(uri.c_str());
 	return true;


### PR DESCRIPTION
Fixes #12631

Tested on Windows 10, compiled with mingw64_14.1.0_MFC 

## To do

This PR is Ready for Review.

## How to test

1. Open the main menu
2. Click the user directory button -> must open to where minetest.conf is
3. Click the website button -> must open the website
