### PR TITLE
Allow mods and games to provide translations for settings

### DIFF
--- a/builtin/common/settings/components.lua
+++ b/builtin/common/settings/components.lua
@@ -34,6 +34,11 @@ local make = {}
 local function get_label(setting)
 	local show_technical_names = core.settings:get_bool("show_technical_names")
 	if not show_technical_names and setting.readable_name then
+		if setting.source then
+			local source = setting.source
+			return core.get_content_translation(source.path, source.textdomain,
+					core.translate(source.textdomain, setting.readable_name))
+		end
 		return fgettext(setting.readable_name)
 	end
 	return setting.name


### PR DESCRIPTION
Fixes #9070.

- How does the PR work?
  The `setting` object now has optional information on the source of the setting. This can be used to find the mod that the setting belongs to. The translation domain is selected from the source mod; `gettext` is used otherwise if the source is not provided.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.

## To do

- [x] Support translations for mod settings.
- [ ] Support translations for mod settings for mods within a modpack.
- [ ] Support translations for game settings.
- [x] Allow translating setting names.
- [ ] Allow translating setting descriptions.
- [ ] Allow searching with translated strings.
- [ ] Create test mod/game.

Out of scope: CSMs currently cannot provide their own translation files; settings from CSMs are therefore not translated.

## How to test

TBD