### PR TITLE
Bump Alpine from `3.19` to `3.23` in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-ARG DOCKER_IMAGE=alpine:3.19
+ARG DOCKER_IMAGE=alpine:3.23
 FROM $DOCKER_IMAGE AS dev
 
 ENV LUAJIT_VERSION=v2.1


### PR DESCRIPTION
Alpine `3.19` is currently [EOL](https://endoflife.date/alpine-linux), so this PR updates the Docker image to `3.23`.

## To do

This PR is a Ready for Review.

## How to test

- Build and tag locally: `docker build . --tag luanti-alpine3.23`
- See `--version` works: `docker run --rm -it luanti-alpine3.23:latest /usr/local/bin/luantiserver --version`
- Try running a game server 
