### PR TITLE
Show keycode migration warning only if keycodes were migrated

### DIFF
--- a/builtin/mainmenu/dlg_rebind_keys.lua
+++ b/builtin/mainmenu/dlg_rebind_keys.lua
@@ -4,7 +4,6 @@
 -- Note that this is only needed for migrating from <5.11 to 5.12.
 
 local doc_url = "https://docs.luanti.org/for-players/controls/"
-local SETTING_NAME = "no_keycode_migration_warning"
 
 local function get_formspec(dialogdata)
 	local markup = table.concat({
@@ -27,7 +26,6 @@ local function get_formspec(dialogdata)
 end
 
 local function close_dialog(this)
-	cache_settings:set_bool(SETTING_NAME, true)
 	this:delete()
 end
 
@@ -86,12 +84,8 @@ local function normalize_key_setting(str)
 end
 
 function migrate_keybindings(parent)
-	-- Show migration dialog if the user upgraded from an earlier version
-	-- and this has not yet been shown before, *or* if keys settings had to be changed
-	if core.is_first_run then
-		cache_settings:set_bool(SETTING_NAME, true)
-	end
-	local has_migration = not cache_settings:get_bool(SETTING_NAME)
+	-- Show migration dialog if keys settings had to be changed
+	local has_migration = false
 
 	-- normalize all existing key settings, this converts them from KEY_KEY_C to SYSTEM_SCANCODE_6
 	local settings = core.settings:to_table()


### PR DESCRIPTION
Currently the keycode migration warning is also shown if a certain entry in the cache is absent. This was originally designed to inform users that the default keybindings may also have been changed even if they did not change keybindings themselves. However, the number of users that this accounts for should be acceptably low by this point as it involves satisfying three conditions at the same time:

* The user upgrades from <5.12 to 5.16[^1],
* The user does not have any custom keybindings, and
* The user uses a keyboard layout for which the scancode-based defaults differ from the keycode-based ones.

[^1]: Debian presently packages 5.10, with 5.14 block due to (apparently) dependency-related reasons. In any case, downstream packagers that migrate from <5.12 to this version can opt to revert this PR.

Meanwhile, @rubenwardy reported that the current approach adversely affects Android users (which there are significantly more of in comparison), as the dialog is shown again when the cache is cleared.

This PR therefore removes the cache check. Players that upgrade from <5.12 to 5.16 will only see the warning if they have keybindings that are migrated.