### PR TITLE
Docs: Fix some formatting in utilities section (path_exists, protocol_version)

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5909,19 +5909,19 @@ Utilities
   ```
 
 * `core.protocol_versions`:
-  * Table mapping Luanti versions to corresponding protocol versions for modder convenience.
-  * For example, to check whether a client has at least the feature set
-    of Luanti 5.8.0 or newer, you could do:
-    `core.get_player_information(player_name).protocol_version >= core.protocol_versions["5.8.0"]`
-  * (available since 5.11)
+    * Table mapping Luanti versions to corresponding protocol versions for modder convenience.
+    * For example, to check whether a client has at least the feature set
+      of Luanti 5.8.0 or newer, you could do:
+      `core.get_player_information(player_name).protocol_version >= core.protocol_versions["5.8.0"]`
+    * (available since 5.11)
 
-  ```lua
-  {
-      [version string] = protocol version at time of release
-      -- every major and minor version has an entry
-      -- patch versions only for the first release whose protocol version is not already present in the table
-  }
-  ```
+    ```lua
+    {
+        [version string] = protocol version at time of release
+        -- every major and minor version has an entry
+        -- patch versions only for the first release whose protocol version is not already present in the table
+    }
+    ```
 
 * `core.get_player_window_information(player_name)`:
 


### PR DESCRIPTION
https://api.luanti.org/core-namespace-reference/#logging

| Before | After |
|--|--|
| <img width="1130" height="938" alt="unformatted end of utilities section" src="https://github.com/user-attachments/assets/084a6be3-d869-4f4f-8cc0-30860b62577f" /> | <img width="939" height="1073" alt="formatted end of utilities section" src="https://github.com/user-attachments/assets/ffa42a06-8bc1-4f7f-bbc7-c53da1897858" /> |
| <img width="720" height="339" alt="un-indented bullets after protocol_version" src="https://github.com/user-attachments/assets/c9505fed-da1d-4a5e-ae73-2143d15fedd2" /> | <img width="885" height="487" alt="indented bullets after protocol_version" src="https://github.com/user-attachments/assets/9daf8316-64c3-4213-9e49-1309525e3352" />
