### PR TITLE
Add per-player shadow direction override via set_lighting

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9147,6 +9147,11 @@ child will follow movement and rotation of that bone.
         * `intensity` sets the intensity of the shadows from 0 (no shadows, default) to 1 (blackness)
         * `tint` tints the shadows with the provided color, with RGB values ranging from 0 to 255.
           (default `{r=0, g=0, b=0}`)
+        * `direction` is a direction vector that can override the direction of the light,
+          disregarding the sun/moon position. This is useful for custom skyboxes.
+          The default is a zero vector and disables the override.
+          Note: the vector points "outwards" so that `(0, 1, 0)` is equivalent to
+          the sun at midday shining straight down.
       * `exposure` is a table that controls automatic exposure.
         The basic exposure factor equation is `e = 2^exposure_correction / clamp(luminance, 2^luminance_min, 2^luminance_max)`
         * This has no effect on clients who have the "Automatic Exposure" effect disabled.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3591,17 +3591,23 @@ void Game::updateShadows()
 
 	float in_timeofday = std::fmod(runData.time_of_day_smooth, 1.0f);
 
-	float timeoftheday = getWickedTimeOfDay(in_timeofday);
-	bool is_day = timeoftheday > 0.25 && timeoftheday < 0.75;
-	bool is_shadow_visible = is_day ? sky->getSunVisible() : sky->getMoonVisible();
 	const auto &lighting = client->getEnv().getLocalPlayer()->getLighting();
-	shadow->setShadowIntensity(is_shadow_visible ? lighting.shadow_intensity : 0.0f);
 	shadow->setShadowTint(lighting.shadow_tint);
 
-	timeoftheday = std::fmod(timeoftheday + 0.75f, 0.5f) + 0.25f;
 	const float offset_constant = 10000.0f;
 
-	v3f light = is_day ? sky->getSunDirection() : sky->getMoonDirection();
+	v3f light;
+	if (lighting.shadow_direction.getLengthSQ() > 0.0f) {
+		// Custom shadow direction: bypass sun/moon visibility check
+		shadow->setShadowIntensity(lighting.shadow_intensity);
+		light = lighting.shadow_direction;
+	} else {
+		float timeoftheday = getWickedTimeOfDay(in_timeofday);
+		bool is_day = timeoftheday > 0.25f && timeoftheday < 0.75f;
+		bool is_shadow_visible = is_day ? sky->getSunVisible() : sky->getMoonVisible();
+		shadow->setShadowIntensity(is_shadow_visible ? lighting.shadow_intensity : 0.0f);
+		light = is_day ? sky->getSunDirection() : sky->getMoonDirection();
+	}
 
 	v3f sun_pos = light * offset_constant;
 	shadow->getDirectionalLight().setDirection(sun_pos);

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "SColor.h"
+#include "irr_v3d.h"
 
 
 /**
@@ -51,4 +52,5 @@ struct Lighting
 	float bloom_intensity {0.05f};
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
+	v3f shadow_direction;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1875,5 +1875,10 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> lighting.bloom_intensity
 				>> lighting.bloom_strength_factor
 				>> lighting.bloom_radius;
+
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.16.0-dev
+		*pkt >> lighting.shadow_direction;
 	} while (0);
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -692,6 +692,13 @@ enum ToClientCommand : u16
 			f32 speed_dark_bright
 			f32 speed_bright_dark
 			f32 center_weight_power
+		f32 volumetric_light_strength
+		SColor shadow_tint
+		bloom parameters
+			f32 bloom_intensity
+			f32 bloom_strength_factor
+			f32 bloom_radius
+		v3f shadow_direction ({0,0,0} = unset)
 	*/
 
 	TOCLIENT_SPAWN_PARTICLE_BATCH = 0x64,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2691,6 +2691,10 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			lua_getfield(L, -1, "tint");
 			read_color(L, -1, &lighting.shadow_tint);
 			lua_pop(L, 1); // tint
+			lua_getfield(L, -1, "direction");
+			if (!lua_isnil(L, -1))
+				lighting.shadow_direction = check_v3f(L, -1);
+			lua_pop(L, 1); // direction
 		}
 		lua_pop(L, 1); // shadows
 
@@ -2744,6 +2748,8 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "intensity");
 	push_ARGB8(L, lighting.shadow_tint);
 	lua_setfield(L, -2, "tint");
+	push_v3f(L, lighting.shadow_direction);
+	lua_setfield(L, -2, "direction");
 	lua_setfield(L, -2, "shadows");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2024,6 +2024,8 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << lighting.bloom_intensity << lighting.bloom_strength_factor <<
 			lighting.bloom_radius;
 
+	pkt << lighting.shadow_direction;
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
Add an optional shadow.direction field to the lighting struct, allowing server mods to override the shadow light direction on a per-player basis. This is needed for games that use custom skyboxes where the sun/moon position in the skybox texture does not correspond to the engine's internal time-of-day cycle.

When shadow_direction is set, Game::updateShadows() uses it directly instead of computing direction from getSunDirection()/getMoonDirection(), and applies shadow_intensity unconditionally (bypassing the sun/moon visibility check that would otherwise zero out shadows).

Lua API:
  player:set_lighting({shadows = {direction = {x=0.3, y=0.9, z=0.3}}})
  player:set_lighting({shadows = {direction = ~~false~~vector.zero()}})  -- clear override

The TOCLIENT_SET_LIGHTING packet documentation in networkprotocol.h was outdated, listing only the original fields (shadow_intensity, saturation, exposure parameters) while the actual packet has grown over several releases to include volumetric_light_strength, shadow_tint, and bloom parameters. The documentation is now updated to reflect all fields actually sent and parsed, plus the new shadow direction.

Network compatibility: the new field is appended to the end of the packet. Old clients ignore the extra bytes. New clients handle missing bytes via the existing hasRemainingBytes() pattern, falling back to sun/moon-based shadows when the server does not send a direction.