### PR TITLE
Avoid a copy of block pointers in client timer update

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -347,16 +347,12 @@ void Map::timerUpdate(float dtime, float unload_timeout, s32 max_loaded_blocks,
 		}
 	} else {
 		std::priority_queue<TimeOrderedMapBlock> mapblock_queue;
-		MapBlockVect blocks;
 		for (auto &sector_it : m_sectors) {
-			MapSector *sector = sector_it.second;
-
-			blocks.clear();
-			sector->getBlocks(blocks);
-
-			for (MapBlock *block : blocks) {
+			const MapSector *sector = sector_it.second;
+			for (const auto &entry : sector->getBlocks()) {
+				MapBlock *block = entry.second.get();
 				block->incrementUsageTimer(dtime);
-				mapblock_queue.push(TimeOrderedMapBlock(sector, block));
+				mapblock_queue.push(TimeOrderedMapBlock(const_cast<MapSector*>(sector), block));
 			}
 		}
 		block_count_all = mapblock_queue.size();


### PR DESCRIPTION
In `Map::timerUpdate` we can use the no-copy version of `MapSector::getBlocks()`

This won't visibly affect performance, but it saves some allocations, and shaves about about 25% (1ms) off the timer update (on my machine with about 30k blocks loaded)

## To do

This PR is Ready for Review.

## How to test

Load any world. Make sure timer updates are still happening on the client (blocks get expired/saved, etc)