### PR TITLE
Formspec: Add font customization to tooltips

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3866,6 +3866,9 @@ Some types may inherit styles from parent types.
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+* tooltip
+    * font - Sets font type. See button `font` property for more information.
+    * font_size - Sets font size. See button `font_size` property for more information.
 
 ### Valid States
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3711,6 +3711,13 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 		)
 	);
 
+	auto style = getDefaultStyleForElement("tooltip", "");
+	gui::IGUIFont *font = style.getFont();
+	if (!font)
+		font = m_font;
+
+	m_tooltip_element->setOverrideFont(font);
+
 	// Display the tooltip
 	m_tooltip_element->setVisible(true);
 	bringToFront(m_tooltip_element);


### PR DESCRIPTION
Fixes #14537.

Does what the title says - adds the option to customize the font used for tooltips.

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->
Use `style_type[tooltip;font=bold]` or any of the other options.

<img width="311" height="208" alt="Screenshot From 2026-03-04 12-43-26" src="https://github.com/user-attachments/assets/b9103080-67a4-4931-b518-9ba6b40e00f7" />

