### PR TITLE
Formspec: don't focus read-only textarea elements

### DIFF
--- a/irr/include/CGUIEditBox.h
+++ b/irr/include/CGUIEditBox.h
@@ -139,7 +139,7 @@ public:
 	bool acceptsIME() override { return isEnabled() && IsWritable; };
 
 	//! set true if this EditBox is writable
-	void setWritable(bool writable) { IsWritable = writable; }
+	void setWritable(bool writable) { IsWritable = writable; setTabStop(writable); }
 
 protected:
 	//! Breaks the single text line.


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Remove the ability to focus read-only textarea elements.
- How does the PR work?
It sets the `tabStop` based on whether the element is writable.
- Does it resolve any reported issue?
Nope.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
I don't think so.
- If not a bug fix, why is this PR needed? What usecases does it solve?
It can be seen as a bugfix.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope.

## To do

This PR is ready for review.

## How to test

open luanti → open a game → pause and tab through the pause menu → observe that textarea element isn't focusable
