### PR TITLE
Fix focus outline appearing around non-focusable elements

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3618,7 +3618,7 @@ void GUIFormSpecMenu::drawMenu()
 
 	// Draw white outline around keyboard-focused form elements.
 	const gui::IGUIElement *focused = Environment->getFocus();
-	if (focused && m_show_focus) {
+	if (focused && m_show_focus && focused->isTabStop() ) {
 		core::rect<s32> rect = focused->getAbsoluteClippingRect();
 		const video::SColor white(255, 255, 255, 255);
 		const s32 border = 2;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Resolve a bug where the outline appears around elements that shouldn't be focusable.
- How does the PR work?
This PR adds a `isTabStop()` check that determines if an element should get focused or not.
- Does it resolve any reported issue?
Closes #16868.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Nope.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope.

## How to test

open luanti → press tab/shift+tab → observe that the outline appears only around non-static elements