### PR TITLE
Allow distant blocks expire outside the view cone

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -752,6 +752,10 @@ void ClientMap::touchMapBlocks()
 	// Number of blocks in rendering range
 	u32 blocks_in_range = 0;
 
+	// see client_mapblock_limit calculation in Client::step
+	constexpr s32 mapblock_limit_enforce_distance = 200;
+	auto is_frustum_culled = m_client->getCamera()->getFrustumCuller();
+
 	for (const auto &sector_it : m_sectors) {
 		const MapSector *sector = sector_it.second;
 		v2s16 sp = sector->getPos();
@@ -787,10 +791,16 @@ void ClientMap::touchMapBlocks()
 				mesh_sphere_radius = 0.0f;
 			}
 
+			const f32 d = mesh_sphere_center.getDistanceFrom(m_camera_position);
+
 			// First, perform a simple distance check.
-			if (mesh_sphere_center.getDistanceFrom(m_camera_position) >
-					m_control.wanted_range * BS + mesh_sphere_radius)
+			if (d > m_control.wanted_range * BS + mesh_sphere_radius)
 				continue; // Out of range, skip.
+
+			// At farther distances also do frustum culling
+			if (d > mapblock_limit_enforce_distance * BS + mesh_sphere_radius &&
+					is_frustum_culled(mesh_sphere_center, mesh_sphere_radius))
+				continue;
 
 			// Keep the block alive as long as it is in range.
 			block->resetUsageTimer();


### PR DESCRIPTION
See in part #16734.
I discovered that the mere presence of a block with a mesh occupies resources on the GPU (even when the H/W buffers are wiped). For large viewing distances (1000 or 2000) this can become an actual problem (whether it is a driver bug or not is not the point, there are resources consumed).

In #15851 we adjust the `client_mapblock_limit` based on the actual `viewing_range`, but only up to a distance of 200. This follows the same logic.

- Goal of the PR
Avoid too many resources consumed on the GPU

- How does the PR work?
Allow distant blocks to expire if they are outside of the viewing cone

- Does it resolve any reported issue?
Does #16734 count?

- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope

## To do

This PR is Ready for Review.

## How to test

Set `client_unload_unused_data_timeout` to a small value. Set `viewing_range` to something larger than 200. Adjust `max_block_generate_distance` and `max_block_send_distance` accordingly. Check that distant blocks behind the play are allowed to expire.