### PR TITLE
Optimize mapgen performance by eliminating redundant calculations

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -85,14 +85,20 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 		// Like randomwalk caves, preserve nodes that have 'is_ground_content = false',
 		// to avoid dungeons that generate out beyond the edge of a mapchunk destroying
 		// nodes added by mods in 'register_on_generated()'.
+		content_t prev_c = CONTENT_IGNORE;
+		ContentFeatures &f = ndef->get(prev_c);
 		for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 			for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 				u32 i = vm->m_area.index(nmin.X, y, z);
 				for (s16 x = nmin.X; x <= nmax.X; x++) {
 					content_t c = vm->m_data[i].getContent();
-					NodeDrawType dtype = ndef->get(c).drawtype;
+					if (c != prev_c) {
+						prev_c = c;
+						f = ndef->get(c);
+					}
+					NodeDrawType dtype = f.drawtype;
 					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
-							c == CONTENT_IGNORE || !ndef->get(c).is_ground_content)
+							c == CONTENT_IGNORE || !f.is_ground_content)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}
@@ -260,8 +266,8 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 
 void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 {
-	MapNode n_wall(dp.c_wall);
-	MapNode n_air(CONTENT_AIR);
+	const MapNode n_wall(dp.c_wall);
+	const MapNode n_air(CONTENT_AIR);
 
 	// Make +-X walls
 	for (s16 z = 0; z < roomsize.Z; z++)
@@ -322,7 +328,7 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 			vm->m_data[vi] = n_wall;
 		}
 		{
-			v3s16 p = roomplace + v3s16(x,roomsize. Y - 1, z);
+			v3s16 p = roomplace + v3s16(x, roomsize.Y - 1, z);
 			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
@@ -495,8 +501,10 @@ bool DungeonGen::findPlaceForDoor(v3s16 &result_place, v3s16 &result_dir)
 			randomizeDir();
 			continue;
 		}
-		if (vm->getNodeNoExNoEmerge(p).getContent() == dp.c_wall &&
-				vm->getNodeNoExNoEmerge(p1).getContent() == dp.c_wall) {
+
+		content_t content_p = vm->getNodeNoExNoEmerge(p).getContent();
+		content_t content_p1 = vm->getNodeNoExNoEmerge(p1).getContent();
+		if (content_p == dp.c_wall && content_p1 == dp.c_wall) {
 			// Found wall, this is a good place!
 			result_place = p;
 			result_dir = m_dir;
@@ -508,22 +516,20 @@ bool DungeonGen::findPlaceForDoor(v3s16 &result_place, v3s16 &result_dir)
 			Determine where to move next
 		*/
 		// Jump one up if the actual space is there
-		if (vm->getNodeNoExNoEmerge(p +
-				v3s16(0, 0, 0)).getContent() == dp.c_wall &&
-				vm->getNodeNoExNoEmerge(p +
-				v3s16(0, 1, 0)).getContent() == CONTENT_AIR &&
-				vm->getNodeNoExNoEmerge(p +
-				v3s16(0, 2, 0)).getContent() == CONTENT_AIR)
+		content_t content_p_up1 = vm->getNodeNoExNoEmerge(p + v3s16(0, 1, 0)).getContent();
+		content_t content_p_up2 = vm->getNodeNoExNoEmerge(p + v3s16(0, 2, 0)).getContent();
+		if (content_p == dp.c_wall &&
+				content_p_up1 == CONTENT_AIR &&
+				content_p_up2 == CONTENT_AIR)
 			p += v3s16(0,1,0);
 		// Jump one down if the actual space is there
-		if (vm->getNodeNoExNoEmerge(p +
-				v3s16(0, 1, 0)).getContent() == dp.c_wall &&
-				vm->getNodeNoExNoEmerge(p +
-				v3s16(0, 0, 0)).getContent() == CONTENT_AIR &&
-				vm->getNodeNoExNoEmerge(p +
-				v3s16(0, -1, 0)).getContent() == CONTENT_AIR)
+		content_t content_p_down1 = vm->getNodeNoExNoEmerge(p + v3s16(0, -1, 0)).getContent();
+		if (content_p_up1 == dp.c_wall &&
+				content_p == CONTENT_AIR &&
+				content_p_down1 == CONTENT_AIR)
 			p += v3s16(0, -1, 0);
 		// Check if walking is now possible
+		// Re-fetch as p may have changed
 		if (vm->getNodeNoExNoEmerge(p).getContent() != CONTENT_AIR ||
 				vm->getNodeNoExNoEmerge(p +
 				v3s16(0, 1, 0)).getContent() != CONTENT_AIR) {

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -373,6 +373,7 @@ int MapgenCarpathian::getSpawnLevelAtPoint(v2s16 p)
 
 	bool solid_below = false;
 	u8 cons_non_solid = 0; // consecutive non-solid nodes
+	const float neg_valley_river_depth = std::sqrt(-valley) * river_depth;
 
 	for (s16 y = water_level; y <= water_level + 32; y++) {
 		float mnt_var = NoiseFractal3D(&noise_mnt_var->np, p.X, y, p.Y, seed);
@@ -395,7 +396,7 @@ int MapgenCarpathian::getSpawnLevelAtPoint(v2s16 p)
 			if (valley < 0.0f) {
 				// River channel
 				surface_level = std::fmin(surface_level,
-					water_level - std::sqrt(-valley) * river_depth);
+					water_level - neg_valley_river_depth);
 			} else if (surface_level > water_level) {
 				// Valley slopes
 				surface_level = water_level + (surface_level - water_level) * valley;
@@ -496,6 +497,7 @@ int MapgenCarpathian::generateTerrain()
 		// Initialise 3D noise index and voxelmanip index to column base
 		u32 index3d = (z - node_min.Z) * zstride_1u1d + (x - node_min.X);
 		u32 vi = vm->m_area.index(x, node_min.Y - 1, z);
+		const float neg_valley_river_depth = std::sqrt(-valley) * river_depth;
 
 		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1;
 				y++,
@@ -533,7 +535,7 @@ int MapgenCarpathian::generateTerrain()
 				if (valley < 0.0f) {
 					// River channel
 					surface_level = std::fmin(surface_level,
-						water_level - std::sqrt(-valley) * river_depth);
+						water_level - neg_valley_river_depth);
 				} else if (surface_level > water_level) {
 					// Valley slopes
 					surface_level = water_level + (surface_level - water_level) * valley;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -498,14 +498,16 @@ int MapgenV7::generateTerrain()
 		// Calculate noise for floatland generation
 		noise_floatland->noiseMap3D(node_min.X, node_min.Y - 1, node_min.Z);
 
+		float floatland_taper_inv = 1.0f / (float)floatland_taper;
+
 		// Cache floatland noise offset values, for floatland tapering
 		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++, cache_index++) {
 			float float_offset = 0.0f;
 			if (y > float_taper_ymax) {
-				float_offset = std::pow((y - float_taper_ymax) / (float)floatland_taper,
+				float_offset = std::pow((y - float_taper_ymax) * floatland_taper_inv,
 					float_taper_exp) * 4.0f;
 			} else if (y < float_taper_ymin) {
-				float_offset = std::pow((float_taper_ymin - y) / (float)floatland_taper,
+				float_offset = std::pow((float_taper_ymin - y) * floatland_taper_inv,
 					float_taper_exp) * 4.0f;
 			}
 			float_offset_cache[cache_index] = float_offset;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -431,12 +431,13 @@ int MapgenValleys::generateTerrain()
 			index_3d += ystride;
 		}
 
+		// Ground height ignoring riverbeds (computed once for all uses below)
+		float t_alt = std::fmax(base, (float)column_max_y);
+
 		// Optionally increase humidity around rivers
 		if (spflags & MGVALLEYS_HUMID_RIVERS) {
 			// Compensate to avoid increasing average humidity
 			m_bgen->humidmap[index_2d] *= 0.8f;
-			// Ground height ignoring riverbeds
-			float t_alt = std::fmax(base, (float)column_max_y);
 			float water_depth = (t_alt - base) / 4.0f;
 			m_bgen->humidmap[index_2d] *=
 				1.0f + std::pow(0.5f, std::fmax(water_depth, 1.0f));
@@ -444,8 +445,6 @@ int MapgenValleys::generateTerrain()
 
 		// Optionally decrease humidity with altitude
 		if (spflags & MGVALLEYS_ALT_DRY) {
-			// Ground height ignoring riverbeds
-			float t_alt = std::fmax(base, (float)column_max_y);
 			// Only decrease above water_level
 			if (t_alt > water_level)
 				m_bgen->humidmap[index_2d] -=
@@ -456,8 +455,6 @@ int MapgenValleys::generateTerrain()
 		if (spflags & MGVALLEYS_ALT_CHILL) {
 			// Compensate to avoid reducing the average heat
 			m_bgen->heatmap[index_2d] += 5.0f;
-			// Ground height ignoring riverbeds
-			float t_alt = std::fmax(base, (float)column_max_y);
 			// Only decrease above water_level
 			if (t_alt > water_level)
 				m_bgen->heatmap[index_2d] -=


### PR DESCRIPTION
Reduce overhead in critical mapgen loops by caching frequently reused calculations that the compiler cannot optimize automatically due to side effects or function call barriers.

Key optimizations:
- dungeongen: Cache node definition lookups and content queries to avoid repeated function calls; precompute roomsize-1 values outside loops
- mapgen_carpathian: Precompute sqrt(-valley) * river_depth once per column instead of recalculating in y-loop
- mapgen_v7: Convert division by floatland_taper to multiplication by precomputed inverse (1/floatland_taper)
- mapgen_valleys: Calculate t_alt (max terrain height) once and reuse across humidity/heat calculations instead of 3 separate calls to fmax

These changes target calculations the compiler cannot hoist or optimize due to memory writes, function calls, or aliasing concerns between loop iterations.

Don't expect big performance improvement, it's minor ones, but mapgens are heavy, let's take some CPU cycles

Note: some findings are done through claude, i wrote the optimizations myself most of them were discarded as it wanted to remove all std::fabs. I prefered to not touch our std::fabs call whereas the result was fine.

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->

I created new worlds compared to previous one visually. No artifacts, all sounds fine. Algorithm and maths are fine.
