### PR TITLE
Fix vendored Lua build trying to compile .h files

### DIFF
--- a/lib/lua/src/CMakeLists.txt
+++ b/lib/lua/src/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Lua core source files.
 file(GLOB LUA_CORE_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
-set(LUA_CORE_SRC
-	${LUA_CORE_HDRS}
+set(LUA_CORE_SRCS
 	lapi.c
 	lauxlib.c
 	lbaselib.c
@@ -35,12 +34,13 @@ set(LUA_CORE_SRC
 )
 
 # Lua library
-add_library(lua STATIC ${LUA_CORE_SRC})
+# Headers are included for IDE visibility but not compiled
+add_library(lua STATIC ${LUA_CORE_SRCS} ${LUA_CORE_HDRS})
 target_link_libraries(lua ${LIBS})
 set_target_properties(lua PROPERTIES
 	VERSION ${LUA_VERSION}
 	CLEAN_DIRECT_OUTPUT 1
 )
 
-# Compile code as C++
-set_source_files_properties(${LUA_CORE_SRC} PROPERTIES LANGUAGE CXX)
+# Compile C source files as C++
+set_source_files_properties(${LUA_CORE_SRCS} PROPERTIES LANGUAGE CXX)


### PR DESCRIPTION
- **Goal:** Fix CMake trying to compile `.h` header files as C++ source when building with vendored Lua
- **How:** Separate `.c` source files from `.h` headers in the CMakeLists.txt, so `set_source_files_properties(... LANGUAGE CXX)` only applies to `.c` files
- **Resolves:** #16890
- **AI disclosure:** This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.

## Background

Commit `ce2380b` added `file(GLOB LUA_CORE_HDRS ...)` to make headers visible in IDEs, then included them in `LUA_CORE_SRC`. Since `set_source_files_properties(${LUA_CORE_SRC} PROPERTIES LANGUAGE CXX)` operates on the entire list, it marks `.h` files for compilation too, producing spurious build artifacts like `lapi.h.o`.

## Changes

- Renamed `LUA_CORE_SRC` to `LUA_CORE_SRCS` (contains only `.c` files)
- Pass both `${LUA_CORE_SRCS}` and `${LUA_CORE_HDRS}` to `add_library()` (headers still visible in IDE)
- Apply `LANGUAGE CXX` only to `${LUA_CORE_SRCS}`

## To do

This PR is Ready for Review.

- [x] Separate header and source file lists in CMakeLists.txt
- [x] Only apply LANGUAGE CXX to source files

## How to test

1. Configure with vendored Lua: `cmake -B build -DENABLE_SYSTEM_LUA=OFF`
2. Build and check the output — `.h` files should no longer appear as compiled objects (no `Building CXX object lua.dir/lapi.h.o` lines)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>