### PR TITLE
Fix node placement sound disabled when prediction is empty

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3002,6 +3002,8 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 			!isKeyDown(KeyType::SNEAK))) {
 		// Report to server
 		client->interact(INTERACT_PLACE, pointed);
+		// Play placement sound even without prediction
+		soundmaker->m_player_rightpunch_sound = selected_def.sound_place;
 		return false;
 	}
 


### PR DESCRIPTION
## Problem

Setting `node_placement_prediction = ""` in a node definition unintentionally disables the node placement sound. Users who want to disable visual prediction without losing the sound effect cannot do so.

## Solution

Separated the prediction logic from the sound logic. Empty prediction no longer affects sound playback - sounds play independently of whether prediction is enabled.

## Validation

```lua
-- Place node with empty prediction
node_placement_prediction = ""

-- Sound plays correctly
-- Prediction is disabled
-- ✅ Both behaviors work independently
```

Fixes #12753