### PR TITLE
Add /clearitems command to builtin

### DIFF
--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -79,6 +79,41 @@ local function format_help_line(cmd, def)
 	return msg
 end
 
+core.register_chatcommand("clearitems", {
+	params = "[<radius>]",
+	description = S("Clear dropped items within the specified radius (default: infinite)"),
+	privs = {server=true},
+	func = function(name, param)
+		local player = core.get_player_by_name(name)
+		if not player then
+			return false, S("You need to be logged in to use this command.")
+		end
+
+		local radius = tonumber(param)
+		local pos = player:get_pos()
+		local count = 0
+		local objects = {}
+
+		if radius then
+			objects = core.get_objects_inside_radius(pos, radius)
+		else
+			return false, S("For scurity reasons, you must specify a radius.")
+		end
+
+		for _, obj in ipairs(objects) do
+			if not obj:is_player() then
+				local lua_entity = obj:get_luaentity()
+				if lua_entity and lua_entity.name == "__builtin:item" then
+					obj:remove()
+					count = count + 1
+				end
+			end
+		end
+
+		return true, S("Cleared @1 dropped item(s).", count)
+	end,
+})
+
 local function do_help_cmd(name, param)
 	local opts, args = getopts("help", param)
 	if not opts then


### PR DESCRIPTION
It implements a new command on te builtin code:

- Add a clearitems command in the builtin code
- it adds a command named clearitems in the base code of the game itself in the builtin folder
- I don't think so
- No, it doesn't
- Is needed to reduce in-game lag, by removing unnecessary entities in an especific radius.
- Used Google Gemini to help on code

## To do

This PR is a Ready for Review.

- [ ] Get feedback
- [ ] Apply feedback
- [ ] Document result

## How to test

Run /clearitems with the radius param in-game to clear entities in that radius.