### PR TITLE
Fix missing translations of reset setting button

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -629,6 +629,7 @@ local function get_formspec(dialogdata)
 
 		if show_reset then
 			local default = comp.setting.default
+
 			if comp.setting.type == "bool" then
 				if default == "true" then
 					default = fgettext_ne("Enabled")
@@ -645,12 +646,15 @@ local function get_formspec(dialogdata)
 				local sinfo = get_setting_info(comp.setting.name)
 				if sinfo and sinfo.option_labels and sinfo.option_labels[default] then
 					default = sinfo.option_labels[default]
+				elseif default == "" then
+					-- TRANSLATORS: Shown when a default setting is the empty string
+					default = fgettext_ne("<empty>")
 				end
 			end
 
 			local reset_tooltip = default and
 					-- TRANSLATORS: $1 will be replaced with a default setting value
-					fgettext("Reset setting to default ($1)", tostring(default)) or
+					fgettext("Reset setting to default: $1", tostring(default)) or
 					fgettext("Reset setting to default")
 			fs[#fs + 1] = ("image_button[%f,%f;0.5,0.5;%s;%s;]"):format(
 					right_pane_width - 1.4, info_reset_y, reset_icon_path, "reset_" .. i)


### PR DESCRIPTION
The 'reset setting' button of the settings menu had a tooltip "Reset setting to default (\<some default value\>)" which I think was an upcoming feature for 5.15.0. This tooltip currently displays the default value as well, but for some types of settings the default value was untranslatable.

This PR makes sure the value in brackets is now translated correctly for the following settings:

* All bool settings now show translated "Enabled"/"Disabled" instead of English-only "true"/"false"
* `language` setting now shows as `Use system language` as default (note the lack of brackets, this is done to prevent "Reset setting to default ((Use system langauge))" to be displayed)
* enum settings in touchscreen settings now show translated default values
* Any other setting in which the default is the empty string, display as "Reset setting to default (\<empty\>)"

This PR adds two new strings.

## Out of scope

This PR does not translate enum settings of mods and games since those cannot be currently provided anyway. It is thus out-of-scope for this PR.

## To do

This PR is Ready for Review.

## How to test

1. Open settings
2. Change checkbox settings on and off and check the "reset setting" tooltip, both for default false and default true settings
3. Change `language` setting and check the "reset setting" tooltip
4. Change all touchscreen enum settings and check the "reset setting" tooltips
5. Change the settings `shader_path` and `video_driver` and check the "reset setting" tooltips (these settings use the empty string as default)
6. Ideally, also test if translation works