### PR TITLE
CPCSM: Fix off-by-one error in value return by localplayer get_wield_index 

### DIFF
--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -66,7 +66,7 @@ int LuaLocalPlayer::l_get_wield_index(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 
-	lua_pushinteger(L, player->getWieldIndex());
+	lua_pushinteger(L, player->getWieldIndex() + 1);
 	return 1;
 }
 


### PR DESCRIPTION
When writing clientmods I noticed that `get_wield_index` returned the incorrect wield index. For slot 1, it would return 0, slot 2 it returns 1 and so on.

The regular Luanti clientmod API does not have a way to interact with inventories, but I was doing stuff like that in my own client. Then it became clear that `player_main_inventory[core.localplayer:get_wield_index()]` consistently returned a different value from `core.localplayer:get_wielded_item()`.


It also becomes obvious this is a bug when comparing the `get_wield_index` implementations in `l_object.cpp` and `l_localplayer.cpp`. The localplayer one returns `getWieldIndex()` while the other returns `getWieldIndex() + 1`

https://github.com/luanti-org/luanti/blob/06e4852fd214a6985eb4665142e7893e4167d8ca/src/script/lua_api/l_localplayer.cpp#L65-L71

https://github.com/luanti-org/luanti/blob/06e4852fd214a6985eb4665142e7893e4167d8ca/src/script/lua_api/l_object.cpp#L318-L328

I know the clientmodding API is in maintenance mode (or whatever it is called), and will not get new features. This is however such an obvious error that I think it makes sense to fix.

## How to test

Apply this diff which logs the wield index while in game. Notice that the index is consistently off by one.

```diff
diff --git a/builtin/client/init.lua b/builtin/client/init.lua
index 769fbe56c..3dbc9c160 100644
--- a/builtin/client/init.lua
+++ b/builtin/client/init.lua
@@ -16,3 +16,12 @@ assert(loadfile(commonpath .. "item_s.lua"))({}) -- Just for push/read node func
 
 -- unset, as promised in initializeSecurityClient()
 debug.getinfo = nil
+
+core.register_globalstep(function()
+       if not core.localplayer then
+               return
+       end
+
+       local wield_index = core.localplayer:get_wield_index()
+       core.log(string.format("get_wield_index()=%d", core.localplayer:get_wield_index()))
+end)
```
