### PR TITLE
Unittests: skip translation test if devtest cannot be found

### DIFF
--- a/src/unittest/test_translations.cpp
+++ b/src/unittest/test_translations.cpp
@@ -14,7 +14,8 @@
 static std::string read_translation_file(const std::string &filename)
 {
 		auto gamespec = findSubgame("devtest");
-		REQUIRE(gamespec.isValid());
+		if(!gamespec.isValid())
+			SKIP("devtest not found");
 		auto path = gamespec.gamemods_path + (DIR_DELIM "testtranslations" DIR_DELIM "test_locale" DIR_DELIM) + filename;
 		std::string content;
 		REQUIRE(fs::ReadFile(path, content));


### PR DESCRIPTION
The commit message/title should be self-explanatory. Fixes #16899.

---

The function for loading translations in the unittests additionally requires `fs::ReadFile` to succeed after locating the translation files. I would keep that as a `REQUIRE` as the situation where devtest is found but translations cannot be loaded should indicate a problem somewhere. 