### PR TITLE
Fix positive borderwidths box style not working

### DIFF
--- a/src/gui/guiBox.cpp
+++ b/src/gui/guiBox.cpp
@@ -96,9 +96,21 @@ void GUIBox::draw()
 	driver->draw2DRectangle(main_rect, m_colors[0], m_colors[1], m_colors[3],
 		m_colors[2], &AbsoluteClippingRect);
 
+	// The border rectangle can be larger than 'AbsoluteClippingRect',
+	// hence clip against the (generally larger) parent.
+	core::rect<s32> border_rect = core::rect<s32>(
+		topleft_border.X,
+		topleft_border.Y,
+		lowerright_border.X,
+		lowerright_border.Y
+	);
+	if(!isNotClipped()) {
+		border_rect.clipAgainst(Parent->getAbsoluteClippingRect());
+	}
+
 	for (size_t i = 0; i <= 3; i++)
 		driver->draw2DRectangle(m_bordercolors[i], border_rects[i],
-				&AbsoluteClippingRect);
+				&border_rect);
 
 	IGUIElement::draw();
 }


### PR DESCRIPTION
Fixes #16437.

## How to test

Use `luacmd` mod, then enter this command in DevTest:

### Test 1

```
/lua core.show_formspec(me:get_player_name(), "test","formspec_version[5]size[5,5]container[1,0]style_type[box;borderwidths=5;bordercolors=#ff0000] box[0,1;1,1;]style_type[box;borderwidths=-5;bordercolors=#0000ff]box[0,3;1,1;]container_end[]")
```

You should two box outlines, the first one is an outer line, the second one is an inner line.

### Test 2

Then run this command:

```
/lua core.show_formspec(me:get_player_name(), "test","formspec_version[5]size[5,5]container[-0.5,0]style_type[box;borderwidths=5;bordercolors=#ff0000] box[0,1;1,1;]style_type[box;borderwidths=-5;bordercolors=#0000ff]box[0,3;1,1;]container_end[]")
```

You should see the same two boxes, but clipped at the left formspec boundary.

### Test 3

Then run this command:

```
/lua core.show_formspec(me:get_player_name(), "test","formspec_version[5]size[5,5]container[-0.5,0]style_type[box;noclip=true;borderwidths=5;bordercolors=#ff0000] box[0,1;1,1;]style_type[box;borderwidths=-5;bordercolors=#0000ff]box[0,3;1,1;]container_end[]")
```

You should see the same two boxes at the left formspec boundary, but *not* clipped (`noclip=true`).