### PR TITLE
Fix setAsyncFatalError() on shutdown causing UaF

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -446,7 +446,7 @@ Server::~Server()
 	// Catch one async error that just happened while this dtor is running
 	auto async_fatal_error = m_async_fatal_error.get();
 	if (old_async_fatal_error != async_fatal_error) {
-		errorstream << "~Server(): new AsyncErr: " << async_fatal_error;
+		errorstream << "Server: new AsyncErr during shutdown: " << async_fatal_error;
 	}
 
 	// Delete the rest in the reverse order of creation


### PR DESCRIPTION
Destruction order was wrong.
Async threads can error while `~Server()` is running.

Essentially what can happen is:

* Server shuts down. (E.g. because one async task errored and set the async error. But can also be any other reason, i.e. a normal server shutdown.)
* `~Server()` is called. It deletes `Server::m_thread`.
* An async or emerge thread errors, therefore calls `setAsyncFatalError()`.
  This accesses the deleted `Server::m_thread` (tries to call `stop()` on it).

## To do

This PR is a Ready for Review.

## How to test

Compile with asan.

```lua
for i = 1, 100 do
	core.handle_async(function()
		local t0 = os.clock()
		while os.clock() < t0 + 3 do end
		error()
	end, function() end)
end
```

Alternatively just this, and press esc in main menu while starting the server, to cause a game shutdown:
```lua
core.handle_async(function()
	local t0 = os.clock()
	while os.clock() < t0 + 10 do end
	error()
end, function() end)
```

In master with asan, asan catches a UaF. In PR it errors and exits properly ((sometimes I get a short lime green screen, interestingly)).