### PR TITLE
Clarify reason for optional OpenSSL dependency

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -18,7 +18,7 @@
 | JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
 | Curl       | 7.56.0+ | Optional   |
 | gettext    | -       | Optional   |
-| OpenSSL    | 3.0+    | Optional (only libcrypto used) |
+| OpenSSL    | 3.0+    | Optional, for optimized SHA hashing functions (only libcrypto used) |
 
 For Debian/Ubuntu users:
 


### PR DESCRIPTION
From a thread on the Discord about someone asking about Luanti's optional dependency on OpenSSL. Due to OpenSSL normally being used for encryption and other usages of cryptography one may assume the reason for the dependency is something security-related, when in reality it is solely for a performance improvement with SHA hashes. This PR adds a clarification to resolve this question.

Worth noting no other optional dependencies clarify what or why Luanti uses it. Maybe those should be described too.

## To do
This PR is a Ready for Review.

## How to test
:eyes: 