### PR TITLE
Add highlight_color, highlight_textcolor style props, and tooltip styling via style_type in formspecs.

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3691,12 +3691,16 @@ Some types may inherit styles from parent types.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * sound - a sound to be played when triggered.
 * dropdown
+    * highlight_color - color, sets the selection highlight background color.
+    * highlight_textcolor - color, sets the selection highlight text color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * sound - a sound to be played when the entry is changed.
 * field, pwdfield, textarea
     * border - set to false to hide the textbox background and border. Default true.
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
+    * highlight_color - color, sets the text selection highlight background color.
+    * highlight_textcolor - color, sets the text selection highlight text color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * textcolor - color. Default white.
 * model
@@ -3735,6 +3739,8 @@ Some types may inherit styles from parent types.
 * table, textlist
     * font - Sets font type. See button `font` property for more information.
     * font_size - Sets font size. See button `font_size` property for more information.
+    * highlight_color - color, sets the selection highlight background color.
+    * highlight_textcolor - color, sets the selection highlight text color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 
 ### Valid States

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3630,6 +3630,7 @@ Some types may inherit styles from parent types.
 * table
 * textarea
 * textlist
+* tooltip
 * vertlabel, inherits from label
 
 
@@ -3742,6 +3743,17 @@ Some types may inherit styles from parent types.
     * highlight_color - color, sets the selection highlight background color.
     * highlight_textcolor - color, sets the selection highlight text color.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+* tooltip
+    * bgcolor - color, sets tooltip background color. Default `#6E823CFF`.
+    * textcolor - color, sets tooltip text color. Default white.
+    * bgimg - texture, sets a 9-slice background image replacing the solid color fill.
+    * bgimg_middle - rect, defines the middle rect for 9-slice rendering of bgimg.
+                     See background9[] documentation for more details.
+    * border - boolean, show the default 3D sunken border. Default true.
+              Ignored when `bordercolor` is set.
+    * bordercolor - color, draws a flat colored border instead of the 3D sunken border.
+    * borderwidths - rect, sets border thickness per side when using bordercolor.
+                     Accepts 1, 2, or 4 values (like CSS). Default `1`.
 
 ### Valid States
 

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -572,6 +572,34 @@ mouse control = true]
 			dropdown[6.5,8.5;5,0.8;hl_dropdown2;Option 1,Option 2,Option 3;1]
 			table[6.5,10;5,2.5;hl_table2;One,Two,Three,Four,Five;1]
 		]],
+
+	-- Tooltip (border)
+		[[
+			formspec_version[3]
+			size[12,13]
+			style_type[tooltip;bgcolor=#000000CC;textcolor=#FFD700;bordercolor=#FFD700;borderwidths=2]
+			label[0.5,0.5;Styled tooltips: black bg, gold text, gold 2px border]
+			button[0.5,1;4,0.8;tt_btn1;Hover for styled tooltip]
+			tooltip[tt_btn1;This tooltip has custom colors]
+			button[0.5,2.5;4,0.8;tt_btn2;Another styled tooltip]
+			tooltip[tt_btn2;Gold text on dark background with a gold border]
+			tooltip[5.5,1;5,1.5;Area tooltip with styling too]
+			label[0.5,5;Per-tooltip color override (cyan on purple)]
+			button[0.5,6;4,0.8;tt_btn3;Hover for per-tooltip colors]
+			tooltip[tt_btn3;Per-tooltip colors override style_type;#800080;#00FFFF]
+		]],
+
+	-- Tooltip (9-slice)
+		[[
+			formspec_version[3]
+			size[12,13]
+			style_type[tooltip;bgimg=testformspec_bg_9slice.png;bgimg_middle=4,6;border=false;textcolor=#FFFFFF;bgcolor=#00000000]
+			label[0.5,0.5;9-slice background tooltip — compare with Styles tab 9-Slice Bg button]
+			button[0.5,1;4,0.8;tt_btn5;Hover for 9-slice tooltip]
+			tooltip[tt_btn5;This tooltip uses a 9-slice background image]
+			button[0.5,2.5;4,0.8;tt_btn6;Another 9-slice tooltip]
+			tooltip[tt_btn6;Same 9-slice texture as the button on the Styles tab;#00000000;#FFD700]
+		]],
 }
 
 local page_id = 2
@@ -581,7 +609,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized,Highlight;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized,Highlight,TT Border,TT 9slice;" .. page_id .. ";false;false]"
 
 	core.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -551,6 +551,27 @@ mouse control = true]
 			background9[0,0;0,0;testformspec_bg_9slice.png;true;4,6]
 			background[1,1;0,0;testformspec_bg.png;true]
 		]],
+
+	-- Highlight
+		[[
+			formspec_version[3]
+			size[12,13]
+			style_type[*;highlight_color=#FF000080;highlight_textcolor=#00FF00]
+			label[0.5,0.5;Highlight colors: red background, green text]
+			field[0.5,1;5,0.8;hl_field;Styled field;select this text]
+			textarea[0.5,2.5;5,2;hl_textarea;Styled textarea;select some of this text to see highlight colors]
+			textlist[0.5,5;5,3;hl_textlist;Item 1,Item 2,Item 3,Item 4,Item 5;1;false]
+			dropdown[0.5,8.5;5,0.8;hl_dropdown;Option 1,Option 2,Option 3;1]
+			tableoptions[background=#00000055;border=false]
+			table[0.5,10;5,2.5;hl_table;One,Two,Three,Four,Five;1]
+			label[6.5,0.5;Default highlight colors (no style)]
+			style_type[*;highlight_color=;highlight_textcolor=]
+			field[6.5,1;5,0.8;hl_field2;Default field;select this text]
+			textarea[6.5,2.5;5,2;hl_textarea2;Default textarea;select some of this text for default highlight]
+			textlist[6.5,5;5,3;hl_textlist2;Item 1,Item 2,Item 3,Item 4,Item 5;1;false]
+			dropdown[6.5,8.5;5,0.8;hl_dropdown2;Option 1,Option 2,Option 3;1]
+			table[6.5,10;5,2.5;hl_table2;One,Two,Three,Four,Five;1]
+		]],
 }
 
 local page_id = 2
@@ -560,7 +581,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized,Highlight;" .. page_id .. ";false;false]"
 
 	core.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/irr/include/CGUIEditBox.h
+++ b/irr/include/CGUIEditBox.h
@@ -141,6 +141,12 @@ public:
 	//! set true if this EditBox is writable
 	void setWritable(bool writable) { IsWritable = writable; setTabStop(writable); }
 
+	//! Sets the color used for the selection highlight
+	void setHighlightColor(video::SColor color) override { HighlightColor = color; HighlightColorEnabled = true; }
+
+	//! Sets the color used for text in the selection highlight
+	void setHighlightTextColor(video::SColor color) override { HighlightTextColor = color; HighlightTextColorEnabled = true; }
+
 protected:
 	//! Breaks the single text line.
 	void breakText();
@@ -191,6 +197,10 @@ protected:
 
 	video::SColor OverrideBgColor = 0;
 	video::SColor OverrideColor;
+	video::SColor HighlightColor;
+	video::SColor HighlightTextColor;
+	bool HighlightColorEnabled = false;
+	bool HighlightTextColorEnabled = false;
 	gui::IGUIFont *OverrideFont, *LastBreakFont;
 	IOSOperator *Operator;
 

--- a/irr/include/IGUIComboBox.h
+++ b/irr/include/IGUIComboBox.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "IGUIElement.h"
+#include "SColor.h"
 
 namespace gui
 {
@@ -64,6 +65,12 @@ public:
 
 	//! Get the maximal number of rows for the selection listbox
 	virtual u32 getMaxSelectionRows() const = 0;
+
+	//! Sets the color used for the selection highlight background
+	virtual void setHighlightColor(video::SColor color) {}
+
+	//! Sets the color used for text in the selection highlight
+	virtual void setHighlightTextColor(video::SColor color) {}
 };
 
 } // end namespace gui

--- a/irr/include/IGUIEditBox.h
+++ b/irr/include/IGUIEditBox.h
@@ -143,6 +143,12 @@ public:
 
 	//! Get the cursor blinktime
 	virtual u32 getCursorBlinkTime() const = 0;
+
+	//! Sets the color used for the selection highlight background
+	virtual void setHighlightColor(video::SColor color) {}
+
+	//! Sets the color used for text in the selection highlight
+	virtual void setHighlightTextColor(video::SColor color) {}
 };
 
 } // end namespace gui

--- a/irr/include/IGUIListBox.h
+++ b/irr/include/IGUIListBox.h
@@ -128,6 +128,12 @@ public:
 
 	//! Access the vertical scrollbar
 	virtual IGUIScrollBar *getVerticalScrollBar() const = 0;
+
+	//! Sets the color used for the selection highlight background
+	virtual void setHighlightColor(video::SColor color) {}
+
+	//! Sets the color used for text in the selection highlight
+	virtual void setHighlightTextColor(video::SColor color) {}
 };
 
 } // end namespace gui

--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -374,10 +374,14 @@ void CGUIComboBox::draw()
 	}
 
 	// set colors each time as skin-colors can be changed
-	SelectedText->setBackgroundColor(skin->getColor(EGDC_HIGH_LIGHT));
+	SelectedText->setBackgroundColor(
+			HighlightColorEnabled ? HighlightColor : skin->getColor(EGDC_HIGH_LIGHT));
 	if (isEnabled()) {
 		SelectedText->setDrawBackground(HasFocus);
-		SelectedText->setOverrideColor(skin->getColor(HasFocus ? EGDC_HIGH_LIGHT_TEXT : EGDC_BUTTON_TEXT));
+		video::SColor textColor = HasFocus
+				? (HighlightTextColorEnabled ? HighlightTextColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT))
+				: skin->getColor(EGDC_BUTTON_TEXT);
+		SelectedText->setOverrideColor(textColor);
 	} else {
 		SelectedText->setDrawBackground(false);
 		SelectedText->setOverrideColor(skin->getColor(EGDC_GRAY_TEXT));
@@ -447,6 +451,11 @@ void CGUIComboBox::openCloseMenu()
 			ListBox->addItem(Items[i].Name.c_str());
 
 		ListBox->setSelected(Selected);
+
+		if (HighlightColorEnabled)
+			ListBox->setHighlightColor(HighlightColor);
+		if (HighlightTextColorEnabled)
+			ListBox->setHighlightTextColor(HighlightTextColor);
 
 		// set focus
 		Environment->setFocus(ListBox);

--- a/irr/src/CGUIComboBox.h
+++ b/irr/src/CGUIComboBox.h
@@ -71,6 +71,12 @@ public:
 	//! draws the element and its children
 	void draw() override;
 
+	//! Sets the color used for the selection highlight
+	void setHighlightColor(video::SColor color) override { HighlightColor = color; HighlightColorEnabled = true; }
+
+	//! Sets the color used for text in the selection highlight
+	void setHighlightTextColor(video::SColor color) override { HighlightTextColor = color; HighlightTextColorEnabled = true; }
+
 private:
 	void openCloseMenu();
 	void sendSelectionChangedEvent();
@@ -96,6 +102,10 @@ private:
 	u32 MaxSelectionRows;
 	bool HasFocus;
 	IGUIFont *ActiveFont;
+	video::SColor HighlightColor;
+	video::SColor HighlightTextColor;
+	bool HighlightColorEnabled = false;
+	bool HighlightTextColorEnabled = false;
 };
 
 } // end namespace gui

--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -853,14 +853,17 @@ void CGUIEditBox::draw()
 					CurrentTextRect.LowerRightCorner.X = CurrentTextRect.UpperLeftCorner.X + mend - mbegin;
 
 					// draw mark
-					skin->draw2DRectangle(this, skin->getColor(EGDC_HIGH_LIGHT), CurrentTextRect, &localClipRect);
+					skin->draw2DRectangle(this,
+							HighlightColorEnabled ? HighlightColor : skin->getColor(EGDC_HIGH_LIGHT),
+							CurrentTextRect, &localClipRect);
 
 					// draw marked text
 					s = txtLine->subString(lineStartPos, lineEndPos - lineStartPos);
 
 					if (s.size())
 						font->draw(s.c_str(), CurrentTextRect,
-								OverrideColorEnabled ? OverrideColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT),
+								HighlightTextColorEnabled ? HighlightTextColor :
+								(OverrideColorEnabled ? OverrideColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT)),
 								false, true, &localClipRect);
 				}
 			}
@@ -893,9 +896,12 @@ void CGUIEditBox::draw()
 					if (mend <= 0)
 						mend = font->getDimension(CursorChar.c_str()).Width;
 					CurrentTextRect.LowerRightCorner.X = CurrentTextRect.UpperLeftCorner.X + mend;
-					skin->draw2DRectangle(this, skin->getColor(EGDC_HIGH_LIGHT), CurrentTextRect, &localClipRect);
+					skin->draw2DRectangle(this,
+							HighlightColorEnabled ? HighlightColor : skin->getColor(EGDC_HIGH_LIGHT),
+							CurrentTextRect, &localClipRect);
 					font->draw(character.c_str(), CurrentTextRect,
-							OverrideColorEnabled ? OverrideColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT),
+							HighlightTextColorEnabled ? HighlightTextColor :
+							(OverrideColorEnabled ? OverrideColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT)),
 							false, true, &localClipRect);
 				} else {
 					font->draw(CursorChar, CurrentTextRect,

--- a/irr/src/CGUIListBox.cpp
+++ b/irr/src/CGUIListBox.cpp
@@ -469,7 +469,9 @@ void CGUIListBox::draw()
 		if (frameRect.LowerRightCorner.Y >= AbsoluteRect.UpperLeftCorner.Y &&
 				frameRect.UpperLeftCorner.Y <= AbsoluteRect.LowerRightCorner.Y) {
 			if (i == Selected && hl)
-				skin->draw2DRectangle(this, skin->getColor(EGDC_HIGH_LIGHT), frameRect, &clientClip);
+				skin->draw2DRectangle(this,
+						HighlightColorEnabled ? HighlightColor : skin->getColor(EGDC_HIGH_LIGHT),
+						frameRect, &clientClip);
 
 			core::rect<s32> textRect = frameRect;
 			textRect.UpperLeftCorner.X += 3;
@@ -706,7 +708,7 @@ video::SColor CGUIListBox::getItemDefaultColor(EGUI_LISTBOX_COLOR colorType) con
 	case EGUI_LBC_TEXT:
 		return skin->getColor(EGDC_BUTTON_TEXT);
 	case EGUI_LBC_TEXT_HIGHLIGHT:
-		return skin->getColor(EGDC_HIGH_LIGHT_TEXT);
+		return HighlightTextColorEnabled ? HighlightTextColor : skin->getColor(EGDC_HIGH_LIGHT_TEXT);
 	case EGUI_LBC_ICON:
 		return skin->getColor(EGDC_ICON);
 	case EGUI_LBC_ICON_HIGHLIGHT:

--- a/irr/src/CGUIListBox.h
+++ b/irr/src/CGUIListBox.h
@@ -122,6 +122,12 @@ public:
 	//! Access the vertical scrollbar
 	IGUIScrollBar *getVerticalScrollBar() const override;
 
+	//! Sets the color used for the selection highlight
+	void setHighlightColor(video::SColor color) override { HighlightColor = color; HighlightColorEnabled = true; }
+
+	//! Sets the color used for text in the selection highlight
+	void setHighlightTextColor(video::SColor color) override { HighlightTextColor = color; HighlightTextColorEnabled = true; }
+
 private:
 	struct ListItem
 	{
@@ -165,6 +171,10 @@ private:
 	bool MoveOverSelect;
 	bool AutoScroll;
 	bool HighlightWhenNotFocused;
+	video::SColor HighlightColor;
+	video::SColor HighlightTextColor;
+	bool HighlightColorEnabled = false;
+	bool HighlightTextColorEnabled = false;
 };
 
 } // end namespace gui

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -44,6 +44,8 @@ public:
 		SOUND,
 		SPACING,
 		SIZE,
+		HIGHLIGHT_COLOR,
+		HIGHLIGHT_TEXTCOLOR,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -117,6 +119,10 @@ public:
 			return SPACING;
 		} else if (name == "size") {
 			return SIZE;
+		} else if (name == "highlight_color") {
+			return HIGHLIGHT_COLOR;
+		} else if (name == "highlight_textcolor") {
+			return HIGHLIGHT_TEXTCOLOR;
 		} else {
 			return NONE;
 		}

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -46,6 +46,7 @@ public:
 		SIZE,
 		HIGHLIGHT_COLOR,
 		HIGHLIGHT_TEXTCOLOR,
+		BORDERCOLOR,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -123,6 +124,8 @@ public:
 			return HIGHLIGHT_COLOR;
 		} else if (name == "highlight_textcolor") {
 			return HIGHLIGHT_TEXTCOLOR;
+		} else if (name == "bordercolor") {
+			return BORDERCOLOR;
 		} else {
 			return NONE;
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1245,6 +1245,11 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 
 	e->setTable(data->table_options, data->table_columns, items);
 
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_COLOR))
+		e->setHighlightColor(style.getColor(StyleSpec::HIGHLIGHT_COLOR));
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_TEXTCOLOR))
+		e->setHighlightTextColor(style.getColor(StyleSpec::HIGHLIGHT_TEXTCOLOR));
+
 	if (data->table_dyndata.find(name) != data->table_dyndata.end()) {
 		e->setDynamicData(data->table_dyndata[name]);
 	}
@@ -1328,6 +1333,11 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	e->setOverrideFont(style.getFont());
 
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_COLOR))
+		e->setHighlightColor(style.getColor(StyleSpec::HIGHLIGHT_COLOR));
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_TEXTCOLOR))
+		e->setHighlightTextColor(style.getColor(StyleSpec::HIGHLIGHT_TEXTCOLOR));
+
 	m_tables.emplace_back(spec, e);
 	m_fields.push_back(spec);
 }
@@ -1403,6 +1413,11 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 	spec.sound = style.get(StyleSpec::Property::SOUND, "");
 
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_COLOR))
+		e->setHighlightColor(style.getColor(StyleSpec::HIGHLIGHT_COLOR));
+	if (style.isNotDefault(StyleSpec::HIGHLIGHT_TEXTCOLOR))
+		e->setHighlightTextColor(style.getColor(StyleSpec::HIGHLIGHT_TEXTCOLOR));
 
 	m_fields.push_back(spec);
 
@@ -1570,6 +1585,11 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		e->setDrawBorder(border);
 		e->setDrawBackground(border);
 		e->setOverrideFont(style.getFont());
+
+		if (style.isNotDefault(StyleSpec::HIGHLIGHT_COLOR))
+			e->setHighlightColor(style.getColor(StyleSpec::HIGHLIGHT_COLOR));
+		if (style.isNotDefault(StyleSpec::HIGHLIGHT_TEXTCOLOR))
+			e->setHighlightTextColor(style.getColor(StyleSpec::HIGHLIGHT_TEXTCOLOR));
 
 		e->drop();
 	}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2409,7 +2409,8 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 	// Read colors
 	video::SColor bgcolor = m_default_tooltip_bgcolor;
 	video::SColor color   = m_default_tooltip_color;
-	if (parts.size() == base_size + 2 &&
+	bool explicit_colors = (parts.size() == base_size + 2);
+	if (explicit_colors &&
 			(!parseColorString(parts[base_size], bgcolor, false) ||
 				!parseColorString(parts[base_size + 1], color, false))) {
 		errorstream << "Invalid color in tooltip element(" << parts.size()
@@ -2419,7 +2420,7 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 
 	// Make tooltip spec
 	std::string text = unescape_string(parts[rect_mode ? 2 : 1]);
-	TooltipSpec spec(utf8_to_wide(text), bgcolor, color);
+	TooltipSpec spec(utf8_to_wide(text), bgcolor, color, explicit_colors);
 
 	// Add tooltip
 	if (rect_mode) {
@@ -3081,6 +3082,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
 	m_default_tooltip_color = video::SColor(255,255,255,255);
+	m_tooltip_bgimg = nullptr;
+	m_tooltip_bgimg_middle = core::rect<s32>();
+	m_tooltip_border = true;
+	m_tooltip_has_bordercolor = false;
+	m_tooltip_borderwidths = core::rect<s32>(1, 1, -1, -1);
 
 	// Add tooltip
 	{
@@ -3288,6 +3294,50 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	} else if (!container_stack.empty()) {
 		errorstream << "Invalid formspec string: container was never closed!"
 			<< std::endl;
+	}
+
+	// Apply tooltip styling from style_type[tooltip;...]
+	{
+		auto tooltip_style = getDefaultStyleForElement("tooltip", "");
+
+		if (tooltip_style.isNotDefault(StyleSpec::BGCOLOR))
+			m_default_tooltip_bgcolor = tooltip_style.getColor(StyleSpec::BGCOLOR);
+		if (tooltip_style.isNotDefault(StyleSpec::TEXTCOLOR))
+			m_default_tooltip_color = tooltip_style.getColor(StyleSpec::TEXTCOLOR);
+
+		m_tooltip_bgimg = tooltip_style.getTexture(StyleSpec::BGIMG, m_tsrc, nullptr);
+		m_tooltip_bgimg_middle = tooltip_style.getRect(StyleSpec::BGIMG_MIDDLE,
+				core::rect<s32>());
+		m_tooltip_border = tooltip_style.getBool(StyleSpec::BORDER, true);
+		m_tooltip_has_bordercolor = tooltip_style.isNotDefault(StyleSpec::BORDERCOLOR);
+		if (m_tooltip_has_bordercolor)
+			m_tooltip_bordercolor = tooltip_style.getColor(StyleSpec::BORDERCOLOR);
+		m_tooltip_borderwidths = tooltip_style.getRect(StyleSpec::BORDERWIDTHS,
+				core::rect<s32>(1, 1, -1, -1));
+
+		// Update tooltips that were created during parsing with old defaults.
+		// Only update tooltips without explicit per-tooltip colors.
+		for (auto &pair : m_tooltips) {
+			if (!pair.second.explicit_colors) {
+				pair.second.bgcolor = m_default_tooltip_bgcolor;
+				pair.second.color = m_default_tooltip_color;
+			}
+		}
+		for (auto &pair : m_tooltip_rects) {
+			if (!pair.second.explicit_colors) {
+				pair.second.bgcolor = m_default_tooltip_bgcolor;
+				pair.second.color = m_default_tooltip_color;
+			}
+		}
+
+		// Update the tooltip element with resolved style.
+		// When we draw custom borders or bgimg, disable the element's own
+		// background so the GUI tree's second draw pass doesn't cover them.
+		bool custom_draw = m_tooltip_has_bordercolor || m_tooltip_bgimg;
+		m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
+		m_tooltip_element->setOverrideColor(m_default_tooltip_color);
+		m_tooltip_element->setDrawBorder(!m_tooltip_has_bordercolor && m_tooltip_border);
+		m_tooltip_element->setDrawBackground(!custom_draw);
 	}
 
 	// get the scrollbar elements for scroll_containers
@@ -3660,7 +3710,72 @@ void GUIFormSpecMenu::drawMenu()
 				rect.LowerRightCorner.X, rect.LowerRightCorner.Y), nullptr);
 	}
 
+	// Draw custom tooltip background before the text element.
+	// We handle this ourselves when using bordercolor or bgimg so that
+	// the GUI tree's second draw pass (with bg disabled) won't cover our borders.
+	// The element rect is the inner text area; expand to the outer rect for drawing.
+	if (m_tooltip_element->isVisible() && (m_tooltip_has_bordercolor || m_tooltip_bgimg)) {
+		core::rect<s32> inner = m_tooltip_element->getAbsolutePosition();
+		core::rect<s32> tt_rect(
+				inner.UpperLeftCorner - m_tooltip_bgimg_middle.UpperLeftCorner,
+				inner.LowerRightCorner - m_tooltip_bgimg_middle.LowerRightCorner);
+		if (m_tooltip_has_bordercolor && !m_tooltip_bgimg)
+			tt_rect = core::rect<s32>(
+				inner.UpperLeftCorner - m_tooltip_borderwidths.UpperLeftCorner,
+				inner.LowerRightCorner - m_tooltip_borderwidths.LowerRightCorner);
+
+		if (m_tooltip_bgimg) {
+			core::rect<s32> srcrect(core::position2d<s32>(0, 0),
+					m_tooltip_bgimg->getOriginalSize());
+			draw2DImage9Slice(driver, m_tooltip_bgimg, tt_rect, srcrect,
+					m_tooltip_bgimg_middle);
+		} else {
+			driver->draw2DRectangle(m_tooltip_element->getBackgroundColor(),
+					tt_rect);
+		}
+	}
+
 	m_tooltip_element->draw();
+
+	// Draw custom tooltip border on top, then hide the element so the
+	// GUI tree's subsequent draw pass doesn't redraw over our borders.
+	if (m_tooltip_element->isVisible() && m_tooltip_has_bordercolor) {
+		core::rect<s32> inner = m_tooltip_element->getAbsolutePosition();
+		core::rect<s32> tt_rect;
+		if (m_tooltip_bgimg)
+			tt_rect = core::rect<s32>(
+				inner.UpperLeftCorner - m_tooltip_bgimg_middle.UpperLeftCorner,
+				inner.LowerRightCorner - m_tooltip_bgimg_middle.LowerRightCorner);
+		else
+			tt_rect = core::rect<s32>(
+				inner.UpperLeftCorner - m_tooltip_borderwidths.UpperLeftCorner,
+				inner.LowerRightCorner - m_tooltip_borderwidths.LowerRightCorner);
+		// borderwidths: UpperLeft = (left, top), LowerRight = (-right, -bottom)
+		s32 bw_top    = m_tooltip_borderwidths.UpperLeftCorner.Y;
+		s32 bw_right  = -m_tooltip_borderwidths.LowerRightCorner.X;
+		s32 bw_bottom = -m_tooltip_borderwidths.LowerRightCorner.Y;
+		s32 bw_left   = m_tooltip_borderwidths.UpperLeftCorner.X;
+		// top
+		driver->draw2DRectangle(m_tooltip_bordercolor,
+			core::rect<s32>(tt_rect.UpperLeftCorner.X, tt_rect.UpperLeftCorner.Y,
+				tt_rect.LowerRightCorner.X, tt_rect.UpperLeftCorner.Y + bw_top));
+		// bottom
+		driver->draw2DRectangle(m_tooltip_bordercolor,
+			core::rect<s32>(tt_rect.UpperLeftCorner.X, tt_rect.LowerRightCorner.Y - bw_bottom,
+				tt_rect.LowerRightCorner.X, tt_rect.LowerRightCorner.Y));
+		// left
+		driver->draw2DRectangle(m_tooltip_bordercolor,
+			core::rect<s32>(tt_rect.UpperLeftCorner.X, tt_rect.UpperLeftCorner.Y + bw_top,
+				tt_rect.UpperLeftCorner.X + bw_left, tt_rect.LowerRightCorner.Y - bw_bottom));
+		// right
+		driver->draw2DRectangle(m_tooltip_bordercolor,
+			core::rect<s32>(tt_rect.LowerRightCorner.X - bw_right, tt_rect.UpperLeftCorner.Y + bw_top,
+				tt_rect.LowerRightCorner.X, tt_rect.LowerRightCorner.Y - bw_bottom));
+
+		m_tooltip_element->setVisible(false);
+	} else if (m_tooltip_element->isVisible() && m_tooltip_bgimg) {
+		m_tooltip_element->setVisible(false);
+	}
 
 	/*
 		Draw dragged item stack
@@ -3681,9 +3796,36 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 
 	setStaticText(m_tooltip_element, ntext);
 
+	// Update element background for per-tooltip color overrides.
+	// setStaticText/setBackgroundColor re-enable Background, so we must
+	// re-disable it when drawing background/borders ourselves.
+	if (m_tooltip_has_bordercolor || m_tooltip_bgimg) {
+		m_tooltip_element->setDrawBackground(false);
+	} else {
+		m_tooltip_element->setBackgroundColor(bgcolor);
+	}
+
 	// Tooltip size and offset
 	s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
 	s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
+
+	// Add extra space for 9-slice margins or custom border widths.
+	// The padding offsets the text element within the outer tooltip rect
+	// so text is centered within the inner content area.
+	s32 pad_left = 0, pad_top = 0, pad_right = 0, pad_bottom = 0;
+	if (m_tooltip_bgimg) {
+		pad_left   = m_tooltip_bgimg_middle.UpperLeftCorner.X;
+		pad_top    = m_tooltip_bgimg_middle.UpperLeftCorner.Y;
+		pad_right  = -m_tooltip_bgimg_middle.LowerRightCorner.X;
+		pad_bottom = -m_tooltip_bgimg_middle.LowerRightCorner.Y;
+	} else if (m_tooltip_has_bordercolor) {
+		pad_left   = m_tooltip_borderwidths.UpperLeftCorner.X;
+		pad_top    = m_tooltip_borderwidths.UpperLeftCorner.Y;
+		pad_right  = -m_tooltip_borderwidths.LowerRightCorner.X;
+		pad_bottom = -m_tooltip_borderwidths.LowerRightCorner.Y;
+	}
+	tooltip_width += pad_left + pad_right;
+	tooltip_height += pad_top + pad_bottom;
 
 	v2u32 screenSize = Environment->getVideoDriver()->getScreenSize();
 	int tooltip_offset_x = m_btn_height;
@@ -3719,10 +3861,13 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 		break;
 	}
 
+	// Position the text element inset by padding so text is centered
+	// within the inner content area (inside 9-slice borders or flat borders).
 	m_tooltip_element->setRelativePosition(
 		core::rect<s32>(
-			core::position2d<s32>(tooltip_x, tooltip_y),
-			core::dimension2d<s32>(tooltip_width, tooltip_height)
+			tooltip_x + pad_left, tooltip_y + pad_top,
+			tooltip_x + tooltip_width - pad_right,
+			tooltip_y + tooltip_height - pad_bottom
 		)
 	);
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -137,16 +137,18 @@ class GUIFormSpecMenu : public GUIModalMenu
 	{
 		TooltipSpec() = default;
 		TooltipSpec(const std::wstring &a_tooltip, video::SColor a_bgcolor,
-				video::SColor a_color):
+				video::SColor a_color, bool a_explicit_colors = false):
 			tooltip(translate_string(a_tooltip)),
 			bgcolor(a_bgcolor),
-			color(a_color)
+			color(a_color),
+			explicit_colors(a_explicit_colors)
 		{
 		}
 
 		std::wstring tooltip;
 		video::SColor bgcolor;
 		video::SColor color;
+		bool explicit_colors = false;
 	};
 
 public:
@@ -376,6 +378,12 @@ protected:
 	video::SColor m_fullscreen_bgcolor;
 	video::SColor m_default_tooltip_bgcolor;
 	video::SColor m_default_tooltip_color;
+	video::ITexture *m_tooltip_bgimg = nullptr;
+	core::rect<s32> m_tooltip_bgimg_middle;
+	bool m_tooltip_border = true;
+	bool m_tooltip_has_bordercolor = false;
+	video::SColor m_tooltip_bordercolor;
+	core::rect<s32> m_tooltip_borderwidths = core::rect<s32>(1, 1, -1, -1);
 
 private:
 	IFormSource               *m_form_src;

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -118,6 +118,12 @@ public:
 	/* Set selection, scroll position and opened (sub)trees */
 	void setDynamicData(const DynamicData &dyndata);
 
+	//! Sets the color used for the selection highlight
+	void setHighlightColor(video::SColor color) { m_highlight = color; }
+
+	//! Sets the color used for text in the selection highlight
+	void setHighlightTextColor(video::SColor color) { m_highlight_text = color; }
+
 	/* Must be called when position or size changes */
 	virtual void updateAbsolutePosition();
 


### PR DESCRIPTION
Allow games to customize tooltip appearance through the style system:
- bgcolor/textcolor: override default tooltip colors
- bgimg/bgimg_middle: 9-slice background image
- border: enable/disable the 3D sunken border
- bordercolor/borderwidths: flat colored border with custom thickness
    
The tooltip element is drawn once explicitly in drawMenu() with custom
background and borders, then hidden so the GUI tree's second draw pass
doesn't overwrite the custom rendering.

Allow games to control the selection/highlight colors in formspec elements
via style[] and style_type[] properties. Previously these were hardcoded
to skin defaults (green highlight, white text) with no way to override
them to match a custom UI theme.
    
Supported elements: field, textarea, textlist, table, dropdown.
