### PR TITLE
Fix non debug build unused warning

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -100,7 +100,7 @@ void PacketCounter::print(std::ostream &o) const
 	}
 }
 
-#ifdef NDEBUG
+[[maybe_unused]]
 static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool include_pos)
 {
 	const u16 cmd = pkt.getCommand();
@@ -118,7 +118,6 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 
 	e.append(" @").append(oss.str());
 }
-#endif
 
 /*
 	Client


### PR DESCRIPTION
Alternatively, use `[[maybe_unused]]`, but it's only needed for debug purposes anyway.