### PR TITLE
Add support for JPEG mod screenshots

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -85,15 +85,26 @@ local function get_formspec(tabview, name, tabdata)
 	end
 
 	if selected_pkg then
-		-- Check for screenshot being available
-		local screenshotfilename = selected_pkg.path .. DIR_DELIM .. "screenshot.png"
-		local screenshotfile, error = io.open(screenshotfilename, "r")
+		local valid_screenshots = {
+			-- See also contentdb/app/tasks/importtasks.py, def import_repo_screenshot
+			selected_pkg.path .. DIR_DELIM .. "screenshot.png",
+			selected_pkg.path .. DIR_DELIM .. "screenshot.jpg",
+			selected_pkg.path .. DIR_DELIM .. "screenshot.jpeg",
+		}
 
+		-- Check for screenshot being available
 		local modscreenshot
-		if not error then
-			screenshotfile:close()
-			modscreenshot = screenshotfilename
-		else
+		for _, screenshotfilename in ipairs(valid_screenshots) do
+			local screenshotfile, err = io.open(screenshotfilename, "r")
+			if not err then
+				screenshotfile:close()
+				modscreenshot = screenshotfilename
+				break
+			end
+		end
+
+		-- Fallback to no_screenshot if no screenshot is avaliable
+		if not modscreenshot then
 			modscreenshot = defaulttexturedir .. "no_screenshot.png"
 		end
 


### PR DESCRIPTION
We probably don't need high-quality lossless screenshots for our mods and games. Also, CDB supports screenshots in JPEG format. This PR adds JPG/JPEG support to mod screenshots for consistency and image size optimization.

This PR could be a fix to an oversight or a new feature. It does not align with any roadmaps, though.

## To do

This PR is Ready for Review.

## How to test

1. Create a mod using `screenshot.jpg` or `screenshot.jpeg` as its screenshot.
2. Verify that the JPEG-formatted screenshot shows up
3. Navigate to another mod that uses `screenshot.png`. Verify that it is still there.
