### PR TITLE
Fix readParam<float> not rejecting nan/inf

### DIFF
--- a/src/script/common/helper.cpp
+++ b/src/script/common/helper.cpp
@@ -39,7 +39,7 @@ template <>
 float LuaHelper::readParam(lua_State *L, int index)
 {
 	lua_Number v = luaL_checknumber(L, index);
-	if (std::isnan(v) && std::isinf(v))
+	if (std::isnan(v) || std::isinf(v))
 		throw LuaError("Invalid float value (NaN or infinity)");
 
 	return static_cast<float>(v);


### PR DESCRIPTION
see also https://github.com/luanti-org/luanti/pull/16870/changes#r2731482868

This was broken by 1d512ef7f4071fadf10078825ce83e77a3707f06 (5.6.0)
For me the big argument here is that when reading vectors, such floats will be correctly rejected¹ so we should fix standalone numbers to conform to this.

I used `rg 'readParam\s*<\s*(float|f32)'`, checked all occurrences and did not find any where there's a reasonable use for `Inf` or `NaN`².

¹:
https://github.com/luanti-org/luanti/blob/b1ed8f25cefbf96e29519fc516f2f92b64ed4d24/src/script/common/c_converter.cpp#L42-L47
²:
Someone could try to use Inf with `time_from_last_punch` (`core.get_hit_params()` and `ObjectRef:punch()`) or `core.get_objects_inside_radius(): radius`, but I don't think that's reasonable or likely.

## To do

This PR is Ready for Review.

## How to test

1. run different games/mods
2. no unexpected errors should happen
