### PR TITLE
Let modders disable skybox dimming in caves

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8962,6 +8962,8 @@ child will follow movement and rotation of that bone.
             * `fog_color`: ColorSpec, override the color of the fog.
                Unlike `base_color` above this will apply regardless of the skybox type.
                (default: `"#00000000"`, which means no override)
+        * `auto_cave_brightness`: boolean, whether to dim skybox brightness in caves. `true` by default.
+          Requires a Luanti 5.16.0+ client and server.
 * `set_sky(base_color, type, {texture names}, clouds)`
     * Deprecated. Use `set_sky(sky_parameters)`
     * `base_color`: ColorSpec, defaults to white

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8962,8 +8962,11 @@ child will follow movement and rotation of that bone.
             * `fog_color`: ColorSpec, override the color of the fog.
                Unlike `base_color` above this will apply regardless of the skybox type.
                (default: `"#00000000"`, which means no override)
-        * `auto_cave_brightness`: boolean, whether to dim skybox brightness in caves. `true` by default.
+        * `auto_dim_skybox`: boolean, whether to dim skybox brightness if
+          the sky is assumed not to be visible (e.g. in caves),
+          based on a hardcoded and sometimes buggy heuristic.
           Requires a Luanti 5.16.0+ client and server.
+          (default: `true`)
 * `set_sky(base_color, type, {texture names}, clouds)`
     * Deprecated. Use `set_sky(sky_parameters)`
     * `base_color`: ColorSpec, defaults to white

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2422,6 +2422,8 @@ void Game::handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam)
 
 	sky->setFogColor(event->set_sky->fog_color);
 
+	sky->setAutoCaveBrightness(event->set_sky->auto_cave_brightness);
+
 	delete event->set_sky;
 }
 
@@ -3399,8 +3401,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 
 	// When in noclip mode force same sky brightness as above ground so you
 	// can see properly
-	if (draw_control->allow_noclip && m_cache_enable_free_move &&
-		client->checkPrivilege("fly")) {
+	bool noclip_fly = draw_control->allow_noclip &&
+			m_cache_enable_free_move &&
+			client->checkPrivilege("fly");
+	if (!sky->getAutoCaveBrightness() || noclip_fly) {
 		direct_brightness = time_brightness;
 		sunlight_seen = true;
 	} else {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2422,7 +2422,7 @@ void Game::handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam)
 
 	sky->setFogColor(event->set_sky->fog_color);
 
-	sky->setAutoCaveBrightness(event->set_sky->auto_cave_brightness);
+	sky->setAutoCaveBrightness(event->set_sky->auto_dim_skybox);
 
 	delete event->set_sky;
 }

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -122,13 +122,13 @@ public:
 		return getBgColor();
 	}
 
-	void setAutoCaveBrightness(bool auto_cave_brightness)
+	void setAutoCaveBrightness(bool auto_dim_skybox)
 	{
-		m_sky_params.auto_cave_brightness = auto_cave_brightness;
+		m_sky_params.auto_dim_skybox = auto_dim_skybox;
 	}
 	bool getAutoCaveBrightness() const
 	{
-		return m_sky_params.auto_cave_brightness;
+		return m_sky_params.auto_dim_skybox;
 	}
 
 private:

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -122,6 +122,15 @@ public:
 		return getBgColor();
 	}
 
+	void setAutoCaveBrightness(bool auto_cave_brightness)
+	{
+		m_sky_params.auto_cave_brightness = auto_cave_brightness;
+	}
+	bool getAutoCaveBrightness() const
+	{
+		return m_sky_params.auto_cave_brightness;
+	}
+
 private:
 	aabb3f m_box{{0.0f, 0.0f, 0.0f}};
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1429,7 +1429,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 		if (!pkt->hasRemainingBytes())
 			break;
 		// >= 5.16.0-dev
-		*pkt >> skybox.auto_cave_brightness;
+		*pkt >> skybox.auto_dim_skybox;
 	} while (0);
 
 	ClientEvent *event = new ClientEvent();

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1425,6 +1425,11 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 			break;
 		// >= 5.9.0-dev
 		*pkt >> skybox.fog_color;
+
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.16.0-dev
+		*pkt >> skybox.auto_cave_brightness;
 	} while (0);
 
 	ClientEvent *event = new ClientEvent();

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2097,7 +2097,7 @@ int ObjectRef::l_set_sky(lua_State *L)
 		if (sky_params.textures.size() != 6 && !sky_params.textures.empty())
 			throw LuaError("Skybox expects 6 textures!");
 
-		sky_params.clouds = getboolfield_default(L, 2, "clouds", sky_params.clouds);
+		getboolfield(L, 2, "clouds", sky_params.clouds);
 
 		lua_getfield(L, 2, "sky_color");
 		if (lua_istable(L, -1)) {
@@ -2160,8 +2160,7 @@ int ObjectRef::l_set_sky(lua_State *L)
 		}
 		lua_pop(L, 1);
 
-		sky_params.auto_cave_brightness = getboolfield_default(L, 2,
-				"auto_cave_brightness", sky_params.auto_cave_brightness);
+		getboolfield(L, 2, "auto_dim_skybox", sky_params.auto_dim_skybox);
 	} else {
 		// Handle old set_sky calls, and log deprecated:
 		log_deprecated(L, "Deprecated call to set_sky, please check lua_api.md");
@@ -2292,8 +2291,8 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_pushboolean(L, skybox_params.clouds);
 	lua_setfield(L, -2, "clouds");
 
-	lua_pushboolean(L, skybox_params.auto_cave_brightness);
-	lua_setfield(L, -2, "auto_cave_brightness");
+	lua_pushboolean(L, skybox_params.auto_dim_skybox);
+	lua_setfield(L, -2, "auto_dim_skybox");
 
 	push_sky_color(L, skybox_params);
 	lua_setfield(L, -2, "sky_color");

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2159,6 +2159,9 @@ int ObjectRef::l_set_sky(lua_State *L)
 			lua_pop(L, 1);
 		}
 		lua_pop(L, 1);
+
+		sky_params.auto_cave_brightness = getboolfield_default(L, 2,
+				"auto_cave_brightness", sky_params.auto_cave_brightness);
 	} else {
 		// Handle old set_sky calls, and log deprecated:
 		log_deprecated(L, "Deprecated call to set_sky, please check lua_api.md");
@@ -2288,6 +2291,9 @@ int ObjectRef::l_get_sky(lua_State *L)
 	lua_setfield(L, -2, "textures");
 	lua_pushboolean(L, skybox_params.clouds);
 	lua_setfield(L, -2, "clouds");
+
+	lua_pushboolean(L, skybox_params.auto_cave_brightness);
+	lua_setfield(L, -2, "auto_cave_brightness");
 
 	push_sky_color(L, skybox_params);
 	lua_setfield(L, -2, "sky_color");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1950,7 +1950,7 @@ void Server::SendSetSky(session_t peer_id, const SkyboxParams &params)
 		pkt << params.body_orbit_tilt << params.fog_distance << params.fog_start
 			<< params.fog_color;
 
-		pkt << params.auto_cave_brightness;
+		pkt << params.auto_dim_skybox;
 	}
 
 	Send(&pkt);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1949,6 +1949,8 @@ void Server::SendSetSky(session_t peer_id, const SkyboxParams &params)
 
 		pkt << params.body_orbit_tilt << params.fog_distance << params.fog_start
 			<< params.fog_color;
+
+		pkt << params.auto_cave_brightness;
 	}
 
 	Send(&pkt);

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -37,6 +37,7 @@ struct SkyboxParams
 	s16 fog_distance { -1 };
 	float fog_start { -1.0f };
 	video::SColor fog_color { 0 }; // override, only used if alpha > 0
+	bool auto_cave_brightness { true };
 };
 
 struct SunParams

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -37,7 +37,7 @@ struct SkyboxParams
 	s16 fog_distance { -1 };
 	float fog_start { -1.0f };
 	video::SColor fog_color { 0 }; // override, only used if alpha > 0
-	bool auto_cave_brightness { true };
+	bool auto_dim_skybox { true };
 };
 
 struct SunParams


### PR DESCRIPTION
Does the obvious easy thing to alleviate #16958: Let modders disable what is a misfeature for some games (e.g. games set in space). Falls under dehardcoding.

## How to test

Enable fly and noclip, fly around. Skybox dimming will be off.
Find yourself a nice long cave such that there is a "hole" that will not be loaded that you can stare out of to see the skybox.
Disable fly in the cave and watch the hole fade to darkness.

Now run `/lua me:set_sky{auto_dim_skybox = false}` and watch the hole assume skybox color again.

Play around with it a bit if you like, maybe also run the getter.

`auto_dim_skybox = false`:

<img width="279" height="238" alt="Screenshot From 2026-02-24 15-49-22" src="https://github.com/user-attachments/assets/989b996b-c048-4d99-89e7-cf1003425d14" />

`auto_dim_skybox = true` (default):

<img width="279" height="238" alt="Screenshot From 2026-02-24 15-49-45" src="https://github.com/user-attachments/assets/9d3a1be3-790f-4ed3-9c35-3f02a8a54a0c" />
