### PR TITLE
Do not hide Luanti desktop icon on Phosh interface

### DIFF
--- a/misc/org.luanti.luanti.desktop
+++ b/misc/org.luanti.luanti.desktop
@@ -13,3 +13,4 @@ Categories=Game;Simulation;
 StartupNotify=false
 StartupWMClass=luanti
 Keywords=sandbox;world;mining;crafting;blocks;nodes;multiplayer;roleplaying;minetest;
+X-Purism-FormFactor=Mobile;Workstation


### PR DESCRIPTION
```
    Do not hide Luanti desktop icon on Phosh interface
    
    Phosh detect if application support Mobile interface and in case it
    doesn't explicitely declare support, hide the application by default.
    

```