### PR TITLE
Avoid using game fonts for non-game formspecs.

### DIFF
--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -172,7 +172,10 @@ void FontEngine::handleReload()
 
 void FontEngine::updateSkin()
 {
-	gui::IGUIFont *font = getFont();
+	// The skin font is used as the default by engine UI elements (e.g. volume
+	// control, password dialog). It must not use server media fonts, since
+	// games should not be able to affect engine UI appearance.
+	gui::IGUIFont *font = getEngineFont();
 	assert(font);
 
 	m_env->getSkin()->setFont(font);
@@ -190,6 +193,22 @@ void FontEngine::refresh()
 	clearCache();
 	updateCache();
 	updateSkin();
+
+	for (auto &[tag, cb] : m_refresh_callbacks)
+		cb();
+}
+
+void FontEngine::addRefreshCallback(void *tag, std::function<void()> cb)
+{
+	m_refresh_callbacks.emplace_back(tag, std::move(cb));
+}
+
+void FontEngine::removeRefreshCallbacks(void *tag)
+{
+	m_refresh_callbacks.erase(
+		std::remove_if(m_refresh_callbacks.begin(), m_refresh_callbacks.end(),
+			[tag](const auto &entry) { return entry.first == tag; }),
+		m_refresh_callbacks.end());
 }
 
 void FontEngine::setMediaFont(const std::string &name, const std::string &data)

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <unordered_map>
+#include <vector>
 #include "irr_ptr.h"
 #include "irrlicht_changes/CGUITTFont.h"
 #include "util/basic_macros.h"
@@ -83,6 +85,15 @@ public:
 		return getFont(spec);
 	}
 
+	// Returns the default font without server media (engine-only font).
+	gui::IGUIFont *getEngineFont(unsigned int font_size=FONT_SIZE_UNSPECIFIED,
+			FontMode mode=FM_Unspecified)
+	{
+		FontSpec spec(font_size, mode, m_default_bold, m_default_italic);
+		spec.allow_server_media = false;
+		return getFont(spec);
+	}
+
 	/** get text height for a specific font */
 	unsigned int getTextHeight(const FontSpec &spec);
 
@@ -145,6 +156,12 @@ public:
 
 	void clearMediaFonts();
 
+	/** Register a callback to be invoked when fonts are refreshed (e.g.
+	 *  after server media fonts are loaded). The tag is used to identify
+	 *  the callback for later removal. */
+	void addRefreshCallback(void *tag, std::function<void()> cb);
+	void removeRefreshCallbacks(void *tag);
+
 private:
 	gui::IGUIFont *getFont(FontSpec spec, bool may_fail);
 
@@ -193,6 +210,8 @@ private:
 	static const FontMode s_default_font_mode = FM_Standard;
 
 	bool m_needs_reload = false;
+
+	std::vector<std::pair<void *, std::function<void()>>> m_refresh_callbacks;
 
 	DISABLE_CLASS_COPY(FontEngine);
 };

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -282,11 +282,14 @@ void GameFormSpec::showPauseMenuFormSpec(const std::string &formspec, const std:
 
 	GUIFormSpecMenu *fs = nullptr;
 	GUIFormSpecMenu::create(fs, m_client, m_rendering_engine->get_gui_env(),
-			// Ignore formspec prepend.
-			&m_input->joystick, fs_src, txt_dst, "",
+			// Ignore formspec prepend. Use _no_server_media to prevent game
+			// fonts from affecting engine UI.
+			&m_input->joystick, fs_src, txt_dst,
+			"style_type[*;font=_no_server_media]",
 			m_client->getSoundManager());
 
 	fs->setName(formname);
+	fs->useEngineFont = true;
 	fs->doPause = true;
 	fs->drop(); // 1 reference held by `g_menumgr`
 }
@@ -381,6 +384,7 @@ void GameFormSpec::showPauseMenu()
 	std::ostringstream os;
 
 	os << "formspec_version[1]" << SIZE_TAG
+		<< "style_type[*;font=_no_server_media]"
 		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Continue") << "]";
@@ -460,9 +464,10 @@ void GameFormSpec::showPauseMenu()
 	HardcodedPauseFormspecHandler *txt_dst = new HardcodedPauseFormspecHandler();
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
-			&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
+			&m_input->joystick, fs_src, txt_dst, "",
 			m_client->getSoundManager());
 	m_formspec->setFocus("btn_continue");
+	m_formspec->useEngineFont = true;
 	// game will be paused in next step, if in singleplayer (see Game::m_is_paused)
 	m_formspec->doPause = true;
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -46,11 +46,8 @@ void GameUI::init()
 	// Chat text
 	m_guitext_chat = gui::StaticText::add(guienv, L"", core::recti(),
 		false, true, guiroot);
-	u16 chat_font_size = g_settings->getU16("chat_font_size");
-	if (chat_font_size != 0) {
-		m_guitext_chat->setOverrideFont(g_fontengine->getFont(
-			rangelim(chat_font_size, 5, 72), FM_Unspecified));
-	}
+	updateChatFont();
+	g_fontengine->addRefreshCallback(this, [this] { updateChatFont(); });
 
 
 	// Infotext of nodes and objects.
@@ -294,8 +291,20 @@ void GameUI::toggleProfiler()
 	}
 }
 
+void GameUI::updateChatFont()
+{
+	if (!m_guitext_chat)
+		return;
+	u16 chat_font_size = g_settings->getU16("chat_font_size");
+	m_guitext_chat->setOverrideFont(g_fontengine->getFont(
+		chat_font_size != 0 ? rangelim(chat_font_size, 5, 72)
+			: FONT_SIZE_UNSPECIFIED, FM_Unspecified));
+}
+
 void GameUI::clearText()
 {
+	g_fontengine->removeRefreshCallbacks(this);
+
 	if (m_guitext_chat) {
 		m_guitext_chat->remove();
 		m_guitext_chat = nullptr;

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -86,6 +86,8 @@ public:
 
 	void clearText();
 
+	void updateChatFont();
+
 private:
 	Flags m_flags;
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1520,8 +1520,11 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
 		// spec field id to 0, this stops submit searching for a value that isn't there
-		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-				data->current_parent, 0);
+		auto *e = gui::StaticText::add(Environment, spec.flabel.c_str(), rect,
+				false, true, data->current_parent, 0);
+		auto style = getDefaultStyleForElement("field", spec.fname);
+		if (auto *font = style.getFont())
+			e->setOverrideFont(font);
 		return;
 	}
 
@@ -3180,7 +3183,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		padding = v2s32(use_imgsize*3.0/8, use_imgsize*3.0/8);
 		m_btn_height = use_imgsize*15.0/13 * 0.35;
 
-		m_font = g_fontengine->getFont();
+		m_font = useEngineFont
+				? g_fontengine->getEngineFont()
+				: g_fontengine->getFont();
 
 		if (mydata.real_coordinates) {
 			mydata.size = v2s32(
@@ -3204,7 +3209,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		// Non-size[] form must consist only of text fields and
 		// implicit "Proceed" button.  Use default font, and
 		// temporary form size which will be recalculated below.
-		m_font = g_fontengine->getFont();
+		m_font = useEngineFont
+				? g_fontengine->getEngineFont()
+				: g_fontengine->getFont();
 		m_btn_height = font_line_height(m_font) * 0.875;
 		DesiredRect = core::rect<s32>(
 			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * 580.0),

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -273,6 +273,9 @@ public:
 	bool doPause;
 	bool pausesGame() { return doPause; }
 
+	// When set, this formspec uses engine fonts instead of game-provided fonts.
+	bool useEngineFont = false;
+
 	GUITable* getTable(const std::string &tablename);
 	std::vector<std::string>* getDropDownValues(const std::string &name);
 


### PR DESCRIPTION
This changes the client to render settings and pause menu using the default fonts set outside the game. A game may override used fonts like `mono` and `regular` but with this change, those fonts are no longer used for the pause menu, options, and volume setting.

The skin font (used as default by engine GUI elements) is now set to the engine-only font, preventing games from affecting engine UI appearance. Since the chat overlay previously relied on the skin font as a fallback, it would also lose game fonts. To fix this, FontEngine gains a refresh callback mechanism: GameUI registers a callback that updates the chat overlay font whenever fonts are reloaded (e.g. when server media arrives), ensuring it always uses the appropriate game font.