### PR TITLE
Play placement sound even when node_placement_prediction is empty

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3002,6 +3002,9 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 			!isKeyDown(KeyType::SNEAK))) {
 		// Report to server
 		client->interact(INTERACT_PLACE, pointed);
+		// Play placement sound even without prediction
+		if (prediction.empty())
+			soundmaker->m_player_rightpunch_sound = selected_def.sound_place;
 		return false;
 	}
 


### PR DESCRIPTION
When a node definition has node_placement_prediction = "", the placement sound was not played because it is set as part of the client-side prediction path, which is skipped entirely when prediction is disabled.

Fix by setting the placement sound when prediction is empty, before returning from nodePlacement(). The sound plays optimistically, same as it does for nodes with prediction enabled.

To test, register a node with prediction disabled and a placement sound:

    core.register_node("test:no_predict", {
        node_placement_prediction = "",
        sounds = { place = {name = "some_sound"} },
        groups = {dig_immediate = 2},
    })

Without the fix, placing this node is silent. With the fix, the placement sound plays.

Fixes #12753

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>