### PR TITLE
Enhanced Camera Control

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -54,6 +54,7 @@ core.features = {
 	chunksize_vector = true,
 	item_inventory_image_animation = true,
 	get_modnames_load_order = true,
+	set_camera_resettable = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9239,7 +9239,25 @@ child will follow movement and rotation of that bone.
       - `first`: first-person camera
       - `third`: third-person camera
       - `third_front`: third-person camera, looking opposite of movement direction
-    * Supported by client since 5.12.0.
+      * (supported by clients since 5.12.0)
+    * `free_mouse`: If true, the mouse points freely to anything in view.
+      If false (default), the mouse is locked to the center and controls the
+      camera angle/direction.
+    * `yaw_limit`: Limits the possible camera yaw.
+      Either `{min=<number>, max=<number>}` to limit to a range
+      or `false` to leave the yaw unrestricted (default).
+      Thee usable range is [0, 720]. Usually you will only need [0, 360],
+      but to restrict the yaw to e.g. between -90° and 90° you need to specify
+      `{min=270, max=450}`.
+    * `pitch_limit`: Limits the possible camera pitch.
+      Either `{min=<number>, max=<number>}` to limit to a range
+      or `false` to leave the pitch unrestricted (default).
+      range: [-90, 90]
+    * Note that restricting yaw and pitch to a single value will not automatically
+      "unlock" the mouse cursor, modify `free_mouse` for that.
+      Conversely, unlocking the mouse does not automatically prevent the camera
+      from moving (e.g. due to joystick input).
+    * (`free_mouse`, `yaw_limit` and `pitch_limit` supported by clients since 5.16.0)
 * `get_camera()`: Returns the camera parameters as a table as above.
 * `send_mapblock(blockpos)`:
     * Sends an already loaded mapblock to the player.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5993,7 +5993,7 @@ Utilities
       remove_item_match_meta = true,
       -- The HTTP API supports the HEAD and PATCH methods (5.12.0)
       httpfetch_additional_methods = true,
-      -- objects have get_guid method (5.13.0)
+      -- `ObjectRef:get_guid()` method exists (5.13.0)
       object_guids = true,
       -- The NodeTimer `on_timer` callback is passed additional `node` and `timeout` args (5.14.0)
       on_timer_four_args = true,
@@ -6006,8 +6006,10 @@ Utilities
       -- Item definition fields `inventory_image`, `inventory_overlay`, `wield_image`
       -- and `wield_overlay` accept a table containing animation definitions. (5.15.0)
       item_image_animation = true,
-      -- `core.get_modnames`' parameter `load_order` (5.16.0)
+      -- `core.get_modnames` has parameter `load_order` (5.16.0)
       get_modnames_load_order = true,
+      -- `ObjectRef:set_camera()` accepts `nil` to indicate reset (5.16.0)
+      set_camera_resettable = true,
   }
   ```
 
@@ -9233,7 +9235,9 @@ child will follow movement and rotation of that bone.
       Same limits as for `thirdperson_back` apply.
       Defaults to `thirdperson_back` if unspecified.
 * `get_eye_offset()`: Returns camera offset vectors as set via `set_eye_offset`.
-* `set_camera(params)`: Sets camera parameters.
+* `set_camera(params)`: Sets camera parameters for the player
+  * `params` must be a table to update the parameters or `nil` to reset all
+    parameters to defaults.
     * `mode`: Defines the camera mode used
       - `any`: free choice between all modes (default)
       - `first`: first-person camera
@@ -9264,9 +9268,10 @@ child will follow movement and rotation of that bone.
     * Returns `false` if nothing was sent (note that this can also mean that
       the client already has the block)
     * Resource intensive - use sparsely
-* `set_lighting(light_definition)`: sets lighting for the player
-    * Passing no arguments resets lighting to its default values.
-    * `light_definition` is a table with the following optional fields:
+* `set_lighting(light_def)`: Sets lighting for the player
+  * `light_def` must be a table to update the parameters or `nil` to reset all
+    light parameters to defaults.
+  * table fields follow:
       * `saturation` sets the saturation (vividness; default: `1.0`).
         * It is applied according to the function `result = b*(1-s) + c*s`, where:
           * `c` is the original color

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1992,7 +1992,7 @@ bool Game::isMouseLocked() const
 bool Game::isMouseShootlineUsed() const
 {
 	// TODO: in this mode we should also allow clicking the hotbar
-	// see TouchControls::resetHotbarRects()
+	// see TouchControls::registerHotbarRect() etc
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 	return player && player->camera.free_mouse;
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1940,7 +1940,7 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 			&& !isMenuActive()) || input->isRandom()) {
 
 		if (cur_control && !input->isRandom()) {
-			// Mac OSX gets upset if this is set every frame
+			// macOS gets upset if this is set every frame
 			if (cur_control->isVisible())
 				cur_control->setVisible(false);
 		}
@@ -1955,7 +1955,7 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 		}
 
 	} else {
-		// Mac OSX gets upset if this is set every frame
+		// macOS gets upset if this is set every frame
 		if (cur_control && !cur_control->isVisible())
 			cur_control->setVisible(true);
 
@@ -1986,6 +1986,7 @@ bool Game::isTouchShootlineUsed() const
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 {
 	f32 sens_scale = getSensitivityScaleFactor();
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 	if (g_touchcontrols) {
 		// User setting is already applied by TouchControls.
@@ -2012,17 +2013,26 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 		cam->camera_pitch += input->joystick.getAxisWithoutDead(JA_FRUSTUM_VERTICAL) * c;
 	}
 
-	// Keyboard look
-	const f32 rate = m_cache_keyboard_camera_speed * dtime * sens_scale;
+	/* Keyboard look */
+	{
+		const f32 rate = m_cache_keyboard_camera_speed * dtime * sens_scale;
 
-	if (input->isKeyDown(KeyType::CAMERA_YAW_LEFT))
-		cam->camera_yaw += rate;
-	if (input->isKeyDown(KeyType::CAMERA_YAW_RIGHT))
-		cam->camera_yaw -= rate;
-	if (input->isKeyDown(KeyType::CAMERA_PITCH_UP))
-		cam->camera_pitch -= rate;
-	if (input->isKeyDown(KeyType::CAMERA_PITCH_DOWN))
-		cam->camera_pitch += rate;
+		if (input->isKeyDown(KeyType::CAMERA_YAW_LEFT))
+			cam->camera_yaw += rate;
+		if (input->isKeyDown(KeyType::CAMERA_YAW_RIGHT))
+			cam->camera_yaw -= rate;
+		if (input->isKeyDown(KeyType::CAMERA_PITCH_UP))
+			cam->camera_pitch -= rate;
+		if (input->isKeyDown(KeyType::CAMERA_PITCH_DOWN))
+			cam->camera_pitch += rate;
+	}
+
+	// Apply server restrictions
+	const auto &cam_spec = player->camera;
+	if (cam_spec.yawValid())
+		cam->camera_yaw = rangelim(cam->camera_yaw, cam_spec.min_yaw, cam_spec.max_yaw);
+	if (cam_spec.pitchValid())
+		cam->camera_pitch = rangelim(cam->camera_pitch, cam_spec.min_pitch, cam_spec.max_pitch);
 
 	cam->camera_pitch = rangelim(cam->camera_pitch, -90, 90);
 }
@@ -2588,8 +2598,9 @@ void Game::updateCameraMode()
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 	// Obey server choice
-	if (player->allowed_camera_mode != CAMERA_MODE_ANY)
-		camera->setCameraMode(player->allowed_camera_mode);
+	auto &cam = player->camera;
+	if (cam.allowed_mode != CAMERA_MODE_ANY)
+		camera->setCameraMode(cam.allowed_mode);
 
 	GenericCAO *playercao = player->getCAO();
 	if (playercao) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -50,6 +50,7 @@
 #include "hud.h"
 #include <AnimatedMeshSceneNode.h>
 #include <ICameraSceneNode.h>
+#include <ISceneCollisionManager.h>
 #include "util/tracy_wrapper.h"
 #include "item_visuals_manager.h"
 
@@ -1988,6 +1989,14 @@ bool Game::isMouseLocked() const
 	return !isMenuActive();
 }
 
+bool Game::isMouseShootlineUsed() const
+{
+	// TODO: in this mode we should also allow clicking the hotbar
+	// see TouchControls::resetHotbarRects()
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	return player && player->camera.free_mouse;
+}
+
 bool Game::isTouchShootlineUsed() const
 {
 	return g_touchcontrols && g_touchcontrols->isShootlineAvailable() &&
@@ -2007,9 +2016,10 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 		v2s32 center(driver->getScreenSize().Width / 2, driver->getScreenSize().Height / 2);
 		v2s32 dist = input->getMousePos() - center;
 
-		if (m_invert_mouse || camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT) {
+		if (m_invert_mouse)
 			dist.Y = -dist.Y;
-		}
+		if (camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT)
+			dist.Y = -dist.Y;
 
 		cam->camera_yaw   -= dist.X * m_cache_mouse_sensitivity * sens_scale;
 		cam->camera_pitch += dist.Y * m_cache_mouse_sensitivity * sens_scale;
@@ -2681,11 +2691,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-	const v3f camera_direction = camera->getDirection();
 	const v3s16 camera_offset  = camera->getOffset();
 
 	/*
-		Calculate what block is the crosshair pointing to
+		Find out what we are pointing at
 	*/
 
 	ItemStack selected_item, hand_item;
@@ -2696,33 +2705,41 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 
 	core::line3d<f32> shootline;
 
-	switch (camera->getCameraMode()) {
-	case CAMERA_MODE_ANY:
-		assert(false);
-		break;
-	case CAMERA_MODE_FIRST:
-		// Shoot from camera position, with bobbing
-		shootline.start = camera->getPosition();
-		break;
-	case CAMERA_MODE_THIRD:
-		// Shoot from player head, no bobbing
-		shootline.start = camera->getHeadPosition();
-		break;
-	case CAMERA_MODE_THIRD_FRONT:
-		shootline.start = camera->getHeadPosition();
-		// prevent player pointing anything in front-view
-		d = 0;
-		break;
-	}
-	shootline.end = shootline.start + camera_direction * BS * d;
-
 	if (isTouchShootlineUsed()) {
 		shootline = g_touchcontrols->getShootline();
-		// Scale shootline to the acual distance the player can reach
+		// Scale shootline to the actual distance the player can reach
 		shootline.end = shootline.start +
 				shootline.getVector().normalize() * BS * d;
-		shootline.start += intToFloat(camera_offset, BS);
-		shootline.end += intToFloat(camera_offset, BS);
+		shootline += intToFloat(camera_offset, BS);
+	} else if (isMouseShootlineUsed()) {
+		shootline = device
+				->getSceneManager()
+				->getSceneCollisionManager()
+				->getRayFromScreenCoordinates(input->getMousePos());
+		// Scale shootline to the actual distance the player can reach
+		shootline.end = shootline.start +
+				shootline.getVector().normalize() * BS * d;
+		shootline += intToFloat(camera_offset, BS);
+	} else {
+		const v3f camera_direction = camera->getDirection();
+		switch (camera->getCameraMode()) {
+		case CAMERA_MODE_ANY:
+			assert(false);
+		case CAMERA_MODE_FIRST:
+			// Shoot from camera position, with bobbing
+			shootline.start = camera->getPosition();
+			break;
+		case CAMERA_MODE_THIRD:
+			// Shoot from player head, no bobbing
+			shootline.start = camera->getHeadPosition();
+			break;
+		case CAMERA_MODE_THIRD_FRONT:
+			shootline.start = camera->getHeadPosition();
+			// prevent player pointing anything in front-view
+			d = 0;
+			break;
+		}
+		shootline.end = shootline.start + camera_direction * BS * d;
 	}
 
 	PointedThing pointed = updatePointedThing(shootline,
@@ -2733,6 +2750,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 
 	if (pointed != runData.pointed_old)
 		infostream << "Pointing at " << pointed.dump() << std::endl;
+
+	/*
+		Update everything accordingly
+	*/
 
 	if (g_touchcontrols) {
 		auto mode = selected_def.touch_interaction.getMode(selected_def, pointed.type);
@@ -3696,7 +3717,7 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(this->camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 
-	if (isTouchShootlineUsed())
+	if (isTouchShootlineUsed() || isMouseShootlineUsed())
 		draw_crosshair = false;
 
 	this->m_rendering_engine->draw_scene(sky_color, this->m_game_ui->m_flags.show_hud,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1927,19 +1927,16 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 {
 	auto *cur_control = device->getCursorControl();
 
-	/* On Linux and Windows, enabling relative mouse mode somehow results
-	in simulated mouse events being generated from touch events, even though
-	SDL_HINT_MOUSE_TOUCH_EVENTS and SDL_HINT_TOUCH_MOUSE_EVENTS are set to 0.
-	Since we have our own code to synthesize mouse events from touch events,
-	this results in duplicated input. To avoid that, we don't enable relative
-	mouse mode if we're in touchscreen mode. */
-	if (cur_control)
-		cur_control->setRelativeMode(!g_touchcontrols && !isMenuActive());
-
-	if ((device->isWindowActive() && device->isWindowFocused()
-			&& !isMenuActive()) || input->isRandom()) {
-
+	if (isMouseLocked()) {
 		if (cur_control && !input->isRandom()) {
+			/* On Linux and Windows, enabling relative mouse mode somehow results
+			in simulated mouse events being generated from touch events, even though
+			SDL_HINT_MOUSE_TOUCH_EVENTS and SDL_HINT_TOUCH_MOUSE_EVENTS are set to 0.
+			Since we have our own code to synthesize mouse events from touch events,
+			this results in duplicated input. To avoid that, we don't enable relative
+			mouse mode if we're in touchscreen mode. */
+			cur_control->setRelativeMode(!g_touchcontrols);
+
 			// macOS gets upset if this is set every frame
 			if (cur_control->isVisible())
 				cur_control->setVisible(false);
@@ -1955,6 +1952,8 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 		}
 
 	} else {
+		if (cur_control)
+			cur_control->setRelativeMode(false);
 		// macOS gets upset if this is set every frame
 		if (cur_control && !cur_control->isVisible())
 			cur_control->setVisible(true);
@@ -1975,6 +1974,18 @@ f32 Game::getSensitivityScaleFactor() const
 	// 16:9 aspect ratio to minimize disruption of existing sensitivity
 	// settings.
 	return std::tan(fov_y / 2.0f) * 1.3763819f;
+}
+
+bool Game::isMouseLocked() const
+{
+	if (input->isRandom())
+		return true;
+	if (!device->isWindowActive() || !device->isWindowFocused())
+		return false;
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (player && player->camera.free_mouse)
+		return false;
+	return !isMenuActive();
 }
 
 bool Game::isTouchShootlineUsed() const

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2030,9 +2030,9 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 	// Apply server restrictions
 	const auto &cam_spec = player->camera;
 	if (cam_spec.yawValid())
-		cam->camera_yaw = rangelim(cam->camera_yaw, cam_spec.min_yaw, cam_spec.max_yaw);
+		cam->camera_yaw = rangelim(cam->camera_yaw, cam_spec.yaw_limit.X, cam_spec.yaw_limit.Y);
 	if (cam_spec.pitchValid())
-		cam->camera_pitch = rangelim(cam->camera_pitch, cam_spec.min_pitch, cam_spec.max_pitch);
+		cam->camera_pitch = rangelim(cam->camera_pitch, cam_spec.pitch_limit.X, cam_spec.pitch_limit.Y);
 
 	cam->camera_pitch = rangelim(cam->camera_pitch, -90, 90);
 }

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -286,8 +286,11 @@ private:
 	static const ClientEventHandler clientEventHandler[CLIENTEVENT_MAX];
 
 	f32 getSensitivityScaleFactor() const;
-	/// @return true if mouse is locked the center (and moves the camera)
+	/// @return true if mouse is locked the center and moves the camera
 	bool isMouseLocked() const;
+	/// @return true if shootline is determined by the mouse position
+	/// (NOT the normal way using the crosshair)
+	bool isMouseShootlineUsed() const;
 	/// @return true if shootline is determined by touch controls
 	bool isTouchShootlineUsed() const;
 

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -286,6 +286,10 @@ private:
 	static const ClientEventHandler clientEventHandler[CLIENTEVENT_MAX];
 
 	f32 getSensitivityScaleFactor() const;
+	/// @return true if mouse is locked the center (and moves the camera)
+	bool isMouseLocked() const;
+	/// @return true if shootline is determined by touch controls
+	bool isTouchShootlineUsed() const;
 
 	InputHandler *input = nullptr;
 
@@ -381,7 +385,6 @@ private:
 	bool m_is_paused = false;
 
 	bool m_touch_simulate_aux1 = false;
-	bool isTouchShootlineUsed() const;
 #ifdef __ANDROID__
 	bool m_android_chat_open;
 #endif

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1594,9 +1594,15 @@ void Client::handleCommand_Camera(NetworkPacket* pkt)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player);
 
+	auto &cam = player->camera;
+
 	u8 tmp;
 	*pkt >> tmp;
-	player->allowed_camera_mode = static_cast<CameraMode>(tmp);
+	cam.allowed_mode = static_cast<CameraMode>(tmp);
+	if (pkt->hasRemainingBytes()) {
+		// >= 5.16.0-dev
+		*pkt >> cam.min_yaw >> cam.max_yaw >> cam.min_pitch >> cam.max_pitch;
+	}
 
 	m_client_event_queue.push(new ClientEvent(CE_UPDATE_CAMERA));
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1601,7 +1601,7 @@ void Client::handleCommand_Camera(NetworkPacket* pkt)
 	cam.allowed_mode = static_cast<CameraMode>(tmp);
 	if (pkt->hasRemainingBytes()) {
 		// >= 5.16.0-dev
-		*pkt >> cam.min_yaw >> cam.max_yaw >> cam.min_pitch >> cam.max_pitch;
+		*pkt >> cam.yaw_limit >> cam.pitch_limit;
 	}
 
 	m_client_event_queue.push(new ClientEvent(CE_UPDATE_CAMERA));

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1601,7 +1601,7 @@ void Client::handleCommand_Camera(NetworkPacket* pkt)
 	cam.allowed_mode = static_cast<CameraMode>(tmp);
 	if (pkt->hasRemainingBytes()) {
 		// >= 5.16.0-dev
-		*pkt >> cam.yaw_limit >> cam.pitch_limit;
+		*pkt >> cam.free_mouse >> cam.yaw_limit >> cam.pitch_limit;
 	}
 
 	m_client_event_queue.push(new ClientEvent(CE_UPDATE_CAMERA));

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -462,6 +462,7 @@ enum ToClientCommand : u16
 	TOCLIENT_CAMERA = 0x48,
 	/*
 		u8 allowed_camera_mode
+		f32 min_yaw, max_yaw, min_pitch, max_pitch
 	*/
 
 	TOCLIENT_HUDADD = 0x49,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -462,6 +462,7 @@ enum ToClientCommand : u16
 	TOCLIENT_CAMERA = 0x48,
 	/*
 		u8 allowed_camera_mode
+		bool free_mouse
 		f32 min_yaw, max_yaw, min_pitch, max_pitch
 	*/
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -501,6 +501,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 		playersao->setBasePosition(position);
 		player->setSpeed(speed);
 	}
+	// TODO: could clamp pitch and yaw according to `player->camera`
 	playersao->setLookPitch(pitch);
 	playersao->setPlayerYaw(yaw);
 	playersao->setFov(fov);

--- a/src/player.h
+++ b/src/player.h
@@ -132,6 +132,30 @@ enum CameraMode : int {
 	CAMERA_MODE_THIRD_FRONT
 };
 
+struct PlayerCameraSpec
+{
+	CameraMode allowed_mode = CAMERA_MODE_ANY;
+	f32 min_yaw = 0, max_yaw = -1;
+	f32 min_pitch = 0, max_pitch = -1;
+
+	inline bool yawValid() const {
+		return min_yaw <= max_yaw;
+	}
+	inline bool pitchValid() const {
+		return min_pitch <= max_pitch;
+	}
+
+#define EQ(prop) (prop == other.prop)
+	inline bool operator==(const PlayerCameraSpec &other) const {
+		return EQ(allowed_mode) && EQ(min_yaw) && EQ(max_yaw) &&
+			EQ(min_pitch) && EQ(max_pitch);
+	}
+	inline bool operator!=(const PlayerCameraSpec &other) const {
+		return !(*this == other);
+	}
+#undef EQ
+};
+
 extern const struct EnumString es_CameraMode[];
 
 struct HudElement;
@@ -166,7 +190,7 @@ public:
 		return size;
 	}
 
-	CameraMode allowed_camera_mode = CAMERA_MODE_ANY;
+	PlayerCameraSpec camera;
 
 	v3f eye_offset_first;
 	v3f eye_offset_third;

--- a/src/player.h
+++ b/src/player.h
@@ -135,6 +135,7 @@ enum CameraMode : int {
 struct PlayerCameraSpec
 {
 	CameraMode allowed_mode = CAMERA_MODE_ANY;
+	bool free_mouse = false;
 	v2f yaw_limit = INVALID_LIMIT; // (min, max)
 	v2f pitch_limit = INVALID_LIMIT; // (min, max)
 
@@ -146,7 +147,8 @@ struct PlayerCameraSpec
 	}
 
 	inline bool operator==(const PlayerCameraSpec &other) const {
-		return allowed_mode == other.allowed_mode && yaw_limit == other.yaw_limit &&
+		return allowed_mode == other.allowed_mode &&
+			free_mouse == other.free_mouse && yaw_limit == other.yaw_limit &&
 			pitch_limit == other.pitch_limit;
 	}
 	inline bool operator!=(const PlayerCameraSpec &other) const {

--- a/src/player.h
+++ b/src/player.h
@@ -135,25 +135,25 @@ enum CameraMode : int {
 struct PlayerCameraSpec
 {
 	CameraMode allowed_mode = CAMERA_MODE_ANY;
-	f32 min_yaw = 0, max_yaw = -1;
-	f32 min_pitch = 0, max_pitch = -1;
+	v2f yaw_limit = INVALID_LIMIT; // (min, max)
+	v2f pitch_limit = INVALID_LIMIT; // (min, max)
 
 	inline bool yawValid() const {
-		return min_yaw <= max_yaw;
+		return yaw_limit.X <= yaw_limit.Y;
 	}
 	inline bool pitchValid() const {
-		return min_pitch <= max_pitch;
+		return pitch_limit.X <= pitch_limit.Y;
 	}
 
-#define EQ(prop) (prop == other.prop)
 	inline bool operator==(const PlayerCameraSpec &other) const {
-		return EQ(allowed_mode) && EQ(min_yaw) && EQ(max_yaw) &&
-			EQ(min_pitch) && EQ(max_pitch);
+		return allowed_mode == other.allowed_mode && yaw_limit == other.yaw_limit &&
+			pitch_limit == other.pitch_limit;
 	}
 	inline bool operator!=(const PlayerCameraSpec &other) const {
 		return !(*this == other);
 	}
-#undef EQ
+
+	static constexpr v2f INVALID_LIMIT = v2f(0, -1);
 };
 
 extern const struct EnumString es_CameraMode[];

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -533,28 +533,30 @@ int ObjectRef::l_set_camera(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	luaL_checktype(L, 2, LUA_TTABLE);
+	const auto &read_v2f_limit = [L] (int idx, v2f &to) {
+		if (lua_isboolean(L, idx) && !lua_toboolean(L, idx)) {
+			to = PlayerCameraSpec::INVALID_LIMIT;
+		} else if (!lua_isnoneornil(L, idx)) {
+			luaL_checktype(L, idx, LUA_TTABLE);
+			to = PlayerCameraSpec::INVALID_LIMIT;
+			getfloatfield(L, idx, "min", to.X);
+			getfloatfield(L, idx, "max", to.Y);
+		}
+	};
 
 	PlayerCameraSpec cam = player->camera;
 
+	luaL_checktype(L, 2, LUA_TTABLE);
 	lua_getfield(L, -1, "mode");
 	if (lua_isstring(L, -1))
 		string_to_enum(es_CameraMode, cam.allowed_mode, lua_tostring(L, -1));
 	lua_pop(L, 1);
 	getboolfield(L, -1, "free_mouse", cam.free_mouse);
 	lua_getfield(L, -1, "yaw_limit");
-	if (lua_istable(L, -1)) {
-		cam.yaw_limit = PlayerCameraSpec::INVALID_LIMIT;
-		getfloatfield(L, -1, "min", cam.yaw_limit.X);
-		getfloatfield(L, -1, "max", cam.yaw_limit.Y);
-	}
+	read_v2f_limit(-1, cam.yaw_limit);
 	lua_pop(L, 1);
 	lua_getfield(L, -1, "pitch_limit");
-	if (lua_istable(L, -1)) {
-		cam.pitch_limit = PlayerCameraSpec::INVALID_LIMIT;
-		getfloatfield(L, -1, "min", cam.pitch_limit.X);
-		getfloatfield(L, -1, "max", cam.pitch_limit.Y);
-	}
+	read_v2f_limit(-1, cam.pitch_limit);
 	lua_pop(L, 1);
 
 	if (cam != player->camera) {
@@ -581,14 +583,18 @@ int ObjectRef::l_get_camera(lua_State *L)
 		lua_newtable(L);
 		setfloatfield(L, -1, "min", cam.yaw_limit.X);
 		setfloatfield(L, -1, "max", cam.yaw_limit.Y);
-		lua_setfield(L, -2, "yaw_limit");
+	} else {
+		lua_pushboolean(L, false);
 	}
+	lua_setfield(L, -2, "yaw_limit");
 	if (cam.pitchValid()) {
 		lua_newtable(L);
 		setfloatfield(L, -1, "min", cam.pitch_limit.X);
 		setfloatfield(L, -1, "max", cam.pitch_limit.Y);
-		lua_setfield(L, -2, "pitch_limit");
+	} else {
+		lua_pushboolean(L, false);
 	}
+	lua_setfield(L, -2, "pitch_limit");
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -535,7 +535,7 @@ int ObjectRef::l_set_camera(lua_State *L)
 
 	const auto &read_v2f_limit = [L] (int idx, v2f &to) {
 		if (lua_isboolean(L, idx) && !lua_toboolean(L, idx)) {
-			to = PlayerCameraSpec::INVALID_LIMIT;
+			to = PlayerCameraSpec::INVALID_LIMIT; // false resets
 		} else if (!lua_isnoneornil(L, idx)) {
 			luaL_checktype(L, idx, LUA_TTABLE);
 			to = PlayerCameraSpec::INVALID_LIMIT;
@@ -546,19 +546,25 @@ int ObjectRef::l_set_camera(lua_State *L)
 
 	PlayerCameraSpec cam = player->camera;
 
+	if (lua_isnoneornil(L, 2)) {
+		cam = PlayerCameraSpec(); // nil resets
+		goto skip;
+	}
+
 	luaL_checktype(L, 2, LUA_TTABLE);
-	lua_getfield(L, -1, "mode");
+	lua_getfield(L, 2, "mode");
 	if (lua_isstring(L, -1))
 		string_to_enum(es_CameraMode, cam.allowed_mode, lua_tostring(L, -1));
 	lua_pop(L, 1);
-	getboolfield(L, -1, "free_mouse", cam.free_mouse);
-	lua_getfield(L, -1, "yaw_limit");
+	getboolfield(L, 2, "free_mouse", cam.free_mouse);
+	lua_getfield(L, 2, "yaw_limit");
 	read_v2f_limit(-1, cam.yaw_limit);
 	lua_pop(L, 1);
-	lua_getfield(L, -1, "pitch_limit");
+	lua_getfield(L, 2, "pitch_limit");
 	read_v2f_limit(-1, cam.pitch_limit);
 	lua_pop(L, 1);
 
+skip:
 	if (cam != player->camera) {
 		player->camera = cam;
 		getServer(L)->SendCamera(player->getPeerId(), player);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -541,14 +541,20 @@ int ObjectRef::l_set_camera(lua_State *L)
 	if (lua_isstring(L, -1))
 		string_to_enum(es_CameraMode, cam.allowed_mode, lua_tostring(L, -1));
 	lua_pop(L, 1);
-	getfloatfield(L, -1, "min_yaw", cam.min_yaw);
-	getfloatfield(L, -1, "max_yaw", cam.max_yaw);
-	getfloatfield(L, -1, "min_pitch", cam.min_pitch);
-	getfloatfield(L, -1, "max_pitch", cam.max_pitch);
-	if (!cam.yawValid()) // prevent confusing behavior
-		cam.max_yaw = (cam.min_yaw = 0) - 1;
-	if (!cam.pitchValid())
-		cam.max_pitch = (cam.min_pitch = 0) - 1;
+	lua_getfield(L, -1, "yaw_limit");
+	if (lua_istable(L, -1)) {
+		cam.yaw_limit = PlayerCameraSpec::INVALID_LIMIT;
+		getfloatfield(L, -1, "min", cam.yaw_limit.X);
+		getfloatfield(L, -1, "max", cam.yaw_limit.Y);
+	}
+	lua_pop(L, 1);
+	lua_getfield(L, -1, "pitch_limit");
+	if (lua_istable(L, -1)) {
+		cam.pitch_limit = PlayerCameraSpec::INVALID_LIMIT;
+		getfloatfield(L, -1, "min", cam.pitch_limit.X);
+		getfloatfield(L, -1, "max", cam.pitch_limit.Y);
+	}
+	lua_pop(L, 1);
 
 	if (cam != player->camera) {
 		player->camera = cam;
@@ -570,12 +576,16 @@ int ObjectRef::l_get_camera(lua_State *L)
 	lua_newtable(L);
 	setstringfield(L, -1, "mode", enum_to_string(es_CameraMode, cam.allowed_mode));
 	if (cam.yawValid()) {
-		setfloatfield(L, -1, "min_yaw", cam.min_yaw);
-		setfloatfield(L, -1, "max_yaw", cam.max_yaw);
+		lua_newtable(L);
+		setfloatfield(L, -1, "min", cam.yaw_limit.X);
+		setfloatfield(L, -1, "max", cam.yaw_limit.Y);
+		lua_setfield(L, -2, "yaw_limit");
 	}
 	if (cam.pitchValid()) {
-		setfloatfield(L, -1, "min_pitch", cam.min_pitch);
-		setfloatfield(L, -1, "max_pitch", cam.max_pitch);
+		lua_newtable(L);
+		setfloatfield(L, -1, "min", cam.pitch_limit.X);
+		setfloatfield(L, -1, "max", cam.pitch_limit.Y);
+		lua_setfield(L, -2, "pitch_limit");
 	}
 
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -555,6 +555,7 @@ int ObjectRef::l_set_camera(lua_State *L)
 		getfloatfield(L, -1, "max", cam.pitch_limit.Y);
 	}
 	lua_pop(L, 1);
+	getboolfield(L, -1, "free_mouse", cam.free_mouse);
 
 	if (cam != player->camera) {
 		player->camera = cam;
@@ -587,6 +588,7 @@ int ObjectRef::l_get_camera(lua_State *L)
 		setfloatfield(L, -1, "max", cam.pitch_limit.Y);
 		lua_setfield(L, -2, "pitch_limit");
 	}
+	setboolfield(L, -1, "free_mouse", cam.free_mouse);
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -541,6 +541,7 @@ int ObjectRef::l_set_camera(lua_State *L)
 	if (lua_isstring(L, -1))
 		string_to_enum(es_CameraMode, cam.allowed_mode, lua_tostring(L, -1));
 	lua_pop(L, 1);
+	getboolfield(L, -1, "free_mouse", cam.free_mouse);
 	lua_getfield(L, -1, "yaw_limit");
 	if (lua_istable(L, -1)) {
 		cam.yaw_limit = PlayerCameraSpec::INVALID_LIMIT;
@@ -555,7 +556,6 @@ int ObjectRef::l_set_camera(lua_State *L)
 		getfloatfield(L, -1, "max", cam.pitch_limit.Y);
 	}
 	lua_pop(L, 1);
-	getboolfield(L, -1, "free_mouse", cam.free_mouse);
 
 	if (cam != player->camera) {
 		player->camera = cam;
@@ -576,6 +576,7 @@ int ObjectRef::l_get_camera(lua_State *L)
 
 	lua_newtable(L);
 	setstringfield(L, -1, "mode", enum_to_string(es_CameraMode, cam.allowed_mode));
+	setboolfield(L, -1, "free_mouse", cam.free_mouse);
 	if (cam.yawValid()) {
 		lua_newtable(L);
 		setfloatfield(L, -1, "min", cam.yaw_limit.X);
@@ -588,7 +589,6 @@ int ObjectRef::l_get_camera(lua_State *L)
 		setfloatfield(L, -1, "max", cam.pitch_limit.Y);
 		lua_setfield(L, -2, "pitch_limit");
 	}
-	setboolfield(L, -1, "free_mouse", cam.free_mouse);
 
 	return 1;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2056,7 +2056,7 @@ void Server::SendCamera(session_t peer_id, Player *player)
 	const auto &cam = player->camera;
 
 	pkt << static_cast<u8>(cam.allowed_mode);
-	pkt << cam.yaw_limit << cam.pitch_limit;
+	pkt << cam.free_mouse << cam.yaw_limit << cam.pitch_limit;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2056,7 +2056,7 @@ void Server::SendCamera(session_t peer_id, Player *player)
 	const auto &cam = player->camera;
 
 	pkt << static_cast<u8>(cam.allowed_mode);
-	pkt << cam.min_yaw << cam.max_yaw << cam.min_pitch << cam.max_pitch;
+	pkt << cam.yaw_limit << cam.pitch_limit;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2051,9 +2051,12 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 void Server::SendCamera(session_t peer_id, Player *player)
 {
-	NetworkPacket pkt(TOCLIENT_CAMERA, 1, peer_id);
+	NetworkPacket pkt(TOCLIENT_CAMERA, 20, peer_id);
 
-	pkt << static_cast<u8>(player->allowed_camera_mode);
+	const auto &cam = player->camera;
+
+	pkt << static_cast<u8>(cam.allowed_mode);
+	pkt << cam.min_yaw << cam.max_yaw << cam.min_pitch << cam.max_pitch;
 
 	Send(&pkt);
 }
@@ -2065,8 +2068,7 @@ void Server::SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed)
 
 	if (peer_id == PEER_ID_INEXISTENT) {
 		m_clients.sendToAll(&pkt);
-	}
-	else {
+	} else {
 		Send(&pkt);
 	}
 }


### PR DESCRIPTION
continuation of #15796

## To do

This PR is ready.

- [x] api docs
- [x] change api to use v2f instead of two props?
- [x] add a flag that unlocks the mouse cursor (for free in-world pointing)
- [x] ~~figure out how that interacts with touch controls on android~~

## How to test

`player:set_camera({pitch_limit={min=-45,max=45}})`
`player:set_camera({yaw_limit={min=340,max=360+20}})`
`player:set_camera({free_mouse=true})`