### PR TITLE
Re-show death screen when a formspec is closed while player is dead

### DIFF
--- a/builtin/game/death_screen.lua
+++ b/builtin/game/death_screen.lua
@@ -27,5 +27,13 @@ core.register_on_player_receive_fields(function(player, formname, fields)
 		player:respawn()
 		core.log("action", player:get_player_name() .. " respawns at " ..
 				player:get_pos():to_string())
+		return
+	end
+
+	-- If a non-death formspec was closed while the player is dead,
+	-- re-show the death screen to prevent the "zombie state" (see #11523).
+	if formname ~= "__builtin:death" and fields.quit and player:get_hp() == 0 then
+		core.log("info", "Re-showing death screen to " .. player:get_player_name())
+		core.show_death_screen(player, nil)
 	end
 end)


### PR DESCRIPTION
If a mod sends a formspec via show_formspec() while the player is on the death screen, it replaces the death screen. When the player closes that formspec, they enter a "zombie state" — walking at 0 HP with no way to respawn, requiring a reconnect.

Fix by re-showing the death screen whenever a non-death formspec is closed (fields.quit) while the player has 0 HP.

To reproduce, register a chat command that kills the player and sends a formspec after a delay:

    core.register_chatcommand("test_death_formspec", {
        privs = {server = true},
        func = function(name)
            local player = core.get_player_by_name(name)
            player:set_hp(0, {type = "set_hp"})
            core.after(3, function()
                core.show_formspec(name, "test:dialog",
                    "size[5,3]label[1,1;Test]button_exit[1.5,2;2,0.5;ok;OK]")
            end)
        end,
    })

Run /test_death_formspec, wait for the dialog, close it. Without the fix, the player is stuck as a zombie. With the fix, the death screen re-appears.

Fixes #11523

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>