### PR TITLE
Formspec: Add setting to toggle closing the formspec when clicked outside

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -867,6 +867,10 @@ gui_scaling (GUI scaling) float 1.0 0.5 20
 #    Enables smooth scrolling.
 smooth_scrolling (Smooth scrolling) bool true
 
+#    Enables closing the formspec when the mouse is clicked
+#    outside of the formspec area.
+formspec_exit_on_click_outside (Close formspecs when clicked outside) bool true
+
 #    Enables animation of inventory items.
 inventory_items_animations (Inventory items animations) bool false
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -295,6 +295,7 @@ void set_default_settings()
 	settings->setDefault("gui_scaling", "1.0");
 	settings->setDefault("gui_scaling_filter", "false");
 	settings->setDefault("smooth_scrolling", "true");
+	settings->setDefault("formspec_exit_on_click_outside", "true");
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -132,19 +132,16 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 		// Return true since the event was handled, even if it wasn't handled by us.
 		return true;
 
-	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
-		if (!g_settings->getBool("formspec_exit_on_click_outside"))
+	if (!g_settings->getBool("formspec_exit_on_click_outside"))
 			return false;
 
+	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
 		m_last_click_outside = current;
 		return true;
 	}
 
 	if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP &&
 			current.isRelated(last)) {
-		if (!g_settings->getBool("formspec_exit_on_click_outside"))
-			return false;
-
 		SEvent translated{};
 		translated.EventType              = EET_KEY_INPUT_EVENT;
 		translated.KeyInput.Key           = KEY_ESCAPE;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -133,7 +133,7 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 		return true;
 
 	if (!g_settings->getBool("formspec_exit_on_click_outside"))
-			return false;
+		return false;
 
 	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
 		m_last_click_outside = current;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -133,12 +133,18 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 		return true;
 
 	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+		if (!g_settings->getBool("formspec_exit_on_click_outside"))
+			return false;
+
 		m_last_click_outside = current;
 		return true;
 	}
 
 	if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP &&
 			current.isRelated(last)) {
+		if (!g_settings->getBool("formspec_exit_on_click_outside"))
+			return false;
+
 		SEvent translated{};
 		translated.EventType              = EET_KEY_INPUT_EVENT;
 		translated.KeyInput.Key           = KEY_ESCAPE;


### PR DESCRIPTION
Fixes #15955 

Simply adds a setting `formspec_exit_on_click_outside` for users who do not wish to close the formspec when they click outside the formspec. :)

## To do

This PR is Ready for Review.


## How to test

<!-- Example code or instructions -->

Enable/disable the setting and ensure it does what it's supposed to do.
Also test dropping items outside the formspec.