### PR TITLE
Fix overflow in getMemorySizeMB on 32-bit arches

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -282,7 +282,7 @@ u32 getMemorySizeMB()
 	long pages = sysconf(_SC_PHYS_PAGES);
 	long page_size = sysconf(_SC_PAGE_SIZE);
 	if (pages != -1 && page_size != -1)
-		return (pages * page_size) >> 20;
+		return ((u64)pages * (u64)page_size) >> 20;
 #elif defined(__APPLE__)
 	int64_t memsize;
 	size_t len = sizeof(memsize);


### PR DESCRIPTION
Avoiding an overflow by using a larger and unsigned type.

## How to test

<!-- Example code or instructions -->

Running C code like this on a 32-bit system (arm or x86) with \~3 GiB of memory results in the following output
```c
long pages = sysconf(_SC_PHYS_PAGES);
printf("pages=%ld\n", pages);
long page_size = sysconf(_SC_PAGE_SIZE);
printf("page_size=%ld\n", page_size);
printf("%"PRIu32"\n", (uint32_t)((pages * page_size) >> 20));
printf("%"PRIu32"\n", (uint32_t)(((uint64_t)pages * (uint64_t)page_size) >> 20));
```

```
pages=772950
page_size=4096
4294966219
3019
```