### PR TITLE
Use native Dockerfile ADD for Git dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
 
 WORKDIR /usr/src/
 
-ADD --keep-git-dir https://github.com/jupp0r/prometheus-cpp.git?branch=master /usr/src/prometheus-cpp
-ADD --keep-git-dir https://github.com/libspatialindex/libspatialindex.git?branch=main /usr/src/libspatialindex
+ADD https://github.com/jupp0r/prometheus-cpp.git?branch=master /usr/src/prometheus-cpp
+ADD https://github.com/libspatialindex/libspatialindex.git?branch=main /usr/src/libspatialindex
 ADD --keep-git-dir https://luajit.org/git/luajit.git?branch=${LUAJIT_VERSION} /usr/src/luajit
 
 RUN cd prometheus-cpp && \


### PR DESCRIPTION
Leverage Dockerfile's native [`ADD`](https://docs.docker.com/reference/dockerfile/#add) instruction to fetch remote repositories. 

That way, they can benefit from Buildkit caching, and letting the build host handle the download allows us to remove the `ca-certificates` dependency from the build process.

Git dependency is still required by the build process to generate version strings for Luanti and LuaJIT.

`prometheus-cpp` and `libspatialindex` build processes don't use it (and consequently don't require the `--keep-git-dir` flag).

## To do

This PR is Ready for Review.

## How to test

- Build and tag locally: `docker build . --tag luanti-add`
- See `--version` works: `docker run --rm -it luanti-add:latest /usr/local/bin/luantiserver --version`
- Try running a game server 
