### PR TITLE
[no squash] Use `int` for handling texture layer index in shader

### DIFF
--- a/client/shaders/inventory_shader/opengl_fragment.glsl
+++ b/client/shaders/inventory_shader/opengl_fragment.glsl
@@ -7,7 +7,7 @@
 CENTROID_ VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 

--- a/client/shaders/inventory_shader/opengl_vertex.glsl
+++ b/client/shaders/inventory_shader/opengl_vertex.glsl
@@ -1,13 +1,13 @@
 CENTROID_ VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 void main(void)
 {
 #ifdef USE_ARRAY_TEXTURE
-	varTexLayer = int(inVertexAux);
+	varTexLayer = inVertexAux;
 #endif
 	varTexCoord = inTexCoord0.st;
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -52,7 +52,7 @@ CENTROID_ VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 // Conditional because 'flat' is not available on old GLSL
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 CENTROID_ VARYING_ float nightRatio;
 VARYING_ highp vec3 eyeVec;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -20,7 +20,7 @@ CENTROID_ VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 // Conditional because 'flat' is not available on old GLSL
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 CENTROID_ VARYING_ float nightRatio;
 
@@ -149,7 +149,7 @@ float snoise(vec3 p)
 void main(void)
 {
 #ifdef USE_ARRAY_TEXTURE
-	varTexLayer = int(inVertexAux);
+	varTexLayer = inVertexAux;
 #endif
 	varTexCoord = inTexCoord0.st;
 

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -44,7 +44,7 @@ VARYING_ vec3 worldPosition;
 VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 VARYING_ highp vec3 eyeVec;
 VARYING_ float nightRatio;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -8,7 +8,7 @@ VARYING_ vec3 worldPosition;
 VARYING_ lowp vec4 varColor;
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
@@ -118,7 +118,7 @@ void main(void)
 #endif
 
 #ifdef USE_ARRAY_TEXTURE
-	varTexLayer = int(inVertexAux);
+	varTexLayer = inVertexAux;
 #endif
 	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
 

--- a/client/shaders/shadow/pass1/opengl_fragment.glsl
+++ b/client/shaders/shadow/pass1/opengl_fragment.glsl
@@ -7,7 +7,7 @@ VARYING_ vec4 tPos;
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 void main()

--- a/client/shaders/shadow/pass1/opengl_vertex.glsl
+++ b/client/shaders/shadow/pass1/opengl_vertex.glsl
@@ -14,7 +14,7 @@ layout (std140) uniform JointMatrices {
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 vec4 getRelativePosition(in vec4 position)
@@ -70,6 +70,6 @@ void main()
 
 	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
 #ifdef USE_ARRAY_TEXTURE
-	varTexLayer = int(inVertexAux);
+	varTexLayer = inVertexAux;
 #endif
 }

--- a/client/shaders/shadow/pass1_trans/opengl_fragment.glsl
+++ b/client/shaders/shadow/pass1_trans/opengl_fragment.glsl
@@ -7,7 +7,7 @@ VARYING_ vec4 tPos;
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 #ifdef COLORED_SHADOWS

--- a/client/shaders/shadow/pass1_trans/opengl_vertex.glsl
+++ b/client/shaders/shadow/pass1_trans/opengl_vertex.glsl
@@ -11,7 +11,7 @@ uniform float zPerspectiveBias;
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 #ifdef USE_ARRAY_TEXTURE
-flat VARYING_ int varTexLayer;
+flat VARYING_ uint varTexLayer;
 #endif
 
 vec4 getRelativePosition(in vec4 position)
@@ -50,7 +50,7 @@ void main()
 
 	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
 #ifdef USE_ARRAY_TEXTURE
-	varTexLayer = int(inVertexAux);
+	varTexLayer = inVertexAux;
 #endif
 
 #ifdef COLORED_SHADOWS

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -62,7 +62,7 @@ static const VertexType vtStandard = {
 				{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Normal)},
 				{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
 				{EVA_TCOORD0, 2, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, TCoords)},
-				{EVA_AUX, 1, GL_UNSIGNED_SHORT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Aux)},
+				{EVA_AUX, 1, GL_UNSIGNED_SHORT, VertexAttribute::Mode::Integer, offsetof(S3DVertex, Aux)},
 		},
 };
 
@@ -1036,6 +1036,11 @@ void COpenGL3DriverBase::drawGeneric(const void *vertices, const void *indexList
 void COpenGL3DriverBase::beginDraw(const VertexType &vertexType, uintptr_t verticesBase)
 {
 	for (auto &attr : vertexType) {
+		if (attr.mode == VertexAttribute::Mode::Integer && Version.Major < 3) {
+			// assume we know what we're doing and just skip if not supported
+			continue;
+		}
+
 		GL.EnableVertexAttribArray(attr.Index);
 		switch (attr.mode) {
 		case VertexAttribute::Mode::Regular:

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -298,7 +298,6 @@ protected:
 	void drawQuad(const VertexType &vertexType, const S3DVertex (&vertices)[4]);
 	void drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount);
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount);
-	void drawElements(GLenum primitiveType, const VertexType &vertexType, uintptr_t vertices, uintptr_t indices, int indexCount);
 
 	void drawGeneric(const void *vertices, const void *indexList, u32 primitiveCount,
 		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -716,6 +716,7 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 		}
 
 		// cf. EVertexAttributes.h for the predefined ones
+		// (note that these need to be in index order starting at 0)
 		vertex_header = R"(
 			uniform highp mat4 mWorldView;
 			uniform highp mat4 mWorldViewProj;
@@ -724,7 +725,10 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 			ATTRIBUTE_(0) highp vec4 inVertexPosition;
 			ATTRIBUTE_(1) mediump vec3 inVertexNormal;
 			ATTRIBUTE_(2) lowp vec4 inVertexColor_raw;
-			ATTRIBUTE_(3) mediump float inVertexAux;
+		)";
+		if (use_glsl3 || use_glsl15)
+			vertex_header += "ATTRIBUTE_(3) mediump uint inVertexAux;";
+		vertex_header += R"(
 			ATTRIBUTE_(4) mediump vec2 inTexCoord0;
 			ATTRIBUTE_(5) mediump vec2 inTexCoord1;
 			ATTRIBUTE_(6) mediump vec4 inVertexTangent;


### PR DESCRIPTION
why so complicated?
To use `int` we have to declare the variable `flat`, which is not available on old GLSL (hence the ifdef). Fortunately this doesn't conflict, because all versions that have array textures also have `flat`.
Next the driver throws an error at us because you can't use `flat` with the deprecated `varying` (hence doing it only for GLES first).
I thought this required migrating to GLSL 3.x, but actually `in`/`out` are already in GLSL 1.5. So that can be fixed.
Finally, we can apply that to both GL3 and GLES2 as originally intended.

Also we can change the vertex attribute to avoid another potentially problematic float conversion.

This *should* fix the "wrong texture rendered" reports we've seen. At least it fixes all bug causes I can think of.

references:
* https://stackoverflow.com/questions/27581271/flat-qualifier-in-glsl
* https://en.wikipedia.org/wiki/OpenGL_Shading_Language#Versions
* https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.1.50.pdf

## To do

This PR is Ready for Review.

## How to test

1. make sure world/inventory/entity rendering works fine on OpenGL legacy, OpenGL3 and OpenGL ES
2. same for shadow rendering
