### PR TITLE
Fix SIGABRT when compiled with MacOSX26.2.sdk

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3360,8 +3360,11 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
 		// TODO: getSpecByID is a linear search. It should made O(1), or cached here.
 		const FieldSpec *spec_a = getSpecByID(a->getID());
 		const FieldSpec *spec_b = getSpecByID(b->getID());
-		return spec_a && spec_b &&
-			spec_a->priority < spec_b->priority;
+		// Have to be deterministic also for elements without spec
+		if (spec_a && spec_b)
+			return spec_a->priority < spec_b->priority;
+
+		return a->getID() < b->getID();
 	});
 
 	// 3: Re-assign the pointers


### PR DESCRIPTION
Bug fix:
https://irc.luanti.org/luanti-dev/2026-02-07#i_6312670

Code change discussed with AI.

## To do

This PR is a Ready for Review.

## How to test

Compile with MacOSX26.2 SDK and try if going through the game menu works without problems.
