### PR TITLE
Remove redundant and broken SDL_opengl.h includes

### DIFF
--- a/irr/src/OpenGL/BufferObject.h
+++ b/irr/src/OpenGL/BufferObject.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "Common.h"
-#include "SDL_opengl.h"
 #include <cstddef>
 
 namespace video

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -14,8 +14,7 @@
 #include "COpenGLCoreCacheHandler.h"
 
 #include "HWBuffer.h"
-#include "OpenGL/Common.h"
-#include "SDL_opengl.h"
+#include "Common.h"
 #include "WeightBuffer.h"
 #include "MaterialRenderer.h"
 #include "FixedPipelineRenderer.h"


### PR DESCRIPTION
Just introduced by #16721.

These break when compiling with SDL3. The transitive include from `Common.h` should just be used.

Will merge once CI passes.