### PR TITLE
Docs: specify `on_player_receive_fields` doesn't work for node formspecs

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10530,7 +10530,7 @@ Used by `core.register_node`.
     on_receive_fields = function(pos, formname, fields, sender),
     -- fields = {name1 = value1, name2 = value2, ...}
     -- formname should be the empty string; you **must not** use formname.
-    -- Called when node metadata formspecs are present and data is returned.
+    -- Called when a node metadata formspec is present and data is returned.
     -- See core.register_on_player_receive_fields for more info regarding
     -- `formname` and `fields`.
     -- default: nil


### PR DESCRIPTION
I've spent 20 minutes understanding why the global callback wasn't working.

Bonus: the bullet list was broken, so I've fixed it

## To do

This PR is Ready for Review.

## How to test

:eye: 