### PR TITLE
Fix documentation: vertlabels can now be colorized

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3908,7 +3908,8 @@ Escape sequences
 ================
 
 Most text can contain escape sequences, that can for example color the text.
-There are a few exceptions: tab headers, dropdowns and vertical labels can't.
+There are a few exceptions: tab headers and dropdowns can't be colorized
+(but they *can* be translated).
 The following functions provide escape sequences:
 
 * `core.get_color_escape_sequence(color)`:


### PR DESCRIPTION
This tiny PR fixes a mistake in the documentation that claims that vertlabels can't be colorized. This is false because since e3f0c5bdc03532f963981b123d5c8eaead379b80 (pre-5.15.0 commit), they can be.

@CrazyladMT 

## How to test

See "How to test" section in #16802.