### PR TITLE
Edited Lua Src Cmake to compile to C and not C++

### DIFF
--- a/lib/lua/src/CMakeLists.txt
+++ b/lib/lua/src/CMakeLists.txt
@@ -2,7 +2,6 @@
 file(GLOB LUA_CORE_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
 set(LUA_CORE_SRC
-	${LUA_CORE_HDRS}
 	lapi.c
 	lauxlib.c
 	lbaselib.c
@@ -36,11 +35,17 @@ set(LUA_CORE_SRC
 
 # Lua library
 add_library(lua STATIC ${LUA_CORE_SRC})
+target_sources(lua PRIVATE ${LUA_CORE_HDRS})
+set_source_files_properties(
+    ${LUA_CORE_HDRS}
+    PROPERTIES HEADER_FILE_ONLY TRUE
+)
 target_link_libraries(lua ${LIBS})
 set_target_properties(lua PROPERTIES
 	VERSION ${LUA_VERSION}
 	CLEAN_DIRECT_OUTPUT 1
 )
 
-# Compile code as C++
-set_source_files_properties(${LUA_CORE_SRC} PROPERTIES LANGUAGE CXX)
+# Compile code as C
+set_source_files_properties(${LUA_CORE_SRC} PROPERTIES LANGUAGE C)
+set_target_properties(lua PROPERTIES LINKER_LANGUAGE C)


### PR DESCRIPTION
The goal of this pull request is to fix the unecessary C++ compilation into object files of header files within lib/lua caused by the CMakeLists.txt file within lib/lua/src. The changes should make the build and make process of that lib significantly shorter. This could have became a bug later on as more recent compilers of C++ such as GCC 15.2.1 which many people ar using to compile Lua is much stricter on a C file being compiled that way or not. I did use ChatGPT and Code pilot but not for coding or identifying changes to be made and instead just exploring the topics of Luanti and building a context for it as a project including the way the file tree worked as an overall structure. 

This PR is Ready for Review.

## How to test
- Test the change by creating a Docker environment to build and run Luanti
- Notice that when building with the cmake command it no longer creates those unnecessary object files made from header files 
- You may also test by running ```cmake . -DENABLE_LUAJIT=0``` from inside the build directory to test it, which was the command used in the issue this addresses.