### PR TITLE
Formspec: Make inventory slots stay hovered on formspec update

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3430,16 +3430,16 @@ GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 		Inventory *inv = m_invmgr->getInventory(e->getInventoryloc());
 		InventoryList *ilist = nullptr;
 		s32 item_index = -1;
-		
+
 		if (inv)
 			ilist = inv->getList(e->getListname());
-			
+
 		if (ilist) {
 			s32 i = e->getItemIndexAtPos(p);
 			if (i < (s32)ilist->getSize())
 				item_index = i;
 		}
-		
+
 		if (item_index != -1)
 			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
 					item_index, e->getSlotSize());

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3427,7 +3427,19 @@ void GUIFormSpecMenu::getAndroidUIInput()
 GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 {
 	for (const GUIInventoryList *e : m_inventorylists) {
-		s32 item_index = e->getItemIndexAtPos(p);
+		Inventory *inv = m_invmgr->getInventory(e->getInventoryloc());
+		InventoryList *ilist = nullptr;
+		s32 item_index = -1;
+		
+		if (inv)
+			ilist = inv->getList(e->getListname());
+			
+		if (ilist) {
+			s32 i = e->getItemIndexAtPos(p);
+			if (i < (s32)ilist->getSize())
+				item_index = i;
+		}
+		
 		if (item_index != -1)
 			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
 					item_index, e->getSlotSize());

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3430,16 +3430,16 @@ GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 		Inventory *inv = m_invmgr->getInventory(e->getInventoryloc());
 		InventoryList *ilist = nullptr;
 		s32 item_index = -1;
-
+		
 		if (inv)
 			ilist = inv->getList(e->getListname());
-
+			
 		if (ilist) {
 			s32 i = e->getItemIndexAtPos(p);
 			if (i < (s32)ilist->getSize())
 				item_index = i;
 		}
-
+		
 		if (item_index != -1)
 			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
 					item_index, e->getSlotSize());

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3427,19 +3427,7 @@ void GUIFormSpecMenu::getAndroidUIInput()
 GUIInventoryList::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 {
 	for (const GUIInventoryList *e : m_inventorylists) {
-		Inventory *inv = m_invmgr->getInventory(e->getInventoryloc());
-		InventoryList *ilist = nullptr;
-		s32 item_index = -1;
-		
-		if (inv)
-			ilist = inv->getList(e->getListname());
-			
-		if (ilist) {
-			s32 i = e->getItemIndexAtPos(p);
-			if (i < (s32)ilist->getSize())
-				item_index = i;
-		}
-		
+		s32 item_index = e->getItemIndexAtPos(p);
 		if (item_index != -1)
 			return GUIInventoryList::ItemSpec(e->getInventoryloc(), e->getListname(),
 					item_index, e->getSlotSize());

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3329,6 +3329,16 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_last_formname = m_text_dst->m_formname;
 		m_is_form_regenerated = true;
 	}
+
+	// Restore hover state for inventory lists
+	if (m_pointer.X != -1) {
+		for (GUIInventoryList *list : m_inventorylists) {
+			s32 hovered = list->getItemIndexAtPos(m_pointer);
+			if (hovered != -1) {
+				list->setHoveredIndex(hovered);
+			}
+		}
+	}
 }
 
 void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from)

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -7,6 +7,7 @@
 #include "drawItemStack.h"
 #include "client/client.h"
 #include "client/renderingengine.h"
+#include "ICursorControl.h"
 #include <IVideoDriver.h>
 
 GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
@@ -34,9 +35,10 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	m_fs_menu(fs_menu),
 	m_options(options),
 	m_font(font),
-	m_hovered_i(-1),
 	m_already_warned(false)
 {
+	ICursorControl *cursor_control = RenderingEngine::get_raw_device()->getCursorControl();
+	m_hovered_i = getItemIndexAtPos(v2s32(cursor_control->getPosition()));
 }
 
 void GUIInventoryList::draw()
@@ -201,14 +203,6 @@ s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 			!AbsoluteClippingRect.isPointInside(p))
 		return -1;
 
-	// there cannot be an item if the inventory or the inventorylist does not exist
-	Inventory *inv = m_invmgr->getInventory(m_inventoryloc);
-	if (!inv)
-		return -1;
-	InventoryList *ilist = inv->getList(m_listname);
-	if (!ilist)
-		return -1;
-
 	core::rect<s32> imgrect(0, 0, m_slot_size.X, m_slot_size.Y);
 	v2s32 base_pos = AbsoluteRect.UpperLeftCorner;
 
@@ -223,8 +217,7 @@ s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 
 	rect.clipAgainst(AbsoluteClippingRect);
 
-	if (rect.getArea() > 0 && rect.isPointInside(p) &&
-			i + m_start_item_i < (s32)ilist->getSize())
+	if (rect.getArea() > 0 && rect.isPointInside(p))
 		return i + m_start_item_i;
 
 	return -1;

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -7,7 +7,6 @@
 #include "drawItemStack.h"
 #include "client/client.h"
 #include "client/renderingengine.h"
-#include "ICursorControl.h"
 #include <IVideoDriver.h>
 
 GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
@@ -35,10 +34,9 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	m_fs_menu(fs_menu),
 	m_options(options),
 	m_font(font),
+	m_hovered_i(-1),
 	m_already_warned(false)
 {
-	ICursorControl *cursor_control = RenderingEngine::get_raw_device()->getCursorControl();
-	m_hovered_i = getItemIndexAtPos(v2s32(cursor_control->getPosition()));
 }
 
 void GUIInventoryList::draw()
@@ -203,6 +201,14 @@ s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 			!AbsoluteClippingRect.isPointInside(p))
 		return -1;
 
+	// there cannot be an item if the inventory or the inventorylist does not exist
+	Inventory *inv = m_invmgr->getInventory(m_inventoryloc);
+	if (!inv)
+		return -1;
+	InventoryList *ilist = inv->getList(m_listname);
+	if (!ilist)
+		return -1;
+
 	core::rect<s32> imgrect(0, 0, m_slot_size.X, m_slot_size.Y);
 	v2s32 base_pos = AbsoluteRect.UpperLeftCorner;
 
@@ -217,7 +223,8 @@ s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 
 	rect.clipAgainst(AbsoluteClippingRect);
 
-	if (rect.getArea() > 0 && rect.isPointInside(p))
+	if (rect.getArea() > 0 && rect.isPointInside(p) &&
+			i + m_start_item_i < (s32)ilist->getSize())
 		return i + m_start_item_i;
 
 	return -1;

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -194,6 +194,11 @@ bool GUIInventoryList::isPointInside(const core::position2d<s32> &point) const
 	return getItemIndexAtPos(point) != -1;
 }
 
+void GUIInventoryList::setHoveredIndex(s32 item_i)
+{
+	m_hovered_i = item_i;
+}
+
 s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 {
 	// no item if no gui element at pointer

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -75,6 +75,8 @@ public:
 
 	bool isPointInside(const core::position2d<s32> &point) const override;
 
+	void setHoveredIndex(s32 item_i);
+
 	const InventoryLocation &getInventoryloc() const
 	{
 		return m_inventoryloc;


### PR DESCRIPTION
Fixes #14530 
Fixes #13668

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
1. perform "steps to reproduce" in #14530 
2. observe that, when a formspec updates, inventory slots stay hovered.


[video.webm](https://github.com/user-attachments/assets/99b22974-bbc5-4016-acd7-632ef3d0688b)
