### PR TITLE
Soft changes to item + entity + LBM + ABM registration, return of definition table on success

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -62,7 +62,7 @@ local function check_modname_prefix(name, modname)
 		return name:sub(2)
 	else
 		-- Enforce that the name starts with the correct mod name.
-		local expected_prefix = (modname or core.get_current_modname() or "") .. ":"
+		local expected_prefix = (modname or "") .. ":"
 		if name:sub(1, #expected_prefix) ~= expected_prefix then
 			error("Name " .. name .. " does not follow naming conventions: " ..
 				"\"" .. expected_prefix .. "\" or \":\" prefix required")
@@ -103,7 +103,8 @@ end
 
 function core.register_lbm(spec)
 	-- Add to core.registered_lbms
-	check_modname_prefix(spec.name)
+  spec.mod_origin = core.get_current_modname() or "??"
+	check_modname_prefix(spec.name, spec.mod_origin)
 	check_node_list(spec.nodenames, "nodenames")
 	local have = spec.action ~= nil
 	local have_bulk = spec.bulk_action ~= nil
@@ -112,7 +113,6 @@ function core.register_lbm(spec)
 	assert(have ~= have_bulk, "Either 'action' or 'bulk_action' must be present")
 
 	core.registered_lbms[#core.registered_lbms + 1] = spec
-	spec.mod_origin = core.get_current_modname() or "??"
 end
 
 function core.register_entity(name, prototype)
@@ -120,14 +120,15 @@ function core.register_entity(name, prototype)
 	if name == nil then
 		error("Unable to register entity: Name is nil")
 	end
-	name = check_modname_prefix(tostring(name))
+
+  prototype.mod_origin = core.get_current_modname() or "??"
+  name = check_modname_prefix(tostring(name), prototype.mod_origin)
 
 	prototype.name = name
 	prototype.__index = prototype  -- so that it can be used as a metatable
 
 	-- Add to core.registered_entities
 	core.registered_entities[name] = prototype
-	prototype.mod_origin = core.get_current_modname() or "??"
 end
 
 local function preprocess_node(nodedef)
@@ -237,7 +238,10 @@ function core.register_item(name, itemdef)
 	if name == nil then
 		error("Unable to register item: Name is nil")
 	end
-	name = check_modname_prefix(tostring(name))
+
+	itemdef.mod_origin = core.get_current_modname() or "??"
+  name = check_modname_prefix(tostring(name), itemdef.mod_origin)
+
 	if forbidden_item_names[name] then
 		error("Unable to register item: Name is forbidden: " .. name)
 	end
@@ -293,8 +297,6 @@ function core.register_item(name, itemdef)
 		})
 	end
 	-- END Legacy stuff
-
-	itemdef.mod_origin = core.get_current_modname() or "??"
 
 	-- Ignore new keys as a failsafe to prevent mistakes
 	getmetatable(itemdef).__newindex = function() end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -55,14 +55,14 @@ local forbidden_item_names = {
 	tool = true,
 }
 
-local function check_modname_prefix(name)
+local function check_modname_prefix(name, modname)
 	if name:sub(1,1) == ":" then
 		-- If the name starts with a colon, we can skip the modname prefix
 		-- mechanism.
 		return name:sub(2)
 	else
 		-- Enforce that the name starts with the correct mod name.
-		local expected_prefix = (core.get_current_modname() or "") .. ":"
+		local expected_prefix = (modname or core.get_current_modname() or "") .. ":"
 		if name:sub(1, #expected_prefix) ~= expected_prefix then
 			error("Name " .. name .. " does not follow naming conventions: " ..
 				"\"" .. expected_prefix .. "\" or \":\" prefix required")
@@ -315,7 +315,11 @@ end
 
 local function make_register_item_wrapper(the_type)
 	return function(name, itemdef)
-		itemdef.type = the_type
+		if type(itemdef) ~= "table" then
+      error("Unable to register "..(the_type == "craft" and "craftitem" or the_type)..
+        ": Definition is non-table, got type '"..type(itemdef).."'")
+    end
+    itemdef.type = the_type
 		return core.register_item(name, itemdef)
 	end
 end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -99,12 +99,12 @@ function core.register_abm(spec)
 
 	core.registered_abms[#core.registered_abms + 1] = spec
 	spec.mod_origin = core.get_current_modname() or "??"
-  return spec
+	return spec
 end
 
 function core.register_lbm(spec)
 	-- Add to core.registered_lbms
-  spec.mod_origin = core.get_current_modname() or "??"
+	spec.mod_origin = core.get_current_modname() or "??"
 	check_modname_prefix(spec.name, spec.mod_origin)
 	check_node_list(spec.nodenames, "nodenames")
 	local have = spec.action ~= nil
@@ -114,7 +114,7 @@ function core.register_lbm(spec)
 	assert(have ~= have_bulk, "Either 'action' or 'bulk_action' must be present")
 
 	core.registered_lbms[#core.registered_lbms + 1] = spec
-  return spec
+	return spec
 end
 
 function core.register_entity(name, prototype)
@@ -123,15 +123,15 @@ function core.register_entity(name, prototype)
 		error("Unable to register entity: Name is nil")
 	end
 
-  prototype.mod_origin = core.get_current_modname() or "??"
-  name = check_modname_prefix(tostring(name), prototype.mod_origin)
+	prototype.mod_origin = core.get_current_modname() or "??"
+	name = check_modname_prefix(tostring(name), prototype.mod_origin)
 
 	prototype.name = name
 	prototype.__index = prototype  -- so that it can be used as a metatable
 
 	-- Add to core.registered_entities
 	core.registered_entities[name] = prototype
-  return prototype
+	return name
 end
 
 local function preprocess_node(nodedef)
@@ -243,7 +243,7 @@ function core.register_item(name, itemdef)
 	end
 
 	itemdef.mod_origin = core.get_current_modname() or "??"
-  name = check_modname_prefix(tostring(name), itemdef.mod_origin)
+	name = check_modname_prefix(tostring(name), itemdef.mod_origin)
 
 	if forbidden_item_names[name] then
 		error("Unable to register item: Name is forbidden: " .. name)
@@ -316,16 +316,16 @@ function core.register_item(name, itemdef)
 	core.registered_aliases[itemdef.name] = nil
 
 	register_item_raw(itemdef)
-  return itemdef
+	return itemdef.name
 end
 
 local function make_register_item_wrapper(the_type)
 	return function(name, itemdef)
 		if type(itemdef) ~= "table" then
-      error("Unable to register "..(the_type == "craft" and "craftitem" or the_type)..
-        ": Definition is non-table, got type '"..type(itemdef).."'")
-    end
-    itemdef.type = the_type
+			error("Unable to register "..(the_type == "craft" and "craftitem" or the_type)..
+				": Definition is non-table, got type '"..type(itemdef).."'")
+		end
+		itemdef.type = the_type
 		return core.register_item(name, itemdef)
 	end
 end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -99,6 +99,7 @@ function core.register_abm(spec)
 
 	core.registered_abms[#core.registered_abms + 1] = spec
 	spec.mod_origin = core.get_current_modname() or "??"
+  return spec
 end
 
 function core.register_lbm(spec)
@@ -113,6 +114,7 @@ function core.register_lbm(spec)
 	assert(have ~= have_bulk, "Either 'action' or 'bulk_action' must be present")
 
 	core.registered_lbms[#core.registered_lbms + 1] = spec
+  return spec
 end
 
 function core.register_entity(name, prototype)
@@ -129,6 +131,7 @@ function core.register_entity(name, prototype)
 
 	-- Add to core.registered_entities
 	core.registered_entities[name] = prototype
+  return prototype
 end
 
 local function preprocess_node(nodedef)
@@ -313,6 +316,7 @@ function core.register_item(name, itemdef)
 	core.registered_aliases[itemdef.name] = nil
 
 	register_item_raw(itemdef)
+  return itemdef
 end
 
 local function make_register_item_wrapper(the_type)


### PR DESCRIPTION

(I don't imagine I was supposed to just copy the template, but, I'm tired and lazy RN :wheeze:)

**Goal of the PR**

Add a more informative error for if an invalid `itemdef` is given for the wrapper variants of `register_item`

Have `get_current_modname` be called once instead of twice per registration, reuse for `check_modname_prefix` (might even make it quicker???)

Return the definition tables upon successful registration

**How does the PR work?**

Well, as described in the goal of the PR! :D

**Does it resolve any reported issue?**

To my knowledge, no. It was a pet peeve of mine to see `itemdef.type =` in the wrapper with no check for if it's a table. I was about to do similar for all other registration as well but thought "hmmm, maybe there's a reason, like performance?"

**Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**

From what I quickly read, no, it does not relate to any engine goals

**If not a bug fix, why is this PR needed? What usecases does it solve?**

Make a more informative error, use `get_current_modname` less if unnecessary, QoL with returning definition table on success

**If you have used an LLM/AI to help with code or assets, you must disclose this.**

None at all :3c

## To do

This PR is Ready for Review.

## How to test

Just register any item, entity, LBM, or ABM :D - should expect a return from them as well

Should this returning of the definition on success be documented?
