### PR TITLE
Prevent loading of mods with invalid names

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1941,6 +1941,12 @@ chat_log_level (Chat log level) [client] enum error ,none,error,warning,action,i
 #    -    error: abort on usage of deprecated call (suggested for mod developers).
 deprecated_lua_api_handling (Deprecated Lua API handling) [common] enum log none,log,error
 
+#    Handling for errors when loading mods:
+#    -    none: Do not log mod load errors
+#    -    log: log errors (default).
+#    -    error: abort on failed load of mod (suggested for mod developers).
+mod_error_handling (Mod load error handling) [common] enum log none,log,error
+
 #    Enable random user input (only used for testing).
 random_input (Random input) [client] bool false
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -214,7 +214,8 @@ The location of this directory can be fetched by using
 A `Settings` file that provides meta information about the mod.
 
 * `name`: The mod name. Allows Luanti to determine the mod name even if the
-          folder is wrongly named.
+          folder is wrongly named. Valid names include only the characters
+          `a-zA-Z0-9_`.
 * `title`: A human-readable title to address the mod. See [Translating content meta](#translating-content-meta).
 * `description`: Description of mod to be shown in the Mods tab of the main
                  menu. See [Translating content meta](#translating-content-meta).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -215,7 +215,7 @@ A `Settings` file that provides meta information about the mod.
 
 * `name`: The mod name. Allows Luanti to determine the mod name even if the
           folder is wrongly named. Valid names include only the characters
-          `a-zA-Z0-9_`.
+          `a-z0-9_`.
 * `title`: A human-readable title to address the mod. See [Translating content meta](#translating-content-meta).
 * `description`: Description of mod to be shown in the Mods tab of the main
                  menu. See [Translating content meta](#translating-content-meta).

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3012,6 +3012,12 @@
 #    type: enum values: none, log, error
 # deprecated_lua_api_handling = log
 
+#    Handling for errors when loading mods:
+#    -    none: Do not log mod load errors
+#    -    log: log errors (default).
+#    -    error: abort on failed load of mod (suggested for mod developers).
+# mod_error_handling = log
+
 #    Enable random user input (only used for testing).
 #    type: bool
 # random_input = false

--- a/src/content/CMakeLists.txt
+++ b/src/content/CMakeLists.txt
@@ -5,6 +5,7 @@ set(content_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/content.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mod_configuration.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/mod_errors.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/subgames.cpp
 	PARENT_SCOPE
 )

--- a/src/content/mod_errors.cpp
+++ b/src/content/mod_errors.cpp
@@ -1,0 +1,50 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+#include <sstream>
+#include "mod_errors.h"
+#include "common/c_internal.h"
+#include "log.h"
+#include "exceptions.h"
+
+struct SingleModErrors {
+	std::set<std::string> messages;
+	bool was_handled;
+};
+
+static std::map<std::string, SingleModErrors> mod_errors;
+
+void ModErrors::logErrors() {
+	auto error_handling_mode = get_mod_error_handling_mode();
+	if (error_handling_mode == ModErrorHandlingMode::IgnoreModError) {
+		return;
+	}
+
+	for (auto &pair : mod_errors) {
+		const auto path = pair.first;
+		SingleModErrors& err = pair.second;
+
+		if (!err.was_handled && !err.messages.empty()) {
+			err.was_handled = true;
+			std::ostringstream os;
+			os << "Mod at " << path << ":" << std::endl;
+			for (const auto& msg : err.messages) {
+				os << "\t" << msg << std::endl;
+			}
+			if (error_handling_mode == ModErrorHandlingMode::ThrowModError)
+				throw ModError(os.str());
+			else
+				warningstream << os.str();
+		}
+	}
+}
+
+
+void ModErrors::setModError(const std::string &path, std::string error_message) {
+	SingleModErrors &cur = mod_errors[path];
+	auto result = cur.messages.emplace(error_message);
+	if (result.second) {
+		// New message was added, reset the was_handled flag
+		cur.was_handled = false;
+	}
+}

--- a/src/content/mod_errors.cpp
+++ b/src/content/mod_errors.cpp
@@ -1,6 +1,9 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#include <set>
+#include <map>
 #include <sstream>
 #include "mod_errors.h"
 #include "common/c_internal.h"

--- a/src/content/mod_errors.cpp
+++ b/src/content/mod_errors.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2026 Luanti developers
 
-#include <set>
-#include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include <sstream>
 #include "mod_errors.h"
 #include "common/c_internal.h"
@@ -11,11 +11,11 @@
 #include "exceptions.h"
 
 struct SingleModErrors {
-	std::set<std::string> messages;
+	std::unordered_set<std::string> messages;
 	bool was_handled;
 };
 
-static std::map<std::string, SingleModErrors> mod_errors;
+static std::unordered_map<std::string, SingleModErrors> mod_errors;
 
 void ModErrors::logErrors() {
 	auto error_handling_mode = get_mod_error_handling_mode();

--- a/src/content/mod_errors.cpp
+++ b/src/content/mod_errors.cpp
@@ -1,6 +1,6 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
-// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+// Copyright (C) 2026 Luanti developers
 
 #include <set>
 #include <map>

--- a/src/content/mod_errors.h
+++ b/src/content/mod_errors.h
@@ -1,6 +1,6 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
-// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+// Copyright (C) 2026 Luanti developers
 
 #pragma once
 

--- a/src/content/mod_errors.h
+++ b/src/content/mod_errors.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <map>
-#include <set>
 #include <string>
 
 class ModErrors {

--- a/src/content/mod_errors.h
+++ b/src/content/mod_errors.h
@@ -1,0 +1,15 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+class ModErrors {
+public:
+	static void logErrors();
+	static void setModError(const std::string &path, std::string error_message);
+};

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -85,7 +85,11 @@ bool parseModContents(ModSpec &spec)
 
 	if (info.exists("name")) {
 		spec.name = info.get("name");
-		spec.is_name_explicit = true;
+    spec.is_name_explicit = true;
+		if (!string_allowed(spec.name, MODNAME_ALLOWED_CHARS)) {
+			warningstream << "Error loading mod \"" + spec.path + "\": Mod does not follow naming conventions: " "Only characters [a-z0-9_] are allowed." << std::endl;
+			return false;
+		}
 	} else if (!spec.is_modpack) {
 		spec.deprecation_msgs.push_back("Mods not having a mod.conf file with the name is deprecated.");
 	}

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -85,7 +85,7 @@ bool parseModContents(ModSpec &spec)
 
 	if (info.exists("name")) {
 		spec.name = info.get("name");
-    spec.is_name_explicit = true;
+		spec.is_name_explicit = true;
 		if (!string_allowed(spec.name, MODNAME_ALLOWED_CHARS)) {
 			warningstream << "Error loading mod \"" + spec.path + "\": Mod does not follow naming conventions: " "Only characters [a-z0-9_] are allowed." << std::endl;
 			return false;

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -85,7 +85,7 @@ bool parseModContents(ModSpec &spec)
 		spec.name = info.get("name");
 		spec.is_name_explicit = true;
 		if (!string_allowed(spec.name, MODNAME_ALLOWED_CHARS)) {
-			ModErrors::setModError(spec.path, "Mod does not follow naming conventions" "Only characters [a-zA-Z0-9_] are allowed.");
+			ModErrors::setModError(spec.path, "Mod does not follow naming conventions" "Only characters [a-z0-9_] are allowed.");
 			return false;
 		}
 	} else if (!spec.is_modpack) {

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -12,7 +12,7 @@
 
 class ModStorageDatabase;
 
-#define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
+#define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
 
 struct ModSpec
 {

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -13,7 +13,7 @@
 
 class ModStorageDatabase;
 
-#define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+#define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
 
 struct ModSpec
 {

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -53,7 +53,7 @@ struct ModSpec
 	// For logging purposes
 	std::vector<const char *> deprecation_msgs;
 	// Set of log messages for mods, keyed by path
-  static std::map<std::string, std::set<std::string>> mod_load_error_msgs;
+	static std::map<std::string, std::set<std::string>> mod_load_error_msgs;
 	static bool mod_load_errors_logged;
 
 	// if modpack:

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <vector>
+#include <set>
 #include <string>
 #include <map>
 #include <unordered_set>
@@ -51,6 +52,9 @@ struct ModSpec
 
 	// For logging purposes
 	std::vector<const char *> deprecation_msgs;
+	// Set of log messages for mods, keyed by path
+  static std::map<std::string, std::set<std::string>> mod_load_error_msgs;
+	static bool mod_load_errors_logged;
 
 	// if modpack:
 	std::map<std::string, ModSpec> modpack_content;
@@ -65,6 +69,8 @@ struct ModSpec
 	}
 
 	void checkAndLog() const;
+
+	static void logModLoadErrors();
 };
 
 /**

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -52,9 +52,6 @@ struct ModSpec
 
 	// For logging purposes
 	std::vector<const char *> deprecation_msgs;
-	// Set of log messages for mods, keyed by path
-	static std::map<std::string, std::set<std::string>> mod_load_error_msgs;
-	static bool mod_load_errors_logged;
 
 	// if modpack:
 	std::map<std::string, ModSpec> modpack_content;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -460,6 +460,7 @@ void set_default_settings()
 	settings->setDefault("anticheat_movement_tolerance", "1.0");
 	settings->setDefault("enable_rollback_recording", "false");
 	settings->setDefault("deprecated_lua_api_handling", "log");
+  settings->setDefault("mod_error_handling", "log");
 
 	settings->setDefault("kick_msg_shutdown", "Server shutting down.");
 	settings->setDefault("kick_msg_crash", "This server has experienced an internal error. You will now be disconnected.");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -460,7 +460,7 @@ void set_default_settings()
 	settings->setDefault("anticheat_movement_tolerance", "1.0");
 	settings->setDefault("enable_rollback_recording", "false");
 	settings->setDefault("deprecated_lua_api_handling", "log");
-  settings->setDefault("mod_error_handling", "log");
+	settings->setDefault("mod_error_handling", "log");
 
 	settings->setDefault("kick_msg_shutdown", "Server shutting down.");
 	settings->setDefault("kick_msg_crash", "This server has experienced an internal error. You will now be disconnected.");

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -197,3 +197,22 @@ void call_string_dump(lua_State *L, int idx)
 	lua_pushvalue(L, idx);
 	lua_call(L, 1, 1);
 }
+
+ModErrorHandlingMode get_mod_error_handling_mode()
+{
+	static thread_local bool configured = false;
+	static thread_local ModErrorHandlingMode ret = ModErrorHandlingMode::IgnoreModError;
+
+	// Only read settings on first call
+	if (!configured) {
+		std::string value = g_settings->get("mod_error_handling");
+		if (value == "log") {
+			ret = ModErrorHandlingMode::LogModError;
+		} else if (value == "error") {
+			ret = ModErrorHandlingMode::ThrowModError;
+		}
+		configured = true;
+	}
+
+	return ret;
+}

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -145,3 +145,16 @@ void log_deprecated(lua_State *L, std::string_view message,
 // Safely call string.dump on a function value
 // (does not pop, leaves one value on stack)
 void call_string_dump(lua_State *L, int idx);
+
+enum ModErrorHandlingMode {
+  IgnoreModError,
+  LogModError,
+  ThrowModError,
+};
+
+/**
+ * Reads `mod_error_handling` in settings, returns cached value.
+ *
+ * @return ModErrorHandlingMode
+ */
+ModErrorHandlingMode get_mod_error_handling_mode();

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -147,9 +147,9 @@ void log_deprecated(lua_State *L, std::string_view message,
 void call_string_dump(lua_State *L, int idx);
 
 enum ModErrorHandlingMode {
-  IgnoreModError,
-  LogModError,
-  ThrowModError,
+	IgnoreModError,
+	LogModError,
+	ThrowModError,
 };
 
 /**


### PR DESCRIPTION
Logs message to warningstream

Add compact, short information about your PR for easier understanding:

- Goal of the PR:
  - Stop loading mod, and log warning when an invalid name is detected in mod.conf
- How does the PR work?
  - Updates `parseModContents` to check for invalid name when loading. Logs and skips mods containing invalid characters.
- Does it resolve any reported issue?
  - Should fix https://github.com/luanti-org/luanti/issues/16478
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - This is a small bug fix that was listed as a good starter fix.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  - I have not used any LLM/AI to develop this

I realize there's already an open PR for this, but it has been inactive for a couple of weeks at this point.

## To do

This PR is Ready for Review.

## How to test

As documented in the issue, set up a mod with invalid characters in the `name` field.

ex: 
```conf
name = """
haha ;]
oops
"""
description = "Mod to test bug that's being fixed"
depends = first_mod
```

Prior to this fix, the mod would load, and show up oddly in the mod list.

Afterwards, there is a WARN log, and the mod does not get loaded/shown.