### PR TITLE
Fix dev build version hash fallback when git is unavailable

### DIFF
--- a/cmake/Modules/GenerateVersion.cmake
+++ b/cmake/Modules/GenerateVersion.cmake
@@ -17,7 +17,11 @@ if(DEVELOPMENT_BUILD)
 	endif()
 endif()
 if(NOT VERSION_GITHASH)
-	set(VERSION_GITHASH "${VERSION_STRING}")
+	if(DEVELOPMENT_BUILD)
+		set(VERSION_GITHASH "${VERSION_STRING}-unknown")
+	else()
+		set(VERSION_GITHASH "${VERSION_STRING}")
+	endif()
 endif()
 
 configure_file(


### PR DESCRIPTION

### Goal of the PR

The goal is to fix compilation (devtest unit tests) on Guix with dev releases of Luanti.
Right now running `guix build luanti --with-branch=luanti=master` (along with my not yet upstreamed patch which runs devtest tests) results in one devtest unit test failing:

```
(server) 2026-03-14 17:37:42: ERROR[Server]: ...er/share/luanti/games/devtest/mods/unittests/version.lua:11: assertion failed!
(server) [FAIL] test_get_version - 0ms
```

In hermetic build environments (e.g. Guix sandbox), `git rev-parse --short HEAD` fails silently for `DEVELOPMENT_BUILD=TRUE`, causing `VERSION_GITHASH` to fall back to `VERSION_STRING`. Since `g_version_hash == g_version_string`, `core.get_version()` omits the hash field while `is_dev` is still true, tripping this devtest assertion:

```lua
if version.is_dev then
    assert(type(version.hash) == "string")  -- hash is nil
end
```

### If you have used an LLM/AI to help with code or assets, you must disclose this.

The issue was investigated and fixed by Github Copilot.

## To do

- [x] Compile
- [x] Confirm all tests pass
- [x] Check version strings in the game 

Ready for Review.

## How to test

Expected results:

- **Dev builds + git unavailable**: VERSION_GITHASH = "VERSION_STRING-unknown" ≠ VERSION_STRING, so hash field is included in core.get_version() → test passes ✓
- **Dev builds + git available**: Unchanged behavior — VERSION_GITHASH = "VERSION_STRING-HASH" (possibly with -dirty) ✓
- **Stable releases** (DEVELOPMENT_BUILD=FALSE): Unchanged behavior — hash remains nil, is_dev is false ✓

Just compile and see the version string in the game with `core.get_version()` or other means.

The version string when building on Guix with this PR:
`2026-03-14 19:32:12: INFO[Main]: Luanti 5.16.0-dev-unknown (Linux)`