### PR TITLE
Add mapblock callbacks and tracking tables

### DIFF
--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -19,6 +19,8 @@ core.EMERGE_GENERATED   = 4
 -- constants.h
 -- Size of mapblocks in nodes
 core.MAP_BLOCKSIZE = 16
+-- Sentinel value for an undefined mapblock timestamp (block has never been activated)
+core.BLOCK_TIMESTAMP_UNDEFINED = 0xffffffff
 -- Default maximal HP of a player
 core.PLAYER_MAX_HP_DEFAULT = 20
 -- Default maximal breath of a player

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -620,6 +620,10 @@ core.registered_allow_player_inventory_actions, core.register_allow_player_inven
 core.registered_on_rightclickplayers, core.register_on_rightclickplayer = make_registration()
 core.registered_on_liquid_transformed, core.register_on_liquid_transformed = make_registration()
 core.registered_on_mapblocks_changed, core.register_on_mapblocks_changed = make_registration()
+core.registered_on_block_loaded, core.register_on_block_loaded = make_registration()
+core.registered_on_block_activated, core.register_on_block_activated = make_registration()
+core.registered_on_block_deactivated, core.register_on_block_deactivated = make_registration()
+core.registered_on_block_unloaded, core.register_on_block_unloaded = make_registration()
 
 -- A bunch of registrations are read by the C++ side once on env init, so we cannot
 -- allow them to change afterwards (see s_env.cpp).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6559,6 +6559,12 @@ Call these functions only at load time!
     * This is called after `on_block_loaded` if the block was just loaded
     * `blockpos`: position of the block (table with x, y, z)
     * Note: callbacks must be registered at mod load time.
+    * **Warning**: As of Luanti 5.15.0, making map modifications using VoxelManip
+      (or similar functions like `core.set_node`) in this callback is unreliable.
+      Changes can be overwritten when neighboring mapchunks generate and extend
+      into already-activated blocks (for example, caves or dungeons crossing
+      mapchunk boundaries). Use `core.register_on_generated` or `core.register_lbm`
+      instead for reliable map modifications.
 * `core.register_on_block_deactivated(function(blockpos_list))`
     * Called after mapblocks are deactivated (moved out of active_block_range)
     * Deactivated blocks remain loaded in memory but no longer run game logic

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6546,6 +6546,29 @@ Call these functions only at load time!
       The set is a table where the keys are hashes and the values are `true`.
     * `modified_block_count` is the number of entries in the set.
     * Note: callbacks must be registered at mod load time.
+* `core.register_on_block_loaded(function(blockpos))`
+    * Called when a mapblock is loaded from disk or generated for the first time
+    * This callback fires for ALL loaded blocks (including those far from players)
+    * For newly generated blocks, the callback runs after the chunk emerges
+      (after liquid transforms and lighting) but before block activation
+    * For blocks loaded from disk, it runs before border lighting is updated
+    * `blockpos`: position of the block (table with x, y, z)
+    * Note: callbacks must be registered at mod load time.
+* `core.register_on_block_activated(function(blockpos))`
+    * Called immediately after a mapblock becomes active (within active_block_range of a player)
+    * This is called after `on_block_loaded` if the block was just loaded
+    * `blockpos`: position of the block (table with x, y, z)
+    * Note: callbacks must be registered at mod load time.
+* `core.register_on_block_deactivated(function(blockpos_list))`
+    * Called after mapblocks are deactivated (moved out of active_block_range)
+    * Deactivated blocks remain loaded in memory but no longer run game logic
+    * `blockpos_list`: array of block positions (each is a table with x, y, z)
+    * Note: callbacks must be registered at mod load time.
+* `core.register_on_block_unloaded(function(blockpos_list))`
+    * Called after mapblocks are completely unloaded from memory
+    * This happens when the server needs to free memory or on shutdown
+    * `blockpos_list`: array of block positions (each is a table with x, y, z)
+    * Note: callbacks must be registered at mod load time.
 
 Setting-related
 ---------------
@@ -8070,6 +8093,21 @@ Global tables
     * Map of active object references, indexed by active object id
 * `core.luaentities`
     * Map of Lua entities, indexed by active object id
+* `core.loaded_blocks`
+    * Read-only table tracking currently loaded mapblocks
+    * Keys are block position hashes (from `core.hash_node_position`)
+    * Values are `true` for loaded blocks, `nil` otherwise
+    * Loaded blocks are in memory and can contain nodes/objects
+    * Updated automatically by the engine when blocks are loaded or unloaded from memory
+    * Example: `if core.loaded_blocks[core.hash_node_position(blockpos)] then ... end`
+* `core.active_blocks`
+    * Read-only table tracking currently active mapblocks
+    * Active blocks are those within active_block_range of a player
+    * Keys are block position hashes (from `core.hash_node_position`)
+    * Values are `true` for active blocks, `nil` otherwise
+    * Active blocks run game logic (ABMs, node timers, etc.)
+    * All active blocks are also loaded, but not all loaded blocks are active
+    * Updated automatically by the engine when blocks become active or inactive
 * `core.registered_abms`
     * List of ABM definitions
 * `core.registered_lbms`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6554,10 +6554,16 @@ Call these functions only at load time!
     * For blocks loaded from disk, it runs before border lighting is updated
     * `blockpos`: position of the block (table with x, y, z)
     * Note: callbacks must be registered at mod load time.
-* `core.register_on_block_activated(function(blockpos))`
+* `core.register_on_block_activated(function(blockpos, last_timestamp))`
     * Called immediately after a mapblock becomes active (within active_block_range of a player)
     * This is called after `on_block_loaded` if the block was just loaded
     * `blockpos`: position of the block (table with x, y, z)
+    * `last_timestamp`: the timestamp of the block before it was activated (unsigned
+      integer, same unit as `core.get_gametime()`). This is
+      `core.BLOCK_TIMESTAMP_UNDEFINED` (4294967295) if the
+      block has never been activated before (e.g. newly generated blocks).
+      Comparing `last_timestamp` to `core.get_gametime()` gives the elapsed time
+      since the block was last active.
     * Note: callbacks must be registered at mod load time.
     * **Warning**: As of Luanti 5.15.0, making map modifications using VoxelManip
       (or similar functions like `core.set_node`) in this callback is unreliable.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8106,20 +8106,20 @@ Global tables
 * `core.luaentities`
     * Map of Lua entities, indexed by active object id
 * `core.loaded_blocks`
-    * Read-only table tracking currently loaded mapblocks
+    * Table tracking currently loaded mapblocks; mods must treat this as read-only and must not modify it
     * Keys are block position hashes (from `core.hash_node_position`)
     * Values are `true` for loaded blocks, `nil` otherwise
     * Loaded blocks are in memory and can contain nodes/objects
-    * Updated automatically by the engine when blocks are loaded or unloaded from memory
+    * Updated automatically by the engine when blocks are loaded or unloaded from memory; any changes made by mods are unsupported and may be overwritten
     * Example: `if core.loaded_blocks[core.hash_node_position(blockpos)] then ... end`
 * `core.active_blocks`
-    * Read-only table tracking currently active mapblocks
+    * Table tracking currently active mapblocks; mods must treat this as read-only and must not modify it
     * Active blocks are those within active_block_range of a player
     * Keys are block position hashes (from `core.hash_node_position`)
     * Values are `true` for active blocks, `nil` otherwise
     * Active blocks run game logic (ABMs, node timers, etc.)
     * All active blocks are also loaded, but not all loaded blocks are active
-    * Updated automatically by the engine when blocks become active or inactive
+    * Updated automatically by the engine when blocks become active or inactive; any changes made by mods are unsupported and may be overwritten
 * `core.registered_abms`
     * List of ABM definitions
 * `core.registered_lbms`

--- a/games/devtest/mods/test_blocks/init.lua
+++ b/games/devtest/mods/test_blocks/init.lua
@@ -1,0 +1,78 @@
+-- Test mod to verify core.loaded_blocks and core.active_blocks tracking
+-- This mod monitors block activation/deactivation and verifies the tables are correct
+
+local function count_blocks(block_table)
+	local count = 0
+	for _ in pairs(block_table) do
+		count = count + 1
+	end
+	return count
+end
+
+-- Monitor block loaded events
+core.register_on_block_loaded(function(blockpos)
+	core.log("action", "[test_blocks] Block loaded: " .. core.pos_to_string(blockpos))
+end)
+
+-- Monitor block activated events
+core.register_on_block_activated(function(blockpos)
+	core.log("action", "[test_blocks] Block activated: " .. core.pos_to_string(blockpos))
+end)
+
+-- Monitor block deactivated events
+core.register_on_block_deactivated(function(blockpos_list)
+	core.log("action", "[test_blocks] " .. #blockpos_list .. " blocks deactivated")
+	for _, pos in ipairs(blockpos_list) do
+		core.log("action", "[test_blocks]   - " .. core.pos_to_string(pos))
+	end
+end)
+
+-- Monitor block unloaded events
+core.register_on_block_unloaded(function(blockpos_list)
+	core.log("action", "[test_blocks] " .. #blockpos_list .. " blocks unloaded from memory")
+	for _, pos in ipairs(blockpos_list) do
+		core.log("action", "[test_blocks]   - " .. core.pos_to_string(pos))
+	end
+end)
+
+-- Periodic check to verify loaded_blocks >= active_blocks
+local check_timer = 0
+core.register_globalstep(function(dtime)
+	check_timer = check_timer + dtime
+	if check_timer >= 5.0 then  -- Check every 5 seconds
+		check_timer = 0
+		
+		local loaded_count = count_blocks(core.loaded_blocks)
+		local active_count = count_blocks(core.active_blocks)
+		
+		core.log("action", string.format(
+			"[test_blocks] Blocks status: %d loaded, %d active",
+			loaded_count, active_count
+		))
+		
+		-- Verify that all active blocks are also loaded
+		for hash, _ in pairs(core.active_blocks) do
+			if not core.loaded_blocks[hash] then
+				core.log("error", "[test_blocks] BUG: Active block is not in loaded_blocks!")
+			end
+		end
+		
+		-- The key test: loaded_blocks should have >= active_blocks
+		if loaded_count < active_count then
+			core.log("error", string.format(
+				"[test_blocks] BUG: More active blocks (%d) than loaded blocks (%d)!",
+				active_count, loaded_count
+			))
+		elseif loaded_count == active_count and loaded_count > 0 then
+			core.log("warning", string.format(
+				"[test_blocks] WARNING: Same number of loaded and active blocks (%d). " ..
+				"This may indicate the old bug if view_range > active_block_range.",
+				loaded_count
+			))
+		else
+			core.log("action", "[test_blocks] OK: loaded_blocks >= active_blocks")
+		end
+	end
+end)
+
+core.log("action", "[test_blocks] Test mod initialized. Monitoring block tracking tables.")

--- a/games/devtest/mods/test_blocks/mod.conf
+++ b/games/devtest/mods/test_blocks/mod.conf
@@ -1,0 +1,2 @@
+name = test_blocks
+description = Test mod to verify core.loaded_blocks and core.active_blocks tracking

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -756,26 +756,20 @@ void *EmergeThread::run()
 			if (!block || error)
 				action = EMERGE_ERRORED;
 
-			// Call on_block_loaded callback after chunk emerges but before activation
-			// This allows voxel manipulator to run after all mapgen liquid transforms
-			// and lighting calculations are complete
+			// Queue on_block_loaded callbacks for all generated blocks.
+			// The callbacks are fired on the main server thread in
+			// ServerEnvironment::step() so that mods can safely use all
+			// Lua APIs (mod storage, etc.) inside the callback.
 			if (block && !error) {
-				Server::EnvAutoLock envlock(m_server);
-				ServerScripting *script = m_server->m_env->getScriptIface();
-				if (script) {
-					// Call for all blocks in the generated chunk
-					const v3s16 &bpmin = bmdata.blockpos_min;
-					const v3s16 &bpmax = bmdata.blockpos_max;
-					// Iterate Y first for better cache locality
-					for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
-					for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
-					for (s16 x = bpmin.X; x <= bpmax.X; x++) {
-						v3s16 bp(x, y, z);
-						// Only call callback if block actually exists
-						MapBlock *gen_block = m_map->getBlockNoCreateNoEx(bp);
-						if (gen_block)
-							script->on_block_loaded(bp);
-					}
+				const v3s16 &bpmin = bmdata.blockpos_min;
+				const v3s16 &bpmax = bmdata.blockpos_max;
+				for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
+				for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
+				for (s16 x = bpmin.X; x <= bpmax.X; x++) {
+					v3s16 bp(x, y, z);
+					// Only queue if the block actually exists
+					if (m_map->getBlockNoCreateNoEx(bp))
+						m_server->m_env->queueBlockLoaded(bp);
 				}
 			}
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -159,6 +159,17 @@ void ScriptApiEnv::player_event(ServerActiveObject *player, const std::string &t
 	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
 
+/*
+ * Helper function for read-only table metatables.
+ * Used as the __newindex metamethod to prevent modifications.
+ * Expects a table name as an upvalue for error messaging.
+ */
+static int block_table_newindex_error(lua_State *L)
+{
+	const char *table_name = lua_tostring(L, lua_upvalueindex(1));
+	return luaL_error(L, "%s is read-only", table_name);
+}
+
 void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 {
 	SCRIPTAPI_PRECHECKHEADER
@@ -166,6 +177,31 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 	assert(env);
 	verbosestream << "ScriptApiEnv: Environment initialized" << std::endl;
 	setEnv(env);
+
+	// Initialize block tracking tables
+	lua_getglobal(L, "core");
+
+	// Create loaded_blocks table with metatable to make it read-only
+	lua_newtable(L);
+	lua_newtable(L); // metatable
+	lua_pushstring(L, "__newindex");
+	lua_pushstring(L, "core.loaded_blocks");
+	lua_pushcclosure(L, block_table_newindex_error, 1);
+	lua_settable(L, -3);
+	lua_setmetatable(L, -2);
+	lua_setfield(L, -2, "loaded_blocks");
+
+	// Create active_blocks table with metatable to make it read-only
+	lua_newtable(L);
+	lua_newtable(L); // metatable
+	lua_pushstring(L, "__newindex");
+	lua_pushstring(L, "core.active_blocks");
+	lua_pushcclosure(L, block_table_newindex_error, 1);
+	lua_settable(L, -3);
+	lua_setmetatable(L, -2);
+	lua_setfield(L, -2, "active_blocks");
+
+	lua_pop(L, 1); // Pop core
 
 	readABMs();
 	readLBMs();
@@ -417,6 +453,143 @@ bool ScriptApiEnv::has_on_mapblocks_changed()
 	lua_getfield(L, -1, "registered_on_mapblocks_changed");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	return lua_objlen(L, -1) > 0;
+}
+
+void ScriptApiEnv::on_block_loaded(v3s16 blockpos)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_block_loaded
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_loaded");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Push block position
+	push_v3s16(L, blockpos);
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+
+	// Update loaded_blocks table
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "loaded_blocks");
+	if (lua_istable(L, -1)) {
+		lua_pushnumber(L, hash_node_position(blockpos));
+		lua_pushboolean(L, true);
+		lua_rawset(L, -3);
+	}
+	lua_pop(L, 2); // Pop loaded_blocks and core
+}
+
+void ScriptApiEnv::on_block_activated(v3s16 blockpos)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_block_activated
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_activated");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Push block position
+	push_v3s16(L, blockpos);
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+
+	// Update loaded_blocks table (activated blocks are by definition loaded)
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "loaded_blocks");
+	if (lua_istable(L, -1)) {
+		lua_pushnumber(L, hash_node_position(blockpos));
+		lua_pushboolean(L, true);
+		lua_rawset(L, -3);
+	}
+	lua_pop(L, 1); // Pop loaded_blocks
+
+	// Update active_blocks table
+	lua_getfield(L, -1, "active_blocks");
+	if (lua_istable(L, -1)) {
+		lua_pushnumber(L, hash_node_position(blockpos));
+		lua_pushboolean(L, true);
+		lua_rawset(L, -3);
+	}
+	lua_pop(L, 2); // Pop active_blocks and core
+}
+
+void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_block_deactivated
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_deactivated");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Create array of block positions
+	lua_createtable(L, blockpos_list.size(), 0);
+	int lua_index = 1; // Lua arrays are 1-indexed
+	for (const v3s16 &blockpos : blockpos_list) {
+		push_v3s16(L, blockpos);
+		lua_rawseti(L, -2, lua_index++);
+	}
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+
+	// Update active_blocks table only (blocks are still loaded in memory)
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "active_blocks");
+	if (lua_istable(L, -1)) {
+		for (const v3s16 &blockpos : blockpos_list) {
+			lua_pushnumber(L, hash_node_position(blockpos));
+			lua_pushnil(L);
+			lua_rawset(L, -3);
+		}
+	}
+	lua_pop(L, 2); // Pop active_blocks and core
+}
+
+void ScriptApiEnv::on_block_unloaded(const std::vector<v3s16> &blockpos_list)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_block_unloaded
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_unloaded");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Create array of block positions
+	lua_createtable(L, blockpos_list.size(), 0);
+	int lua_index = 1; // Lua arrays are 1-indexed
+	for (const v3s16 &blockpos : blockpos_list) {
+		push_v3s16(L, blockpos);
+		lua_rawseti(L, -2, lua_index++);
+	}
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+
+	// Update loaded_blocks and active_blocks tables
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "loaded_blocks");
+	if (lua_istable(L, -1)) {
+		for (const v3s16 &blockpos : blockpos_list) {
+			lua_pushnumber(L, hash_node_position(blockpos));
+			lua_pushnil(L);
+			lua_rawset(L, -3);
+		}
+	}
+	lua_pop(L, 1); // Pop loaded_blocks
+
+	lua_getfield(L, -1, "active_blocks");
+	if (lua_istable(L, -1)) {
+		for (const v3s16 &blockpos : blockpos_list) {
+			lua_pushnumber(L, hash_node_position(blockpos));
+			lua_pushnil(L);
+			lua_rawset(L, -3);
+		}
+	}
+	lua_pop(L, 2); // Pop active_blocks and core
 }
 
 void ScriptApiEnv::triggerABM(int id, v3s16 p, MapNode n,

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -523,6 +523,19 @@ void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	// Update active_blocks table before running callbacks so mods see the
+	// blocks as inactive when querying inside the callback
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "active_blocks");
+	if (lua_istable(L, -1)) {
+		for (const v3s16 &blockpos : blockpos_list) {
+			lua_pushnumber(L, hash_node_position(blockpos));
+			lua_pushnil(L);
+			lua_rawset(L, -3);
+		}
+	}
+	lua_pop(L, 2); // Pop active_blocks and core
+
 	// Get core.registered_on_block_deactivated
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_block_deactivated");
@@ -538,18 +551,6 @@ void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)
 	}
 
 	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
-
-	// Update active_blocks table only (blocks are still loaded in memory)
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "active_blocks");
-	if (lua_istable(L, -1)) {
-		for (const v3s16 &blockpos : blockpos_list) {
-			lua_pushnumber(L, hash_node_position(blockpos));
-			lua_pushnil(L);
-			lua_rawset(L, -3);
-		}
-	}
-	lua_pop(L, 2); // Pop active_blocks and core
 }
 
 void ScriptApiEnv::on_block_unloaded(const std::vector<v3s16> &blockpos_list)

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -554,7 +554,7 @@ void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)
 
 	// Create array of block positions
 	lua_createtable(L, blockpos_list.size(), 0);
-	int lua_index = 1; // Lua arrays are 1-indexed
+	int lua_index = 1;
 	for (const v3s16 &blockpos : blockpos_list) {
 		push_v3s16(L, blockpos);
 		lua_rawseti(L, -2, lua_index++);

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -485,20 +485,8 @@ void ScriptApiEnv::on_block_activated(v3s16 blockpos, u32 last_stamp)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	// Get core.registered_on_block_activated
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "registered_on_block_activated");
-	luaL_checktype(L, -1, LUA_TTABLE);
-	lua_remove(L, -2); // Remove core
-
-	// Push block position
-	push_v3s16(L, blockpos);
-	// Push old timestamp (BLOCK_TIMESTAMP_UNDEFINED if this is a new/never-activated block)
-	lua_pushinteger(L, last_stamp);
-
-	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
-
-	// Update loaded_blocks table (activated blocks are by definition loaded)
+	// Update loaded_blocks and active_blocks tables before running callbacks
+	// so mods can query them inside the callback
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "loaded_blocks");
 	if (lua_istable(L, -1)) {
@@ -508,7 +496,6 @@ void ScriptApiEnv::on_block_activated(v3s16 blockpos, u32 last_stamp)
 	}
 	lua_pop(L, 1); // Pop loaded_blocks
 
-	// Update active_blocks table
 	lua_getfield(L, -1, "active_blocks");
 	if (lua_istable(L, -1)) {
 		lua_pushnumber(L, hash_node_position(blockpos));
@@ -516,6 +503,20 @@ void ScriptApiEnv::on_block_activated(v3s16 blockpos, u32 last_stamp)
 		lua_rawset(L, -3);
 	}
 	lua_pop(L, 2); // Pop active_blocks and core
+
+	// Get core.registered_on_block_activated
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_activated");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Push block position
+	push_v3s16(L, blockpos);
+	// Push old timestamp as a number to handle BLOCK_TIMESTAMP_UNDEFINED (0xffffffff)
+	// safely on 32-bit builds where lua_pushinteger would produce -1
+	lua_pushnumber(L, (lua_Number)last_stamp);
+
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
 
 void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -481,7 +481,7 @@ void ScriptApiEnv::on_block_loaded(v3s16 blockpos)
 	lua_pop(L, 2); // Pop loaded_blocks and core
 }
 
-void ScriptApiEnv::on_block_activated(v3s16 blockpos)
+void ScriptApiEnv::on_block_activated(v3s16 blockpos, u32 last_stamp)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -493,8 +493,10 @@ void ScriptApiEnv::on_block_activated(v3s16 blockpos)
 
 	// Push block position
 	push_v3s16(L, blockpos);
+	// Push old timestamp (BLOCK_TIMESTAMP_UNDEFINED if this is a new/never-activated block)
+	lua_pushinteger(L, last_stamp);
 
-	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 
 	// Update loaded_blocks table (activated blocks are by definition loaded)
 	lua_getglobal(L, "core");

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -557,23 +557,8 @@ void ScriptApiEnv::on_block_unloaded(const std::vector<v3s16> &blockpos_list)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	// Get core.registered_on_block_unloaded
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "registered_on_block_unloaded");
-	luaL_checktype(L, -1, LUA_TTABLE);
-	lua_remove(L, -2); // Remove core
-
-	// Create array of block positions
-	lua_createtable(L, blockpos_list.size(), 0);
-	int lua_index = 1; // Lua arrays are 1-indexed
-	for (const v3s16 &blockpos : blockpos_list) {
-		push_v3s16(L, blockpos);
-		lua_rawseti(L, -2, lua_index++);
-	}
-
-	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
-
-	// Update loaded_blocks and active_blocks tables
+	// Update loaded_blocks and active_blocks tables before running callbacks
+	// so mods see the blocks as unloaded when querying inside the callback
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "loaded_blocks");
 	if (lua_istable(L, -1)) {
@@ -594,6 +579,22 @@ void ScriptApiEnv::on_block_unloaded(const std::vector<v3s16> &blockpos_list)
 		}
 	}
 	lua_pop(L, 2); // Pop active_blocks and core
+
+	// Get core.registered_on_block_unloaded
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_block_unloaded");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_remove(L, -2); // Remove core
+
+	// Create array of block positions
+	lua_createtable(L, blockpos_list.size(), 0);
+	int lua_index = 1; // Lua arrays are 1-indexed
+	for (const v3s16 &blockpos : blockpos_list) {
+		push_v3s16(L, blockpos);
+		lua_rawseti(L, -2, lua_index++);
+	}
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
 }
 
 void ScriptApiEnv::triggerABM(int id, v3s16 p, MapNode n,

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -544,7 +544,7 @@ void ScriptApiEnv::on_block_deactivated(const std::vector<v3s16> &blockpos_list)
 			lua_rawset(L, -3);
 		}
 	}
-	lua_pop(L, 2); // Pop active_blocks and core
+	lua_pop(L, 2); // active_blocks, core
 
 	// Get core.registered_on_block_deactivated
 	lua_getglobal(L, "core");

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -459,6 +459,16 @@ void ScriptApiEnv::on_block_loaded(v3s16 blockpos)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	// Update loaded_blocks table before running callbacks so mods can query it
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "loaded_blocks");
+	if (lua_istable(L, -1)) {
+		lua_pushnumber(L, hash_node_position(blockpos));
+		lua_pushboolean(L, true);
+		lua_rawset(L, -3);
+	}
+	lua_pop(L, 2); // Pop loaded_blocks and core
+
 	// Get core.registered_on_block_loaded
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_block_loaded");
@@ -469,16 +479,6 @@ void ScriptApiEnv::on_block_loaded(v3s16 blockpos)
 	push_v3s16(L, blockpos);
 
 	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
-
-	// Update loaded_blocks table
-	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "loaded_blocks");
-	if (lua_istable(L, -1)) {
-		lua_pushnumber(L, hash_node_position(blockpos));
-		lua_pushboolean(L, true);
-		lua_rawset(L, -3);
-	}
-	lua_pop(L, 2); // Pop loaded_blocks and core
 }
 
 void ScriptApiEnv::on_block_activated(v3s16 blockpos, u32 last_stamp)

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -181,22 +181,32 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 	// Initialize block tracking tables
 	lua_getglobal(L, "core");
 
-	// Create loaded_blocks table with metatable to make it read-only
+	// Create loaded_blocks table with metatable to make it read-only.
+	// __newindex prevents direct assignments; __metatable prevents setmetatable()
+	// replacement. Note: rawset() can still bypass this - this is best-effort protection.
 	lua_newtable(L);
 	lua_newtable(L); // metatable
 	lua_pushstring(L, "__newindex");
 	lua_pushstring(L, "core.loaded_blocks");
 	lua_pushcclosure(L, block_table_newindex_error, 1);
 	lua_settable(L, -3);
+	lua_pushstring(L, "__metatable");
+	lua_pushboolean(L, false);
+	lua_settable(L, -3);
 	lua_setmetatable(L, -2);
 	lua_setfield(L, -2, "loaded_blocks");
 
-	// Create active_blocks table with metatable to make it read-only
+	// Create active_blocks table with metatable to make it read-only.
+	// __newindex prevents direct assignments; __metatable prevents setmetatable()
+	// replacement. Note: rawset() can still bypass this - this is best-effort protection.
 	lua_newtable(L);
 	lua_newtable(L); // metatable
 	lua_pushstring(L, "__newindex");
 	lua_pushstring(L, "core.active_blocks");
 	lua_pushcclosure(L, block_table_newindex_error, 1);
+	lua_settable(L, -3);
+	lua_pushstring(L, "__metatable");
+	lua_pushboolean(L, false);
 	lua_settable(L, -3);
 	lua_setmetatable(L, -2);
 	lua_setfield(L, -2, "active_blocks");

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -41,6 +41,12 @@ public:
 	// Determines whether there are any on_mapblocks_changed callbacks
 	bool has_on_mapblocks_changed();
 
+	// Block tracking callbacks
+	void on_block_loaded(v3s16 blockpos);
+	void on_block_activated(v3s16 blockpos);
+	void on_block_deactivated(const std::vector<v3s16> &blockpos_list);
+	void on_block_unloaded(const std::vector<v3s16> &blockpos_list);
+
 	// Initializes environment and loads some definitions from Lua
 	void initializeEnvironment(ServerEnvironment *env);
 

--- a/src/script/cpp_api/s_env.h
+++ b/src/script/cpp_api/s_env.h
@@ -43,7 +43,7 @@ public:
 
 	// Block tracking callbacks
 	void on_block_loaded(v3s16 blockpos);
-	void on_block_activated(v3s16 blockpos);
+	void on_block_activated(v3s16 blockpos, u32 last_stamp);
 	void on_block_deactivated(const std::vector<v3s16> &blockpos_list);
 	void on_block_unloaded(const std::vector<v3s16> &blockpos_list);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -738,9 +738,15 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 		EnvAutoLock lock(this);
 		// Run Map's timers and unload unused data
 		ScopeProfiler sp(g_profiler, "Server: map timer and unload");
+		std::vector<v3s16> unloaded_blocks;
 		m_env->getMap().timerUpdate(map_timer_and_unload_dtime,
 			std::max(g_settings->getFloat("server_unload_unused_data_timeout"), 0.0f),
-			-1);
+			-1, &unloaded_blocks);
+
+		// Notify scripts of blocks that were unloaded from memory
+		if (!unloaded_blocks.empty()) {
+			m_env->getScriptIface()->on_block_unloaded(unloaded_blocks);
+		}
 	}
 
 	/*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -588,7 +588,7 @@ void ServerEnvironment::activateBlock(MapBlock *block)
 
 	// Call Lua on_block_activated callback
 	// Note: on_block_loaded is called earlier during block load, not here
-	m_script->on_block_activated(block->getPos());
+	m_script->on_block_activated(block->getPos(), stamp);
 }
 
 void ServerEnvironment::addActiveBlockModifier(ActiveBlockModifier *abm)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -601,6 +601,12 @@ void ServerEnvironment::addLoadingBlockModifierDef(LoadingBlockModifierDef *lbm)
 	m_lbm_mgr.addLBMDef(lbm);
 }
 
+void ServerEnvironment::queueBlockLoaded(v3s16 pos)
+{
+	std::lock_guard<std::mutex> lock(m_pending_loaded_blocks_mutex);
+	m_pending_loaded_blocks.push_back(pos);
+}
+
 bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 {
 	const NodeDefManager *ndef = m_server->ndef();
@@ -1087,6 +1093,21 @@ void ServerEnvironment::step(float dtime)
 		g_profiler->avg("ServerEnv: ABMs run", abms_run);
 
 		timer.stop(true);
+	}
+
+	/*
+		Fire on_block_loaded callbacks for blocks that were loaded or generated
+		on emerge/mapgen threads. We drain the queue here on the main server
+		thread so that mods can safely use all Lua APIs inside the callback.
+	*/
+	{
+		std::vector<v3s16> loaded_blocks;
+		{
+			std::lock_guard<std::mutex> lock(m_pending_loaded_blocks_mutex);
+			loaded_blocks = std::move(m_pending_loaded_blocks);
+		}
+		for (const v3s16 &bp : loaded_blocks)
+			m_script->on_block_loaded(bp);
 	}
 
 	/*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -849,10 +849,18 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 				<< percent << "%)" << std::endl;
 		}
 		if (num_blocks_checked % unload_interval == 0) {
-			m_map->unloadUnreferencedBlocks();
+			std::vector<v3s16> interval_unloaded;
+			m_map->unloadUnreferencedBlocks(&interval_unloaded);
+			if (!interval_unloaded.empty())
+				m_script->on_block_unloaded(interval_unloaded);
 		}
 	}
-	m_map->unloadUnreferencedBlocks();
+	{
+		std::vector<v3s16> final_unloaded;
+		m_map->unloadUnreferencedBlocks(&final_unloaded);
+		if (!final_unloaded.empty())
+			m_script->on_block_unloaded(final_unloaded);
+	}
 
 	// Drop references that were added above
 	for (v3s16 p : loaded_blocks) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -603,7 +603,7 @@ void ServerEnvironment::addLoadingBlockModifierDef(LoadingBlockModifierDef *lbm)
 
 void ServerEnvironment::queueBlockLoaded(v3s16 pos)
 {
-	std::lock_guard<std::mutex> lock(m_pending_loaded_blocks_mutex);
+	auto lock = std::lock_guard(m_pending_loaded_blocks_mutex);
 	m_pending_loaded_blocks.push_back(pos);
 }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory> // std::unique_ptr
+#include <mutex>
 #include <set>
 #include <unordered_map>
 #include <utility> // std::function
@@ -218,6 +219,11 @@ public:
 	void addActiveBlockModifier(ActiveBlockModifier *abm);
 	void addLoadingBlockModifierDef(LoadingBlockModifierDef *lbm);
 
+	// Queue a block position so that on_block_loaded callbacks are fired on
+	// the main server thread during the next step(). Safe to call from any
+	// thread (e.g. emerge/mapgen threads).
+	void queueBlockLoaded(v3s16 pos);
+
 	/*
 		Other stuff
 		-------------------------------------------
@@ -374,6 +380,10 @@ private:
 	GUIDGenerator m_guid_generator;
 	// Outgoing network message buffer for active objects
 	std::queue<ActiveObjectMessage> m_active_object_messages;
+	// Block positions queued for on_block_loaded callbacks (filled by emerge /
+	// load threads, drained on the main thread in step()).
+	std::mutex m_pending_loaded_blocks_mutex;
+	std::vector<v3s16> m_pending_loaded_blocks;
 	// Some timers
 	float m_send_recommended_timer = 0.0f;
 	IntervalLimiter m_object_management_interval;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -774,17 +774,13 @@ MapBlock *ServerMap::loadBlock(const std::string &blob, v3s16 p3d, bool save_aft
 		ReflowScan scanner(this, m_emerge->ndef);
 		scanner.scan(block, &m_transforming_liquid);
 
-		// Call on_block_loaded callback before fixing lighting
-		// This allows voxel manipulator to modify the block, and lighting
-		// will be fixed afterwards
-		if (m_env) {
-			ServerScripting *script = m_env->getScriptIface();
-			if (script)
-				script->on_block_loaded(p3d);
-		}
+		// Queue on_block_loaded callback to be fired on the main server
+		// thread in ServerEnvironment::step() so that mods can safely use
+		// all Lua APIs inside the callback.
+		if (m_env)
+			m_env->queueBlockLoaded(p3d);
 
 		std::map<v3s16, MapBlock*> modified_blocks;
-		// Fix lighting after callback to handle any voxel manipulator changes
 		voxalgo::update_block_border_lighting(this, block, modified_blocks);
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -11,6 +11,7 @@
 #include "util/container.h" // UniqueQueue
 #include "util/metricsbackend.h" // ptr typedefs
 #include "map_settings_manager.h"
+#include "log.h"
 
 class Settings;
 class MapDatabase;
@@ -47,6 +48,16 @@ public:
 	*/
 	ServerMap(const std::string &savedir, IGameDef *gamedef, EmergeManager *emerge, MetricsBackend *mb);
 	~ServerMap();
+
+	// Set the server environment (called after map construction)
+	void setServerEnvironment(ServerEnvironment *env) {
+		if (!env) {
+			errorstream << "ServerMap::setServerEnvironment: "
+				<< "Attempted to set null ServerEnvironment pointer!" << std::endl;
+			return;
+		}
+		m_env = env;
+	}
 
 	/*
 		Get a sector from somewhere.
@@ -176,6 +187,9 @@ private:
 
 	// Emerge manager
 	EmergeManager *m_emerge;
+
+	// Server environment (for callbacks)
+	ServerEnvironment *m_env = nullptr;
 
 	std::string m_savedir;
 	bool m_map_saving_enabled;

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -111,7 +111,7 @@ void TestServerModManager::testGetMods()
 	auto sm = makeManager(m_worlddir);
 	const auto &mods = sm.getMods();
 	// `ls ./games/devtest/mods | wc -l` + 1 (test mod)
-	UASSERTEQ(std::size_t, mods.size(), 35 + 1);
+	UASSERTEQ(std::size_t, mods.size(), 36 + 1);
 
 	// Ensure we found basenodes mod (part of devtest)
 	// and test_mod (for testing MINETEST_MOD_PATH).


### PR DESCRIPTION
### Goal
The goal of this PR is to fix this issue https://github.com/luanti-org/luanti/issues/14723
The PR implements the block tracking API proposed in issue https://github.com/luanti-org/luanti/issues/14723#issuecomment-2726413946 to enable mods to react to block state changes and check block status.
TL;DR mapblock callbacks

### AI slop

I used Github Copilot to code the entire thing. I did read the code and tested it in game, but I'm not a C++ pro so there could be some problems hidden.

The AI model was fed with this PR: https://github.com/luanti-org/luanti/pull/15999
and was given the API proposal: https://github.com/luanti-org/luanti/issues/14723#issuecomment-2726413946

Prompt:

>Clone this branch https://github.com/luanti-org/luanti/pull/15999 rebase it with latest master and try implementing the API proposed here: https://github.com/luanti-org/luanti/issues/14723#issuecomment-2726413946

### API (short version, for details see the commits)

* `core.register_on_block_loaded(function(blockpos))`
    * Called immediately after a mapblock is loaded from disk or generated for the first time
* `core.register_on_block_activated(function(blockpos))`
    * Called immediately after a mapblock becomes active (within active_block_range of a player)
    * This is called after `on_block_loaded` if the block was just loaded
* `core.register_on_block_deactivated(function(blockpos_list))`
    * Called after mapblocks are deactivated (moved out of active_block_range)
    * Deactivated blocks remain loaded in memory but no longer run game logic
* `core.register_on_block_unloaded(function(blockpos_list))`
    * Called after mapblocks are completely unloaded from memory
    * This happens when the server needs to free memory or on shutdown

* `core.loaded_blocks`
    * Read-only table tracking currently loaded mapblocks
* `core.active_blocks`
    * Read-only table tracking currently active mapblocks


## To do

This PR is **Ready for review**

- [x] Compile
- [x] Start game
- [x] test everything
- [ ] retest everything after changes suggested by code review 

## How to test

Put the code attached below into a mod. Start the game and fly/walk around.
See messages appearing on your screen, use the commands provided by the mod.

<details>
  <summary>Test code</summary>
  
Also generated by Copilot
  
 ```lua
-- Test mod for block loading callbacks and tracking tables

local function print_to_everything(msg)
	core.log("action", "[testblocks] " .. msg)
	core.chat_send_all("[testblocks] " .. msg)
end

-- Register on_block_loaded callback
core.register_on_block_loaded(function(blockpos)
	print_to_everything("Block loaded at " .. core.pos_to_string(blockpos))
end)

-- Register on_block_activated callback
core.register_on_block_activated(function(blockpos)
	print_to_everything("Block activated at " .. core.pos_to_string(blockpos))
end)

-- Register on_block_unloaded callback
core.register_on_block_unloaded(function(blockpos_list)
	if #blockpos_list > 0 then
		print_to_everything("Blocks unloaded: " .. #blockpos_list)
		-- Print first few positions for debugging
		for i = 1, math.min(3, #blockpos_list) do
			print_to_everything("  - " .. core.pos_to_string(blockpos_list[i]))
		end
		if #blockpos_list > 3 then
			print_to_everything("  ... and " .. (#blockpos_list - 3) .. " more")
		end
	end
end)

-- Add chat commands to query loaded and active blocks
core.register_chatcommand("list_loaded_blocks", {
	description = "List all currently loaded blocks",
	func = function(name, param)
		local count = 0
		local examples = {}
		
		for hash, _ in pairs(core.loaded_blocks) do
			count = count + 1
			if count <= 5 then
				local pos = core.get_position_from_hash(hash)
				table.insert(examples, core.pos_to_string(pos))
			end
		end
		
		local msg = "Total loaded blocks: " .. count
		if #examples > 0 then
			msg = msg .. "\nFirst " .. #examples .. " examples:\n  " .. table.concat(examples, "\n  ")
		end
		
		return true, msg
	end,
})

core.register_chatcommand("list_active_blocks", {
	description = "List all currently active blocks",
	func = function(name, param)
		local count = 0
		local examples = {}
		
		for hash, _ in pairs(core.active_blocks) do
			count = count + 1
			if count <= 5 then
				local pos = core.get_position_from_hash(hash)
				table.insert(examples, core.pos_to_string(pos))
			end
		end
		
		local msg = "Total active blocks: " .. count
		if #examples > 0 then
			msg = msg .. "\nFirst " .. #examples .. " examples:\n  " .. table.concat(examples, "\n  ")
		end
		
		return true, msg
	end,
})

-- Add command to check if a specific block is loaded or active
core.register_chatcommand("check_block", {
	params = "<x> <y> <z>",
	description = "Check if a block at given position is loaded and/or active",
	func = function(name, param)
		local x, y, z = param:match("^([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+)$")
		if not x then
			return false, "Invalid coordinates. Usage: /check_block <x> <y> <z>"
		end
		
		local blockpos = {x = tonumber(x), y = tonumber(y), z = tonumber(z)}
		local hash = core.hash_node_position(blockpos)
		
		local is_loaded = core.loaded_blocks[hash] ~= nil
		local is_active = core.active_blocks[hash] ~= nil
		
		local msg = "Block at " .. core.pos_to_string(blockpos) .. ":\n"
		msg = msg .. "  Loaded: " .. tostring(is_loaded) .. "\n"
		msg = msg .. "  Active: " .. tostring(is_active)
		
		return true, msg
	end,
})

print_to_everything("Test mod loaded successfully!")

```
</details>

Also run the code provided with devtest.
