### PR TITLE
Work around glObjectLabel problem with GLES

### DIFF
--- a/irr/src/OpenGLES2/DriverGLES2.cpp
+++ b/irr/src/OpenGLES2/DriverGLES2.cpp
@@ -120,9 +120,14 @@ void COpenGLES2Driver::initFeatures()
 	BlendMinMaxSupported = (Version.Major >= 3) || FeatureAvailable[IRR_GL_EXT_blend_minmax];
 	TextureMultisampleSupported = isVersionAtLeast(3, 1);
 	Texture2DArraySupported = Version.Major >= 3 || queryExtension("GL_EXT_texture_array");
-	KHRDebugSupported = queryExtension("GL_KHR_debug");
-	if (KHRDebugSupported)
-		MaxLabelLength = GetInteger(GL.MAX_LABEL_LENGTH);
+	// FIXME: on GLES the functions are suffixed, but our loader code ignores
+	// this and violates the spec (see #15830). This happens to work on Mesa
+	// nonetheless so continue allowing this useful debug feature there.
+	if (Name.find("Mesa") != -1) {
+		KHRDebugSupported = queryExtension("GL_KHR_debug");
+		if (KHRDebugSupported)
+			MaxLabelLength = GetInteger(GL.MAX_LABEL_LENGTH);
+	}
 	RenderToFloatTextureSupported = isVersionAtLeast(3, 2)|| queryExtension("GL_EXT_color_buffer_float");
 
 	// COGLESCoreExtensionHandler::Feature


### PR DESCRIPTION
interim fix until #15830.
I didn't want to disable the thing entirely because it's very helpful when looking at renderdoc.