### PR TITLE
Fix `star_seed` being stored into a too small integer

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2454,7 +2454,11 @@ int ObjectRef::l_set_stars(lua_State *L)
 			"scale", star_params.scale);
 		star_params.day_opacity = getfloatfield_default(L, 2,
 			"day_opacity", star_params.day_opacity);
-		star_params.star_seed = getintfield_default(L, 2, "star_seed", star_params.star_seed);
+
+		lua_getfield(L, 2, "star_seed");
+		if (!lua_isnil(L, -1))
+			star_params.star_seed = lua_tointeger(L, -1);
+		lua_pop(L, 1);
 	}
 
 	getServer(L)->setStars(player, star_params);


### PR DESCRIPTION
Fixes #16867.

It turned out `star_seed` was only read as an `s32` although the intended data type was `u64`.

I added `getu64field_default` as a variant of `getintfield_default` as a helper function, it may come in handy if the Lua API needs other functions that want to take large numbers.

## To do

This PR is Ready for Review.

## How to test

1. Install `luacmd` mod
2. In DevTest, run: `/lua s=2^45; me:set_stars({star_seed=s}); print(string.format("expected star_seed: %d ; got: %d", s, me:get_stars().star_seed))`
3. Run the same command, but replace the value of `s` with some other numbers (anywhere in the range `[0, 2^53]`)
4. Repeat until you're bored

Each time you call this function, the star positions should change and also the chat output should two equal numbers to prove the written number can also be read back correctly.