### PR TITLE
Refine/fix block jump physics

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -721,6 +721,8 @@ Methods:
             liquid_sink = float,
             sneak = boolean,
             sneak_glitch = boolean,
+            upward_rejump = boolean,
+            loose_lips = boolean,
             new_move = boolean,
         }
         ```

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -722,7 +722,7 @@ Methods:
             sneak = boolean,
             sneak_glitch = boolean,
             upward_rejump = boolean,
-            loose_lips = boolean,
+            upward_step = boolean,
             new_move = boolean,
         }
         ```

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8827,7 +8827,7 @@ child will follow movement and rotation of that bone.
           (default: `false`)
         * `upward_rejump`: legacy ability to jump again while contacting a jumpable surface mid-jump
           (default: `false`)
-        * `loose_lips`: legacy step-up while jumping into the corner of a node (default: `false`)
+        * `upward_step`: legacy step-up while jumping into the corner of a node (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8825,6 +8825,9 @@ child will follow movement and rotation of that bone.
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
           (default: `false`)
+        * `upward_rejump`: legacy ability to jump again while contacting a jumpable surface mid-jump
+          (default: `false`)
+        * `loose_lips`: legacy step-up while jumping into the corner of a node (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8826,9 +8826,9 @@ child will follow movement and rotation of that bone.
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
           (default: `false`)
-        * `upward_rejump`: legacy ability to jump again while contacting a jumpable surface mid-jump
-          (default: `false`)
-        * `upward_step`: legacy step-up while jumping into the corner of a node (default: `false`)
+        * `upward_rejump`: ability to jump again while contacting a jumpable surface mid-jump
+          (default: `true`)
+        * `upward_step`: step-up while jumping into the corner of a node (default: `true`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behavior (default: `true`)
     * Note: All numeric fields above modify a corresponding `movement_*` setting.

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1581,9 +1581,11 @@ void GenericCAO::processMessage(const std::string &data)
 		phys.gravity = readF32(is);
 
 		// MT 0.4.10 legacy: send inverted for detault `true` if the server sends nothing
-		phys.sneak        = !readU8(is);
-		phys.sneak_glitch = !readU8(is);
-		phys.new_move     = !readU8(is);
+		phys.sneak         = !readU8(is);
+		phys.sneak_glitch  = !readU8(is);
+		phys.upward_rejump = !readU8(is);
+		phys.loose_lips    = !readU8(is);
+		phys.new_move      = !readU8(is);
 
 		// new overrides since 5.8.0
 		if (canRead(is)) {

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1584,7 +1584,7 @@ void GenericCAO::processMessage(const std::string &data)
 		phys.sneak         = !readU8(is);
 		phys.sneak_glitch  = !readU8(is);
 		phys.upward_rejump = !readU8(is);
-		phys.loose_lips    = !readU8(is);
+		phys.upward_step    = !readU8(is);
 		phys.new_move      = !readU8(is);
 
 		// new overrides since 5.8.0

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -322,12 +322,12 @@ void LocalPlayer::move(f32 dtime, Environment *env,
 	// /src/script/common/c_content.cpp and /src/content_sao.cpp
 	float player_stepheight = 0.0f;
 	if (m_cao) {
-		// Only allow stepping if we are on the ground and NOT moving upward (jumping)
-		if (touching_ground && m_speed.Y <= 0.01f * BS) {
-			player_stepheight = m_cao->getStepHeight();
-		} else {
-			// Disable stepping in mid-air or while ascending to prevent the "snap" to block tops
+		if (m_speed.Y > 0.01f * BS) {
+			// Disable stepheight while moving upward to prevent snapping to block tops
 			player_stepheight = 0.0f;
+		} else {
+			// Use standard stepheights while on ground OR while falling/crossing gaps
+			player_stepheight = touching_ground ? m_cao->getStepHeight() : (0.2f * BS);
 		}
 	}
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -322,13 +322,16 @@ void LocalPlayer::move(f32 dtime, Environment *env,
 	// /src/script/common/c_content.cpp and /src/content_sao.cpp
 	float player_stepheight = 0.0f;
 	if (m_cao != nullptr) {
-		if (touching_ground &&
-			(physics_override.loose_lips || m_speed.Y <= 0.01f * BS)) {
-			player_stepheight = m_cao->getStepHeight();
-		} else {
-			// Still allow slight snap-up when clearing a lip mid-jump
-			player_stepheight = physics_override.loose_lips ? 0.2f * BS : 0.05f * BS;
-		}
+
+		const bool rising = m_speed.Y > 0.01f * BS;
+		const bool loose = physics_override.loose_lips;
+
+		const float snap_height =
+			(rising && !loose ? 0.05f : 0.2f) * BS;
+
+		player_stepheight = touching_ground
+			? m_cao->getStepHeight()
+			: snap_height;
 	}
 
 	v3f accel_f(0, -gravity, 0);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -324,7 +324,7 @@ void LocalPlayer::move(f32 dtime, Environment *env,
 	if (m_cao != nullptr) {
 
 		const bool rising = m_speed.Y > 0.01f * BS;
-		const bool loose = physics_override.loose_lips;
+		const bool loose = physics_override.upward_step;
 
 		const float snap_height =
 			(rising && !loose ? 0.05f : 0.2f) * BS;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -320,11 +320,6 @@ void LocalPlayer::move(f32 dtime, Environment *env,
 
 	// Player object property step height is multiplied by BS in
 	// /src/script/common/c_content.cpp and /src/content_sao.cpp
-
-	/* Previously:
-	float player_stepheight = (m_cao == nullptr) ? 0.0f : 
-			(touching_ground ? m_cao->getStepHeight() : (0.2f * BS));
-	*/
 	float player_stepheight = 0.0f;
 	if (m_cao != nullptr) {
 		if (touching_ground &&

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -658,7 +658,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				at its starting value
 			*/
 			v3f speedJ = getSpeed();
-			if (speedJ.Y >= -0.5f * BS) {
+			if (speedJ.Y >= -0.5f * BS && speedJ.Y <= 0.1f * BS) {
 				speedJ.Y = movement_speed_jump * physics_override.jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -320,8 +320,16 @@ void LocalPlayer::move(f32 dtime, Environment *env,
 
 	// Player object property step height is multiplied by BS in
 	// /src/script/common/c_content.cpp and /src/content_sao.cpp
-	float player_stepheight = (m_cao == nullptr) ? 0.0f :
-		(touching_ground ? m_cao->getStepHeight() : (0.2f * BS));
+	float player_stepheight = 0.0f;
+	if (m_cao) {
+		// Only allow stepping if we are on the ground and NOT moving upward (jumping)
+		if (touching_ground && m_speed.Y <= 0.01f * BS) {
+			player_stepheight = m_cao->getStepHeight();
+		} else {
+			// Disable stepping in mid-air or while ascending to prevent the "snap" to block tops
+			player_stepheight = 0.0f;
+		}
+	}
 
 	v3f accel_f(0, -gravity, 0);
 	const v3f initial_position = position;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -249,7 +249,7 @@ static auto tie(const PlayerPhysicsOverride &o)
 {
 	// Make sure to add new members to this list!
 	return std::tie(
-	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.upward_rejump, o.loose_lips, o.new_move, o.speed_climb,
+	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.upward_rejump, o.upward_step, o.new_move, o.speed_climb,
 	o.speed_crouch, o.liquid_fluidity, o.liquid_fluidity_smooth, o.liquid_sink,
 	o.acceleration_default, o.acceleration_air, o.speed_fast, o.acceleration_fast,
 	o.speed_walk

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -249,7 +249,7 @@ static auto tie(const PlayerPhysicsOverride &o)
 {
 	// Make sure to add new members to this list!
 	return std::tie(
-	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.new_move, o.speed_climb,
+	o.speed, o.jump, o.gravity, o.sneak, o.sneak_glitch, o.upward_rejump, o.loose_lips, o.new_move, o.speed_climb,
 	o.speed_crouch, o.liquid_fluidity, o.liquid_fluidity_smooth, o.liquid_sink,
 	o.acceleration_default, o.acceleration_air, o.speed_fast, o.acceleration_fast,
 	o.speed_walk

--- a/src/player.h
+++ b/src/player.h
@@ -101,10 +101,11 @@ struct PlayerPhysicsOverride
 	float jump = 1.f;
 	float gravity = 1.f;
 
-	bool sneak = true;
-	bool sneak_glitch = false;
 	bool upward_rejump = true;
 	bool upward_step = true;
+	
+	bool sneak = true;
+	bool sneak_glitch = false;
 	// "Temporary" option for old move code
 	bool new_move = true;
 

--- a/src/player.h
+++ b/src/player.h
@@ -104,7 +104,7 @@ struct PlayerPhysicsOverride
 	bool sneak = true;
 	bool sneak_glitch = false;
 	bool upward_rejump = false;
-	bool loose_lips = false;
+	bool upward_step = false;
 	// "Temporary" option for old move code
 	bool new_move = true;
 

--- a/src/player.h
+++ b/src/player.h
@@ -103,7 +103,7 @@ struct PlayerPhysicsOverride
 
 	bool upward_rejump = true;
 	bool upward_step = true;
-	
+
 	bool sneak = true;
 	bool sneak_glitch = false;
 	// "Temporary" option for old move code

--- a/src/player.h
+++ b/src/player.h
@@ -103,8 +103,8 @@ struct PlayerPhysicsOverride
 
 	bool sneak = true;
 	bool sneak_glitch = false;
-	bool upward_rejump = false;
-	bool upward_step = false;
+	bool upward_rejump = true;
+	bool upward_step = true;
 	// "Temporary" option for old move code
 	bool new_move = true;
 

--- a/src/player.h
+++ b/src/player.h
@@ -103,6 +103,8 @@ struct PlayerPhysicsOverride
 
 	bool sneak = true;
 	bool sneak_glitch = false;
+	bool upward_rejump = false;
+	bool loose_lips = false;
 	// "Temporary" option for old move code
 	bool new_move = true;
 

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -162,8 +162,8 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, phys.upward_rejump);
 	lua_setfield(L, -2, "upward_rejump");
 
-	lua_pushboolean(L, phys.loose_lips);
-	lua_setfield(L, -2, "loose_lips");
+	lua_pushboolean(L, phys.upward_step);
+	lua_setfield(L, -2, "upward_step");
 
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -159,6 +159,12 @@ int LuaLocalPlayer::l_get_physics_override(lua_State *L)
 	lua_pushboolean(L, phys.sneak_glitch);
 	lua_setfield(L, -2, "sneak_glitch");
 
+	lua_pushboolean(L, phys.upward_rejump);
+	lua_setfield(L, -2, "upward_rejump");
+
+	lua_pushboolean(L, phys.loose_lips);
+	lua_setfield(L, -2, "loose_lips");
+
 	lua_pushboolean(L, phys.new_move);
 	lua_setfield(L, -2, "new_move");
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1744,6 +1744,8 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	getfloatfield(L, 2, "gravity", phys.gravity);
 	getboolfield(L, 2, "sneak", phys.sneak);
 	getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
+	getboolfield(L, 2, "upward_rejump", phys.upward_rejump);
+	getboolfield(L, 2, "loose_lips", phys.loose_lips);
 	getboolfield(L, 2, "new_move", phys.new_move);
 	getfloatfield(L, 2, "speed_climb", phys.speed_climb);
 	getfloatfield(L, 2, "speed_crouch", phys.speed_crouch);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1745,7 +1745,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	getboolfield(L, 2, "sneak", phys.sneak);
 	getboolfield(L, 2, "sneak_glitch", phys.sneak_glitch);
 	getboolfield(L, 2, "upward_rejump", phys.upward_rejump);
-	getboolfield(L, 2, "loose_lips", phys.loose_lips);
+	getboolfield(L, 2, "upward_step", phys.upward_step);
 	getboolfield(L, 2, "new_move", phys.new_move);
 	getfloatfield(L, 2, "speed_climb", phys.speed_climb);
 	getfloatfield(L, 2, "speed_crouch", phys.speed_crouch);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -320,6 +320,8 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	// MT 0.4.10 legacy: send inverted for detault `true` if the server sends nothing
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
+	writeU8(os, !phys.upward_rejump);
+	writeU8(os, !phys.loose_lips);
 	writeU8(os, !phys.new_move);
 	// new physics overrides since 5.8.0
 	writeF32(os, phys.speed_climb);

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -321,7 +321,7 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	writeU8(os, !phys.sneak);
 	writeU8(os, !phys.sneak_glitch);
 	writeU8(os, !phys.upward_rejump);
-	writeU8(os, !phys.loose_lips);
+	writeU8(os, !phys.upward_step);
 	writeU8(os, !phys.new_move);
 	// new physics overrides since 5.8.0
 	writeF32(os, phys.speed_climb);


### PR DESCRIPTION
## Goal of the PR
- Remove the gliding-up-hills effect caused by jumps being immediately allowed when near the top of a block, regardless of what's going on.  It makes more sense to wait for the jump to be over before allowing another jump to happen.
- Prevent the premature snap-up when jumping up and over a node.  This appears to have been caused by logic that treated all 0.2 height discrepancies as close enough to act like stairs, but it feels really bad when you don't need that to happen.

## How does the PR work?
- The only changes needed are client-side player movement behavior, as this still seems to fit within the expected means of world traversal that the server would validate.

## Does it resolve any reported issue?
- This appears to be a resolution to #16006 and somewhat of a solution to #13856.

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- This to my mind fits Goal 2 from Celeron55's roadmap: "Overally fix non-blocking technical issues" (Things that don't prevent playing the game, but make it a lesser experience)

## If not a bug fix, why is this PR needed? What usecases does it solve?
- Some may disagree, but I _do_ call this a bug fix.  The existing physics of jumping over blocks seems soft, insubstantial, and glitchy.  I can only speak for myself, but it doesn't feel intuitive, expected, or polished.  And it takes me out of the game every time it happens, which is a lot of the time considering gameplay hinges on node traversal.

## If you have used an LLM/AI to help with code or assets, you must disclose this.
- I did use an LLM to help me make sense of the code and draft some minimal modifications.  I tested it in Windows after compiling it with MSYS2 CLANG64.  Hopefully that's not a problem, but if it is, I'm sure we can rearrange or rewrite things as needed.  I'm just not all that familiar with the codebase or C++ programming, but I am in the process of learning it in earnest.

---

# Pending Review

## Features
- Snap-up disabled when y movement is positive.
- Jump disabled when y movement is already positive.
- Stairs and slabs still work.
- Auto-jump still works.
- Walking over small gaps still works.

## How to test

1. Compile the game with these changes.
2. Attempt to jump up one full block, and compare that to doing so without these changes.
3. Attempt to walk over a one-block gap
4. Use the [backwards compatibility mod](https://github.com/AbbyRead/luanti_legacy_block_jump_physics) to change things back.

## Checks

To avoid breaking any games or maps that rely on legacy physics:
 - [x] Keep the ability to cross small gaps when walking or running.
 - [x] Add backwards compatibility to revert the changes if needed.
 - [x] Test new block jump physics in various games.
 - [x] Make and test a mod that reverts the changes.
 - [x] Sneak-glitch still works if enabled by a mod.

## Things Considered When Making This PR 
**Luanti isn't Minecraft**.  It doesn't need to have a full set of identical features.
  - Some things it does better (besides being free and open source).  Items go straight into the player's inventory by default, for instance, which is a lot less fuss and processing overhead.  Picking up scattered items in your inventory by hold-clicking is very convenient.  I could go on.
  - Luanti can have its own personality, but I don't think that personality should be of permanent jank that you just get used to.  Luanti deserves better than that.  Luanti has the potential to become much better than Minecraft.