### PR TITLE
Fix bug with missing scrollbar in world mod selection dialog 

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3360,7 +3360,7 @@ void GUIFormSpecMenu::legacySortElements(std::list<IGUIElement *>::iterator from
 		// TODO: getSpecByID is a linear search. It should made O(1), or cached here.
 		const FieldSpec *spec_a = getSpecByID(a->getID());
 		const FieldSpec *spec_b = getSpecByID(b->getID());
-		// The comparasion has to be compatible with strict weak ordering
+		// The comparison has to be compatible with strict weak ordering
 		if (spec_a && spec_b)
 			return spec_a->priority < spec_b->priority;
 


### PR DESCRIPTION
Fix bug with missing scrollbar in world mod selection dialog caused by commit 3b67e73.

Reported: https://github.com/luanti-org/luanti/pull/16987#issuecomment-4034310550

## To do

Ready for Review.

