### PR TITLE
Add bounds check for from_i in IDropAction::apply()

### DIFF
--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -686,6 +686,13 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 				<<"from_inv=\""<<from_inv.dump()<<"\""<<std::endl;
 		return;
 	}
+	if (from_i < 0 || list_from->getSize() <= (u32) from_i) {
+		warningstream << "IDropAction::apply(): FAIL: index " << from_i
+			<< " out of bounds (list \"" << from_list << "\", size "
+			<< list_from->getSize() << "), player=\""
+			<< player->getDescription() << "\"" << std::endl;
+		return;
+	}
 	ItemStack src_item = list_from->getItem(from_i);
 	if (src_item.empty()) {
 		infostream<<"IDropAction::apply(): FAIL: source item not found: "


### PR DESCRIPTION
IDropAction::apply() accessed list_from->getItem(from_i) without validating that from_i is within the inventory list bounds. In release builds, InventoryList::getItem() only guards this with an assert, so an out-of-bounds index causes undefined behavior.

A malicious client can exploit this by sending a crafted TOSERVER_INVENTORY_ACTION packet with a Drop action containing an arbitrary from_i value, crashing the server via segfault:

This was reproduced using a custom network packet fuzzer I made a long time ago.

IMoveAction::apply() already had the equivalent bounds check (lines 325-330). This adds the same check to IDropAction::apply().

This fixes the crash referenced in #11526.