### PR TITLE
Render text to node faces client-side.

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -651,6 +651,22 @@ function core.get_background_escape_sequence(color)
 	return ESCAPE_CHAR .. "(b@" .. color .. ")"
 end
 
+function core.get_font_size_escape_sequence(size)
+	return ESCAPE_CHAR .. "(s@" .. size .. ")"
+end
+
+function core.get_font_escape_sequence(font)
+	return ESCAPE_CHAR .. "(f@" .. font .. ")"
+end
+
+function core.get_font_weight_escape_sequence(weight)
+	return ESCAPE_CHAR .. "(w@" .. weight .. ")"
+end
+
+function core.get_alignment_escape_sequence(alignment)
+	return ESCAPE_CHAR .. "(a@" .. alignment .. ")"
+end
+
 function core.colorize(color, message)
 	local lines = tostring(message):split("\n", true)
 	local color_code = core.get_color_escape_sequence(color)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -931,6 +931,57 @@ embedding a whole image, this may vary by use case.
 
 *See notes: `TEXMOD_UPSCALE`*
 
+#### `[text:<base64_text>:<rect>:<res_x>,<res_y>`
+
+Renders text using the engine's font system. When used as a modifier
+on a base texture (`base.png^[text:...`), the text is composited onto
+the base. When used standalone (`[text:...`), a transparent texture is
+created. The text content is base64-encoded to avoid conflicts with the
+texture modifier parser. Use `core.encode_base64(text)` to produce the
+encoded string.
+
+Parameters:
+
+* `base64_text`: base64-encoded text content, may contain escape
+  sequences (see below)
+* `rect`: text area in UV coordinates as `x1,y1,x2,y2` (0-1 range)
+* `res_x,res_y`: texture resolution in pixels. Default: `256,256`
+
+The text content supports the following escape sequences (using the
+`\x1b(key@value)` format, where `\x1b` is the ESC character,
+`string.char(0x1b)` in Lua):
+
+| Escape | Description | Example |
+|--------|-------------|---------|
+| `\x1b(c@<color>)` | Text color | `\x1b(c@#ff0000)` |
+| `\x1b(b@<color>)` | Background color (fills text rect) | `\x1b(b@#000000c0)` |
+| `\x1b(s@<size>)` | Font size in pixels | `\x1b(s@24)` |
+| `\x1b(f@<face>)` | Font face: `normal` or `mono` | `\x1b(f@mono)` |
+| `\x1b(w@<weight>)` | Font weight: `normal`, `bold`, `italic`, `bolditalic` | `\x1b(w@bold)` |
+| `\x1b(a@<align>)` | Horizontal alignment: `left`, `center`, `right` | `\x1b(a@center)` |
+
+Font escapes (`s@`, `f@`, `w@`, `a@`, `b@`) are parsed from the
+beginning of the text and apply to the entire text. Color escapes
+(`c@`) work per-character as in chat and HUD text. Newlines (`\n`) are
+supported. Text does not word-wrap automatically; use explicit newlines.
+
+If no font size is specified, a default of 24px (scaled proportionally
+to the texture resolution) is used.
+
+Example:
+
+    local text = core.get_font_size_escape_sequence(32)
+        .. core.get_alignment_escape_sequence("center")
+        .. core.colorize("#ffffff", "Hello World")
+    local tex = "base.png^[text:" .. core.encode_base64(text)
+        .. ":0.05,0.05,0.95,0.95:256,256"
+
+This modifier can be used on any texture — node tiles, entity
+textures, HUD elements, etc.
+
+For node tiles specifically, the `text_face` node definition field
+automates this process. See "Node definition" for details.
+
 Hardware coloring
 -----------------
 
@@ -3955,6 +4006,18 @@ The following functions provide escape sequences:
     * `color` is a ColorString
     * The escape sequence sets the background of the whole text element to
       `color`. Only defined for item descriptions and tooltips.
+* `core.get_font_size_escape_sequence(size)`
+    * `size` is a number (font size in pixels)
+    * The escape sequence sets the font size for subsequent text.
+* `core.get_font_escape_sequence(font)`
+    * `font` is `"normal"` or `"mono"`
+    * The escape sequence sets the font face for subsequent text.
+* `core.get_font_weight_escape_sequence(weight)`
+    * `weight` is `"normal"`, `"bold"`, `"italic"`, or `"bolditalic"`
+    * The escape sequence sets the font weight for subsequent text.
+* `core.get_alignment_escape_sequence(alignment)`
+    * `alignment` is `"left"`, `"center"`, or `"right"`
+    * The escape sequence sets the text alignment.
 * `core.strip_foreground_colors(str)`
     * Removes foreground colors added by `get_color_escape_sequence`.
 * `core.strip_background_colors(str)`
@@ -10558,6 +10621,42 @@ Used by `core.register_node`.
         fall = <SimpleSoundSpec>,
         -- When node starts to fall or is detached
     },
+
+    text_face = {
+        -- Optional. Renders text from node metadata onto a tile face.
+        -- The text is read from the node metadata key "text".
+        -- Supported drawtypes: normal, nodebox, signlike, mesh.
+        -- Not supported: glasslike, glasslike_framed, allfaces.
+
+        tile = 0,
+        -- Which tile index receives the text (0-5).
+        -- For normal/nodebox nodes: 0=top, 1=bottom, 2=right, 3=left,
+        -- 4=front (+Z), 5=back (-Z).
+        -- For mesh nodes: corresponds to the mesh buffer index
+        -- (determined by material groups in the OBJ/mesh file).
+
+        rect = {{x = 0, y = 0}, {x = 1, y = 1}},
+        -- Text area within the tile as two vector2 UV coordinates.
+        -- First is the top-left corner, second is the bottom-right.
+        -- Values range from 0 to 1.
+
+        resolution_x = 256,
+        resolution_y = 256,
+        -- Texture resolution in pixels for the text overlay.
+        -- Both values must be provided.
+        -- Higher values produce sharper text but use more memory.
+        -- Range: 16 to 2048. Default: 256.
+        -- Use different x/y values for non-square faces
+        -- (e.g. resolution_x = 1024, resolution_y = 341 for a
+        -- 3:1 aspect ratio sign).
+    },
+    -- Text content is stored in node metadata under the key "text".
+    -- The text supports escape sequences for styling; see the [text:
+    -- texture modifier documentation for details.
+    --
+    -- Example:
+    --   core.get_meta(pos):set_string("text",
+    --       core.colorize("#ffffff", "Hello World"))
 
     drop = "",
     -- Name of dropped item when dug.

--- a/games/devtest/mods/testtextface/init.lua
+++ b/games/devtest/mods/testtextface/init.lua
@@ -1,0 +1,513 @@
+-- Test nodes for text_face feature (#1367)
+-- Tests text rendering on various node drawtypes.
+
+testtextface = {}
+
+local ESC = string.char(0x1b) -- needed for parsing functions below
+
+local default_text = function(label)
+	return core.get_background_escape_sequence("#00000080")
+		.. core.colorize("#ffffff", label)
+end
+
+-- Shared right-click text editor
+local FORMNAME = "testtextface:edit"
+
+-- Strip escape sequences for display in formspec
+local function strip_escapes(s)
+	return core.strip_escapes(s)
+end
+
+-- Extract style prefix (all leading escape sequences before first printable char)
+local function get_style_prefix(s)
+	local prefix = ""
+	local i = 1
+	while i <= #s do
+		if s:byte(i) == 0x1b and s:sub(i+1, i+1) == "(" then
+			local j = s:find(")", i+2, true)
+			if j then
+				prefix = prefix .. s:sub(i, j)
+				i = j + 1
+			else
+				break
+			end
+		else
+			break
+		end
+	end
+	return prefix
+end
+
+-- Parse style values from the escape prefix
+local function parse_style(s)
+	local style = { size = "", font = "normal", weight = "normal",
+		color = "#ffffff", bgcolor = "", align = "left" }
+	for key, val in s:gmatch(ESC .. "%((%w)@([^%)]+)%)") do
+		if key == "s" then style.size = val
+		elseif key == "f" then style.font = val
+		elseif key == "w" then style.weight = val
+		elseif key == "c" then style.color = val
+		elseif key == "b" then style.bgcolor = val
+		elseif key == "a" then style.align = val
+		end
+	end
+	return style
+end
+
+-- Build escape prefix from style values
+local function build_style(style)
+	local s = ""
+	if style.size ~= "" then
+		s = s .. core.get_font_size_escape_sequence(style.size)
+	end
+	if style.font == "mono" then
+		s = s .. core.get_font_escape_sequence("mono")
+	end
+	if style.weight ~= "normal" and style.weight ~= "" then
+		s = s .. core.get_font_weight_escape_sequence(style.weight)
+	end
+	if style.align ~= "left" and style.align ~= "" then
+		s = s .. core.get_alignment_escape_sequence(style.align)
+	end
+	if style.bgcolor ~= "" then
+		s = s .. core.get_background_escape_sequence(style.bgcolor)
+	end
+	if style.color ~= "" then
+		s = s .. core.get_color_escape_sequence(style.color)
+	end
+	return s
+end
+
+local function tf_on_rightclick(pos, node, clicker)
+	local meta = core.get_meta(pos)
+	local name = clicker:get_player_name()
+	local raw_text = meta:get_string("text")
+	local display_text = strip_escapes(raw_text)
+	local style = parse_style(raw_text)
+
+	core.show_formspec(name, FORMNAME,
+		"formspec_version[4]" ..
+		"size[10,9]" ..
+
+		-- Text area
+		"textarea[0.5,0.3;9,3.5;text;Text;" ..
+			core.formspec_escape(display_text) .. "]" ..
+
+		-- Font size (empty = auto)
+		"label[0.5,4.3;Size (default):]" ..
+		"field[2.5,4;2,0.8;font_size;;" .. style.size .. "]" ..
+
+		-- Font face
+		"label[5,4.3;Font:]" ..
+		"dropdown[6,4;3.5,0.8;font;normal,mono;" ..
+			(style.font == "mono" and "2" or "1") .. "]" ..
+
+		-- Weight
+		"label[0.5,5.3;Weight:]" ..
+		"dropdown[2.5,5;3,0.8;weight;normal,bold,italic,bolditalic;" ..
+			(({normal=1, bold=2, italic=3, bolditalic=4})[style.weight] or 1) ..
+			"]" ..
+
+		-- Alignment
+		"label[5.5,5.3;Align:]" ..
+		"dropdown[6.5,5;3,0.8;align;left,center,right;" ..
+			(({left=1, center=2, right=3})[style.align] or 1) ..
+			"]" ..
+
+		-- Text color
+		"label[0.5,6.3;Color:]" ..
+		"field[2.5,6;3,0.8;color;;" ..
+			core.formspec_escape(style.color) .. "]" ..
+
+		-- Background color
+		"label[5.5,6.3;BG color:]" ..
+		"field[7,6;2.5,0.8;bgcolor;;" ..
+			core.formspec_escape(style.bgcolor) .. "]" ..
+
+		-- Submit
+		"button_exit[3.5,7.5;3,0.8;submit;Set Text]")
+
+	clicker:get_meta():set_string("editing_sign", core.pos_to_string(pos))
+end
+
+core.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= FORMNAME or not fields.submit then
+		return
+	end
+	local pos_str = player:get_meta():get_string("editing_sign")
+	if pos_str == "" then return end
+	local pos = core.string_to_pos(pos_str)
+	if not pos then return end
+
+	local style = {
+		size = fields.font_size or "16",
+		font = fields.font or "normal",
+		weight = fields.weight or "normal",
+		align = fields.align or "left",
+		color = fields.color or "#ffffff",
+		bgcolor = fields.bgcolor or "",
+	}
+
+	local prefix = build_style(style)
+	core.get_meta(pos):set_string("text", prefix .. (fields.text or ""))
+	player:get_meta():set_string("editing_sign", "")
+end)
+
+-- 1. Normal (top face)
+core.register_node("testtextface:normal", {
+	description = "TextFace: Normal",
+	tiles = {"default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.5}}, resolution_x = 512, resolution_y = 512 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#00000080") ..
+			core.get_color_escape_sequence("#ffcc00") .. "WELCOME" ..
+			core.get_color_escape_sequence("#ffffff") .. "\nTo the test area\n" ..
+			core.get_color_escape_sequence("#88ff88") .. "Have fun!")
+	end,
+})
+
+-- 2. Normal with text on side face (tile 2 = +X)
+core.register_node("testtextface:normal_side", {
+	description = "TextFace: Normal Side",
+	tiles = {"default_stone.png", "default_stone.png", "default_cobble.png",
+		"default_stone.png", "default_stone.png", "default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 2, rect = {{x = 0.05, y = 0.1}, {x = 0.95, y = 0.6}}, resolution_x = 512, resolution_y = 512 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#1a1a2e") ..
+			core.get_color_escape_sequence("#e94560") .. "DANGER" ..
+			core.get_color_escape_sequence("#ffffff") .. "\nKeep out!")
+	end,
+})
+
+-- 3. Nodebox (slab)
+core.register_node("testtextface:nodebox", {
+	description = "TextFace: Nodebox Slab",
+	tiles = {"default_stone.png"},
+	drawtype = "nodebox",
+	paramtype = "light",
+	paramtype2 = "facedir",
+	node_box = {
+		type = "fixed",
+		fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},
+	},
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.95}}, resolution_x = 128, resolution_y = 128 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_font_size_escape_sequence(12) ..
+			core.get_color_escape_sequence("#333333") .. "Floor plaque\n" ..
+			core.get_color_escape_sequence("#886644") .. "Est. 2026")
+	end,
+})
+
+-- 4. Signlike
+core.register_node("testtextface:signlike", {
+	description = "TextFace: Signlike",
+	tiles = {"default_stone.png"},
+	drawtype = "signlike",
+	paramtype = "light",
+	paramtype2 = "wallmounted",
+	walkable = false,
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.1}, {x = 0.95, y = 0.9}}, resolution_x = 256, resolution_y = 256 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_font_size_escape_sequence(20) ..
+			core.get_background_escape_sequence("#ffffffd0") ..
+			core.get_color_escape_sequence("#000000") .. "Wall sign\n" ..
+			core.get_color_escape_sequence("#0066cc") .. "Room 42")
+	end,
+})
+
+
+-- 8. Mesh node (cube)
+core.register_node("testtextface:mesh", {
+	description = "TextFace: Mesh Cube",
+	tiles = {"default_stone.png"},
+	drawtype = "mesh",
+	mesh = "textface_cube.obj",
+	paramtype = "light",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.1}, {x = 0.95, y = 0.6}} },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#002244e0") ..
+			core.get_color_escape_sequence("#00ffff") .. "MESH\n" ..
+			core.get_color_escape_sequence("#ffffff") .. "Cube node\n" ..
+			core.get_color_escape_sequence("#888888") .. "tile 0")
+	end,
+})
+
+-- 9. Mesh node with slanted display (2 groups: display + body)
+core.register_node("testtextface:mesh_slanted", {
+	description = "TextFace: Slanted Mesh",
+	tiles = {"default_cobble.png", "default_stone.png"},
+	drawtype = "mesh",
+	mesh = "textface_slanted.obj",
+	paramtype = "light",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.1}, {x = 0.95, y = 0.9}} },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#2d132c") ..
+			core.get_color_escape_sequence("#ee4540") .. "NOTICE\n" ..
+			core.get_color_escape_sequence("#c72c41") .. "Slanted display\n" ..
+			core.get_color_escape_sequence("#801336") .. "with angled face")
+	end,
+})
+
+-- 10. Auto-wrap test (long text, no newlines)
+core.register_node("testtextface:wrap", {
+	description = "TextFace: Wrap Test",
+	tiles = {"default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.95}} },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#f5f5dcc0") ..
+			core.get_color_escape_sequence("#333333") ..
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. " ..
+			"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+	end,
+})
+
+-- 11. Color test — rainbow + mixed styles
+core.register_node("testtextface:colors", {
+	description = "TextFace: Color Test",
+	tiles = {"default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.7}} },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_background_escape_sequence("#ffffffc0") ..
+			core.get_color_escape_sequence("#ff0000") .. "Red " ..
+			core.get_color_escape_sequence("#ff8800") .. "Orange " ..
+			core.get_color_escape_sequence("#ffff00") .. "Yellow\n" ..
+			core.get_color_escape_sequence("#00ff00") .. "Green " ..
+			core.get_color_escape_sequence("#0088ff") .. "Blue " ..
+			core.get_color_escape_sequence("#8800ff") .. "Purple\n" ..
+			core.get_color_escape_sequence("#000000") .. "Black on white bg")
+	end,
+})
+
+-- 12. Mono font
+core.register_node("testtextface:mono", {
+	description = "TextFace: Mono Font",
+	tiles = {"default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.95}}, resolution_x = 512, resolution_y = 512 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_font_size_escape_sequence(14) .. core.get_font_escape_sequence("mono") ..
+			core.get_background_escape_sequence("#000000e0") ..
+			core.get_color_escape_sequence("#00ff00") .. "$ ls -la\n" ..
+			core.get_color_escape_sequence("#aaaaaa") .. "drwxr-xr-x 2 user\n" ..
+			"-rw-r--r-- 1 user\n" ..
+			core.get_color_escape_sequence("#00ff00") .. "$ _")
+	end,
+})
+
+-- 13. Bold font
+core.register_node("testtextface:bold", {
+	description = "TextFace: Bold Font",
+	tiles = {"default_stone.png"},
+	drawtype = "normal",
+	paramtype2 = "facedir",
+	text_face = { tile = 0, rect = {{x = 0.05, y = 0.05}, {x = 0.95, y = 0.5}}, resolution_x = 512, resolution_y = 512 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_font_size_escape_sequence(28) .. core.get_font_weight_escape_sequence("bold") ..
+			core.get_background_escape_sequence("#cc0000") ..
+			core.get_color_escape_sequence("#ffffff") .. "BOLD TEXT\n" ..
+			core.get_color_escape_sequence("#ffcccc") .. "Important!")
+	end,
+})
+
+-- Full-face signlike (1x1, default settings for calibration)
+core.register_node("testtextface:signlike_full", {
+	description = "TextFace: Signlike Full Face",
+	tiles = {"default_cobble.png"},
+	drawtype = "signlike",
+	paramtype = "light",
+	paramtype2 = "wallmounted",
+	walkable = false,
+	text_face = { tile = 0, rect = {{x = 0, y = 0}, {x = 1, y = 1}} },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_color_escape_sequence("#000000") ..
+			"The quick brown fox\njumps over the\nlazy dog.\nLine 4\nLine 5")
+	end,
+})
+
+-- Wide sign (3 nodes wide, mesh node)
+core.register_node("testtextface:wide_sign", {
+	description = "TextFace: Wide Sign (3 nodes)",
+	tiles = {"default_cobble.png", "default_stone.png"},
+	drawtype = "mesh",
+	mesh = "textface_wide.obj",
+	paramtype = "light",
+	paramtype2 = "facedir",
+	selection_box = {
+		type = "fixed",
+		fixed = {-1.5, -0.5, -0.05, 1.5, 0.5, 0.05},
+	},
+	collision_box = {
+		type = "fixed",
+		fixed = {-1.5, -0.5, -0.05, 1.5, 0.5, 0.05},
+	},
+	text_face = { tile = 0, rect = {{x = 0.02, y = 0.05}, {x = 0.98, y = 0.95}}, resolution_x = 1024, resolution_y = 341 },
+	groups = {dig_immediate = 2},
+	on_rightclick = tf_on_rightclick,
+	on_construct = function(pos)
+		core.get_meta(pos):set_string("text",
+			core.get_font_size_escape_sequence(48) .. core.get_alignment_escape_sequence("center") ..
+			core.get_background_escape_sequence("#1a1a2ee0") ..
+			core.get_color_escape_sequence("#ffffff") .. "WIDE SIGN\n" ..
+			core.get_color_escape_sequence("#aaaaaa") .. "3 nodes wide, high resolution")
+	end,
+})
+
+-- Helper: build a [text: texture string for use on entities
+function testtextface.make_text_texture(base_tex, text, rect, res_x, res_y)
+	rect = rect or {0, 0, 1, 1}
+	res_x = res_x or 256
+	res_y = res_y or 256
+	return base_tex ..
+		"^[text:" .. core.encode_base64(text) ..
+		":" .. table.concat(rect, ",") ..
+		":" .. res_x .. "," .. res_y
+end
+
+-- Test entity with text face
+core.register_entity("testtextface:sign_entity", {
+	initial_properties = {
+		visual = "cube",
+		visual_size = {x = 1, y = 1, z = 0.1},
+		physical = false,
+		collisionbox = {-0.5, -0.5, -0.05, 0.5, 0.5, 0.05},
+		textures = {"default_stone.png", "default_stone.png",
+			"default_stone.png", "default_stone.png",
+			"default_stone.png", "default_stone.png"},
+	},
+	_text = "",
+	on_activate = function(self, staticdata)
+		if staticdata and staticdata ~= "" then
+			self._text = staticdata
+		else
+			self._text = core.get_font_size_escape_sequence(24) .. core.get_alignment_escape_sequence("center") ..
+				core.get_background_escape_sequence("#000000c0") ..
+				core.get_color_escape_sequence("#00ffcc") .. "ENTITY\n" ..
+				core.get_color_escape_sequence("#ffffff") .. "Right-click to edit"
+		end
+		self:_update_texture()
+	end,
+	get_staticdata = function(self)
+		return self._text
+	end,
+	on_rightclick = function(self, clicker)
+		local name = clicker:get_player_name()
+		local display = strip_escapes(self._text)
+		local style = parse_style(self._text)
+		core.show_formspec(name, "testtextface:entity_edit",
+			"formspec_version[4]" ..
+			"size[8,5]" ..
+			"textarea[0.5,0.3;7,2.5;text;Entity text;" ..
+				core.formspec_escape(display) .. "]" ..
+			"field[0.5,3.3;3,0.8;font_size;Size (default);" .. style.size .. "]" ..
+			"dropdown[4,3.3;3.5,0.8;align;left,center,right;" ..
+				(({left=1, center=2, right=3})[style.align] or 1) .. "]" ..
+			"button_exit[2.5,4.2;3,0.8;submit;Set Text]")
+		-- Store entity ref via object ID
+		clicker:get_meta():set_string("editing_entity",
+			tostring(self.object:get_pos()))
+		clicker:get_meta():set_string("editing_entity_style",
+			get_style_prefix(self._text))
+	end,
+	_update_texture = function(self)
+		local tex = testtextface.make_text_texture(
+			"default_cobble.png", self._text,
+			{0.02, 0.02, 0.98, 0.98}, 256, 256, 0)
+		local props = self.object:get_properties()
+		-- Front face gets text, rest keeps stone
+		props.textures = {
+			"default_stone.png", "default_stone.png",
+			"default_stone.png", "default_stone.png",
+			tex, "default_stone.png",
+		}
+		self.object:set_properties(props)
+	end,
+})
+
+-- Spawner item
+core.register_craftitem("testtextface:sign_entity_spawner", {
+	description = "TextFace: Spawn Sign Entity",
+	inventory_image = "default_cobble.png",
+	on_place = function(itemstack, placer, pointed_thing)
+		if pointed_thing.type == "node" then
+			local pos = pointed_thing.above
+			core.add_entity(pos, "testtextface:sign_entity")
+		end
+		return itemstack
+	end,
+})
+
+-- Handle entity text editing
+core.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "testtextface:entity_edit" or not fields.submit then
+		return
+	end
+	local pos_str = player:get_meta():get_string("editing_entity")
+	if pos_str == "" then return end
+	local pos = core.string_to_pos(pos_str)
+	if not pos then return end
+
+	-- Find the entity near this position
+	local objects = core.get_objects_inside_radius(pos, 0.5)
+	for _, obj in ipairs(objects) do
+		local ent = obj:get_luaentity()
+		if ent and ent.name == "testtextface:sign_entity" then
+			local style = {
+				size = fields.font_size or "",
+				font = "normal",
+				weight = "normal",
+				align = fields.align or "left",
+				color = "#ffffff",
+				bgcolor = "",
+			}
+			ent._text = build_style(style) .. (fields.text or "")
+			ent:_update_texture()
+			break
+		end
+	end
+	player:get_meta():set_string("editing_entity", "")
+	player:get_meta():set_string("editing_entity_style", "")
+end)

--- a/games/devtest/mods/testtextface/mod.conf
+++ b/games/devtest/mods/testtextface/mod.conf
@@ -1,0 +1,3 @@
+name = testtextface
+description = Test nodes for text_face feature (#1367)
+depends = basenodes

--- a/games/devtest/mods/testtextface/models/textface_cube.obj
+++ b/games/devtest/mods/testtextface/models/textface_cube.obj
@@ -1,0 +1,36 @@
+# Cube mesh for text_face testing
+# UVs oriented so text reads left-to-right on each face
+
+v -0.5 -0.5 -0.5
+v  0.5 -0.5 -0.5
+v  0.5  0.5 -0.5
+v -0.5  0.5 -0.5
+v -0.5 -0.5  0.5
+v  0.5 -0.5  0.5
+v  0.5  0.5  0.5
+v -0.5  0.5  0.5
+
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+
+vn  0  0 -1
+vn  0  0  1
+vn  0  1  0
+vn  0 -1  0
+vn  1  0  0
+vn -1  0  0
+
+# front (-Z) facing viewer
+f 2/1/1 1/2/1 4/3/1 3/4/1
+# back (+Z)
+f 5/1/2 6/2/2 7/3/2 8/4/2
+# top (+Y)
+f 8/1/3 7/2/3 3/3/3 4/4/3
+# bottom (-Y)
+f 1/1/4 2/2/4 6/3/4 5/4/4
+# right (+X)
+f 6/1/5 2/2/5 3/3/5 7/4/5
+# left (-X)
+f 1/1/6 5/2/6 8/3/6 4/4/6

--- a/games/devtest/mods/testtextface/models/textface_slanted.obj
+++ b/games/devtest/mods/testtextface/models/textface_slanted.obj
@@ -1,0 +1,28 @@
+# Display stand with slanted front face (~30 degrees)
+# Two groups for separate tile indices.
+
+v -0.5 -0.5 -0.3
+v  0.5 -0.5 -0.3
+v  0.5  0.5 -0.3
+v -0.5  0.5 -0.3
+v -0.5 -0.5  0.5
+v  0.5 -0.5  0.5
+v  0.5  0.5  0.2
+v -0.5  0.5  0.2
+
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+
+g display
+usemtl display
+f 5/1/1 6/2/1 7/3/1 8/4/1
+
+g body
+usemtl body
+f 2/1/1 1/2/1 4/3/1 3/4/1
+f 4/1/1 3/2/1 7/3/1 8/4/1
+f 1/1/1 2/2/1 6/3/1 5/4/1
+f 6/1/1 2/2/1 3/3/1 7/4/1
+f 1/1/1 5/2/1 8/3/1 4/4/1

--- a/games/devtest/mods/testtextface/models/textface_wide.obj
+++ b/games/devtest/mods/testtextface/models/textface_wide.obj
@@ -1,0 +1,35 @@
+# Wide sign: 3 nodes wide, 1 node tall, 0.1 nodes thick
+# Two material groups: display (front) and body (rest)
+
+v -1.5 -0.5 -0.05
+v  1.5 -0.5 -0.05
+v  1.5  0.5 -0.05
+v -1.5  0.5 -0.05
+v -1.5 -0.5  0.05
+v  1.5 -0.5  0.05
+v  1.5  0.5  0.05
+v -1.5  0.5  0.05
+
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+
+# Display face (front +Z) = tile 0
+g display
+usemtl display
+f 5/1/1 6/2/1 7/3/1 8/4/1
+
+# Body faces = tile 1
+g body
+usemtl body
+# back
+f 2/1/1 1/2/1 4/3/1 3/4/1
+# top
+f 8/1/1 7/2/1 3/3/1 4/4/1
+# bottom
+f 1/1/1 2/2/1 6/3/1 5/4/1
+# right
+f 6/1/1 2/2/1 3/3/1 7/4/1
+# left
+f 1/1/1 5/2/1 8/3/1 4/4/1

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -405,8 +405,14 @@ Game::~Game()
 	delete camera;
 	delete quicktune;
 	delete eventmgr;
+	// Remove all scene nodes to ensure map block meshes are destroyed
+	// before the texture source (they call putTexture in destructors).
+	if (smgr)
+		smgr->clear();
+
 	delete nodedef_manager;
 	delete itemdef_manager;
+	m_item_visuals_manager.reset();
 	delete texture_src;
 	delete shader_src;
 	delete draw_control;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -405,10 +405,10 @@ Game::~Game()
 	delete camera;
 	delete quicktune;
 	delete eventmgr;
-	delete texture_src;
-	delete shader_src;
 	delete nodedef_manager;
 	delete itemdef_manager;
+	delete texture_src;
+	delete shader_src;
 	delete draw_control;
 
 	clearTextureNameCache();

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -9,6 +9,9 @@
 #include <IReadFile.h>
 #include "imagefilters.h"
 #include "renderingengine.h"
+#include "fontengine.h"
+#include "irrlicht_changes/CGUITTFont.h"
+#include "util/enriched_string.h"
 #include "settings.h"
 #include "texturepaths.h"
 #include "irrlicht_changes/printing.h"
@@ -979,6 +982,38 @@ static void imageTransform(u32 transform, video::IImage *src, video::IImage *dst
 			COMPLAIN_INVALID("height"); \
 	} while(0)
 
+enum class TextHAlign : u8 { Left, Center, Right };
+
+static void drawText(gui::IGUIFont *font, gui::CGUITTFont *ttfont,
+	const EnrichedString &estr, video::SColor fg, const core::recti &rect,
+	TextHAlign halign = TextHAlign::Left)
+{
+	u32 line_h = font->getDimension(L"A").Height;
+	s32 max_w = rect.getWidth();
+	s32 cy = rect.UpperLeftCorner.Y;
+
+	size_t line_pos = 0;
+	while (line_pos < estr.size() && cy + (s32)line_h <= rect.LowerRightCorner.Y) {
+		EnrichedString line = estr.getNextLine(&line_pos);
+
+		s32 lx = rect.UpperLeftCorner.X;
+		if (halign != TextHAlign::Left) {
+			u32 tw = font->getDimension(line.getString().c_str()).Width;
+			if (halign == TextHAlign::Center)
+				lx += (max_w - (s32)tw) / 2;
+			else // Right
+				lx += max_w - (s32)tw;
+		}
+		core::recti r(lx, cy, rect.LowerRightCorner.X, rect.LowerRightCorner.Y);
+		if (ttfont)
+			ttfont->draw(line, r, false, false);
+		else
+			font->draw(core::stringw(line.getString().c_str()),
+				r, fg, false, false);
+		cy += line_h;
+	}
+}
+
 bool ImageSource::generateImagePart(std::string_view part_of_name,
 		video::IImage *& baseimg, std::set<std::string> &source_image_names)
 {
@@ -1782,6 +1817,167 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 
 			apply_brightness_contrast(baseimg, v2u32(0, 0),
 				baseimg->getDimension(), brightness, contrast);
+		}
+		/*
+			[text:TEXT:x1,y1,x2,y2:res_x,res_y
+
+			Creates a transparent texture with text rendered in the
+			specified rectangle (in 0-1 UV coordinates). Intended for
+			use as a tile overlay layer.
+
+			TEXT is base64-encoded because the raw text may contain
+			characters that conflict with the texture modifier parser
+			(^, \x1b, etc.). Base64 guarantees only A-Za-z0-9+/=
+			characters, which are safe with the : delimiter.
+		*/
+		else if (str_starts_with(part_of_name, "[text:")) {
+
+			Strfnd sf(part_of_name);
+			sf.next(":"); // skip "[text"
+			std::string text = base64_decode(sf.next(":"));
+			std::string rect_str = sf.next(":");
+			std::string resolution_str = sf.next(":");
+
+			if (text.empty()) {
+				errorstream << "generateImagePart(): [text: empty text" << std::endl;
+				return false;
+			}
+
+			f32 rx1 = 0, ry1 = 0, rx2 = 1, ry2 = 1;
+			if (!rect_str.empty()) {
+				Strfnd rf(rect_str);
+				rx1 = mystof(rf.next(","));
+				ry1 = mystof(rf.next(","));
+				rx2 = mystof(rf.next(","));
+				ry2 = mystof(rf.next(","));
+			}
+
+			u32 res_x = 256, res_y = 256;
+			if (!resolution_str.empty()) {
+				Strfnd rsf(resolution_str);
+				res_x = mystoi(rsf.next(","));
+				res_y = rsf.at_end() ? res_x : mystoi(rsf.next(","));
+			}
+			res_x = rangelim(res_x, 16, 2048);
+			res_y = rangelim(res_y, 16, 2048);
+
+			core::dimension2du dim(res_x, res_y);
+
+			u32 x1 = (u32)(rx1 * dim.Width);
+			u32 y1 = (u32)(ry1 * dim.Height);
+			u32 x2 = (u32)(rx2 * dim.Width);
+			u32 y2 = (u32)(ry2 * dim.Height);
+
+			if (x2 <= x1 || y2 <= y1)
+				return true; // nothing to draw
+
+			auto *device = RenderingEngine::get_raw_device();
+			auto *driver = device->getVideoDriver();
+
+			u32 fsize = std::max(8u, dim.Height * 24 / 256);
+			FontMode fmode = FM_Standard;
+			bool fbold = false, fitalic = false;
+			TextHAlign halign = TextHAlign::Left;
+			{
+				size_t i = 0;
+				while (i < text.size() && text[i] == '\x1b' &&
+						i + 1 < text.size() && text[i + 1] == '(') {
+					size_t end = text.find(')', i + 2);
+					if (end == std::string::npos) break;
+					std::string esc = text.substr(i + 2, end - (i + 2));
+					size_t at = esc.find('@');
+					if (at != std::string::npos) {
+						std::string key = esc.substr(0, at);
+						std::string val = esc.substr(at + 1);
+						if (key == "s" && !val.empty())
+							fsize = atoi(val.c_str());
+						else if (key == "f")
+							fmode = (val == "mono") ? FM_Mono : FM_Standard;
+						else if (key == "w") {
+							fbold = (val == "bold" || val == "bolditalic");
+							fitalic = (val == "italic" || val == "bolditalic");
+						} else if (key == "a") {
+							if (val == "center") halign = TextHAlign::Center;
+							else if (val == "right") halign = TextHAlign::Right;
+							else halign = TextHAlign::Left;
+						}
+					}
+					i = end + 1;
+				}
+			}
+
+			gui::IGUIFont *font = g_fontengine->getFont(
+				FontSpec(fsize, fmode, fbold, fitalic));
+
+			if (font) {
+				video::ITexture *rt = driver->addRenderTargetTexture(
+					dim, "__text_rt");
+				if (!rt) {
+					errorstream << "generateImagePart(): [text: "
+						<< "failed to create render target" << std::endl;
+					return false;
+				}
+				{
+					driver->setRenderTarget(rt, true, true,
+						video::SColor(0, 0, 0, 0));
+
+					// If applied as a modifier on a base image, draw
+					// the base first (entity texture use case).
+					video::ITexture *base_tex = nullptr;
+					if (baseimg) {
+						base_tex = driver->addTexture("__text_base", baseimg);
+						driver->draw2DImage(base_tex,
+							core::recti(0, 0, dim.Width, dim.Height),
+							core::recti(0, 0, baseimg->getDimension().Width,
+								baseimg->getDimension().Height));
+					}
+
+					video::SColor fg(255, 0, 0, 0);
+					EnrichedString estr(utf8_to_wide(text), fg);
+
+					// Don't draw background via GPU (blending mangles
+					// alpha on a transparent render target). We'll fill
+					// it in the CPU image below.
+
+					s32 pad = std::max(2, (s32)dim.Height / 64);
+					auto *ttfont = dynamic_cast<gui::CGUITTFont *>(font);
+					drawText(font, ttfont, estr, fg,
+						core::recti(x1 + pad, y1 + pad, x2 - pad, y2), halign);
+
+					driver->setRenderTarget(nullptr);
+					video::IImage *result = driver->createImage(rt,
+						core::position2di(0, 0), dim);
+					if (result) {
+						// Fill background in CPU image to preserve exact alpha
+						if (estr.hasBackground()) {
+							video::SColor bg = estr.getBackground();
+							for (u32 py = y1; py < y2 && py < dim.Height; py++)
+								for (u32 px = x1; px < x2 && px < dim.Width; px++) {
+									video::SColor existing = result->getPixel(px, py);
+									if (existing.getAlpha() == 0)
+										result->setPixel(px, py, bg);
+									else {
+										// Blend bg behind existing text pixels
+										u32 a = existing.getAlpha();
+										u32 ia = 255 - a;
+										result->setPixel(px, py, video::SColor(
+											std::min(255u, a + bg.getAlpha() * ia / 255),
+											(existing.getRed() * a + bg.getRed() * ia) / 255,
+											(existing.getGreen() * a + bg.getGreen() * ia) / 255,
+											(existing.getBlue() * a + bg.getBlue() * ia) / 255));
+									}
+								}
+						}
+						if (baseimg)
+							baseimg->drop();
+						baseimg = result;
+					}
+
+					if (base_tex)
+						driver->removeTexture(base_tex);
+					driver->removeTexture(rt);
+				}
+			}
 		}
 		else
 		{

--- a/src/client/item_visuals_manager.cpp
+++ b/src/client/item_visuals_manager.cpp
@@ -19,9 +19,8 @@ struct ItemVisualsManager::ItemVisuals
 	AnimationInfo inventory_normal;
 	AnimationInfo inventory_overlay;
 
-	// ItemVisuals owns the frames and AnimationInfo points to them
-	std::vector<FrameSpec> frames_normal;
-	std::vector<FrameSpec> frames_overlay;
+	std::shared_ptr<std::vector<FrameSpec>> frames_normal;
+	std::shared_ptr<std::vector<FrameSpec>> frames_overlay;
 
 	ItemVisuals() :
 		palette(nullptr)
@@ -71,14 +70,16 @@ ItemVisualsManager::ItemVisuals *ItemVisualsManager::createItemVisuals( const It
 
 	// Create inventory image textures
 	int frame_length = 0;
-	iv->frames_normal = createAnimationFrames(tsrc, inventory_image.name,
-			inventory_image.animation, frame_length);
-	iv->inventory_normal = AnimationInfo(&iv->frames_normal, frame_length);
+	iv->frames_normal = std::make_shared<std::vector<FrameSpec>>(
+			createAnimationFrames(tsrc, inventory_image.name,
+			inventory_image.animation, frame_length));
+	iv->inventory_normal = AnimationInfo(iv->frames_normal, frame_length);
 
 	// Create inventory overlay textures
-	iv->frames_overlay = createAnimationFrames(tsrc, inventory_overlay.name,
-			inventory_overlay.animation, frame_length);
-	iv->inventory_overlay = AnimationInfo(&iv->frames_overlay, frame_length);
+	iv->frames_overlay = std::make_shared<std::vector<FrameSpec>>(
+			createAnimationFrames(tsrc, inventory_overlay.name,
+			inventory_overlay.animation, frame_length));
+	iv->inventory_overlay = AnimationInfo(iv->frames_overlay, frame_length);
 
 	createItemMesh(client, def,
 			iv->inventory_normal,

--- a/src/client/item_visuals_manager.cpp
+++ b/src/client/item_visuals_manager.cpp
@@ -15,6 +15,7 @@ struct ItemVisualsManager::ItemVisuals
 {
 	ItemMesh item_mesh;
 	Palette *palette;
+	ITextureSource *tsrc = nullptr;
 
 	AnimationInfo inventory_normal;
 	AnimationInfo inventory_overlay;
@@ -28,6 +29,16 @@ struct ItemVisualsManager::ItemVisuals
 
 	~ItemVisuals()
 	{
+		if (tsrc) {
+			auto putFrames = [this](const std::shared_ptr<std::vector<FrameSpec>> &f) {
+				if (!f) return;
+				for (const auto &frame : *f)
+					if (frame.texture_id)
+						tsrc->putTexture(frame.texture_id);
+			};
+			putFrames(frames_normal);
+			putFrames(frames_overlay);
+		}
 		if (item_mesh.mesh)
 			item_mesh.mesh->drop();
 	}
@@ -87,6 +98,17 @@ ItemVisualsManager::ItemVisuals *ItemVisualsManager::createItemVisuals( const It
 			&(iv->item_mesh));
 
 	iv->palette = tsrc->getPalette(def.palette_image);
+
+	// Grab texture references
+	iv->tsrc = tsrc;
+	auto grabFrames = [tsrc](const std::shared_ptr<std::vector<FrameSpec>> &f) {
+		if (!f) return;
+		for (const auto &frame : *f)
+			if (frame.texture_id)
+				tsrc->grabTexture(frame.texture_id);
+	};
+	grabFrames(iv->frames_normal);
+	grabFrames(iv->frames_overlay);
 
 	// Put in cache
 	ItemVisuals *ptr = iv.get();

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -754,10 +754,16 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 	m_has_animation =
 		!m_crack_materials.empty() ||
 		!m_animation_info.empty();
+
+	// Take ownership of grabbed texture references
+	m_grabbed_textures = std::move(data->m_grabbed_textures);
 }
 
 MapBlockMesh::~MapBlockMesh()
 {
+	for (u32 tex_id : m_grabbed_textures)
+		m_tsrc->putTexture(tex_id);
+
 	size_t sz = 0;
 	for (auto &&m : m_mesh) {
 		for (u32 i = 0; i < m->getMeshBufferCount(); i++)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -15,6 +15,7 @@
 #include "util/tracy_wrapper.h"
 #include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
+#include "util/base64.h"
 #include <array>
 #include <algorithm>
 #include <cmath>
@@ -336,6 +337,23 @@ void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, 
 	const ContentFeatures &f = ndef->get(mn);
 	tile = f.visuals->tiles[tileindex];
 	bool has_crack = p == data->m_crack_pos_relative;
+
+	if (f.text_face.enabled && f.text_face.tile == tileindex && data->m_tsrc) {
+		auto it = data->m_node_text.find(p);
+		if (it != data->m_node_text.end() && it->second.texture_id != 0) {
+			u32 tex_id = it->second.texture_id;
+			tile.layers[1].texture = data->m_tsrc->getTexture(tex_id);
+			tile.layers[1].texture_id = tex_id;
+			tile.layers[1].texture_layer_idx = 0;
+			tile.layers[1].shader_id = f.visuals->text_face_shader_id;
+			tile.layers[1].material_type = TILE_MATERIAL_ALPHA;
+			tile.layers[1].material_flags = tile.layers[0].material_flags;
+			tile.layers[0].need_polygon_offset = true;
+			data->m_tsrc->grabTexture(tex_id);
+			data->m_grabbed_textures.push_back(tex_id);
+		}
+	}
+
 	for (TileLayer &layer : tile.layers) {
 		if (layer.empty())
 			continue;
@@ -755,7 +773,6 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 		!m_crack_materials.empty() ||
 		!m_animation_info.empty();
 
-	// Take ownership of grabbed texture references
 	m_grabbed_textures = std::move(data->m_grabbed_textures);
 }
 

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -51,6 +51,9 @@ struct MeshMakeData
 
 	const NodeDefManager *m_nodedef;
 
+	// Texture IDs grabbed during mesh generation (moved to MapBlockMesh)
+	std::vector<u32> m_grabbed_textures;
+
 	MeshMakeData(const NodeDefManager *ndef, u16 side_lingth, MeshGrid mesh_grid);
 
 	/*
@@ -298,6 +301,9 @@ private:
 	// Animation info: texture animation
 	// Maps mesh and mesh buffer indices to TileSpecs
 	std::map<MeshIndex, AnimationInfo> m_animation_info;
+
+	// Texture IDs grabbed by this mesh (for refcount-based GC)
+	std::vector<u32> m_grabbed_textures;
 
 	// list of all semitransparent triangles in the mapblock
 	std::vector<MeshTriangle> m_transparent_triangles;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -13,6 +13,7 @@
 #include "client/tile.h"
 #include "voxel.h"
 #include <map>
+#include <unordered_map>
 
 namespace video {
 	class IVideoDriver;
@@ -29,6 +30,11 @@ class ITextureSource;
 
 
 struct MinimapMapblock;
+
+struct NodeTextEntry {
+	std::string text;
+	u32 texture_id = 0;
+};
 
 struct MeshMakeData
 {
@@ -50,6 +56,13 @@ struct MeshMakeData
 	bool m_enable_water_reflections = false;
 
 	const NodeDefManager *m_nodedef;
+
+	// Node text data: maps node position (relative to blockpos * MAP_BLOCKSIZE)
+	// to pre-collected text and pre-generated texture ID.
+	std::unordered_map<v3s16, NodeTextEntry> m_node_text;
+
+	// Texture source for dynamic texture generation (e.g. text on nodes)
+	ITextureSource *m_tsrc = nullptr;
 
 	// Texture IDs grabbed during mesh generation (moved to MapBlockMesh)
 	std::vector<u32> m_grabbed_textures;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -9,7 +9,10 @@
 #include "mapblock.h"
 #include "mapblock_mesh.h"
 #include "map.h"
+#include "util/base64.h"
 #include "util/directiontables.h"
+#include "nodedef.h"
+#include "texturesource.h"
 #include "porting.h"
 
 /*
@@ -136,6 +139,7 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server,
 			q->crack_pos = m_client->getCrackPos();
 			q->urgent |= urgent;
 			q->retrieveBlocks(map, mesh_grid.cell_size);
+			collectNodeText(q, mesh_grid);
 			return true;
 		}
 	}
@@ -151,6 +155,7 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server,
 	q->crack_pos = m_client->getCrackPos();
 	q->urgent = urgent;
 	q->retrieveBlocks(map, mesh_grid.cell_size);
+	collectNodeText(q.get(), mesh_grid);
 
 	/*
 		Air blocks won't suddenly become visible due to a neighbor update, so
@@ -207,6 +212,41 @@ void MeshUpdateQueue::done(v3s16 pos)
 }
 
 
+void MeshUpdateQueue::collectNodeText(QueuedMeshUpdate *q, const MeshGrid &mesh_grid)
+{
+	q->node_text.clear();
+	const NodeDefManager *ndef = m_client->ndef();
+	ITextureSource *tsrc = m_client->tsrc();
+	v3s16 origin = q->p * MAP_BLOCKSIZE;
+	for (auto *block : q->map_blocks) {
+		if (!block)
+			continue;
+		v3s16 bp_nodes = block->getPos() * MAP_BLOCKSIZE;
+		for (auto it = block->m_node_metadata.begin();
+				it != block->m_node_metadata.end(); ++it) {
+			const std::string &text = it->second->getString("text");
+			if (text.empty())
+				continue;
+			v3s16 abs_pos = bp_nodes + it->first;
+			MapNode node = block->getNodeNoCheck(it->first);
+			const ContentFeatures &f = ndef->get(node);
+			if (!f.text_face.enabled)
+				continue;
+			const auto &tf = f.text_face;
+			std::string tex_name = "[text:" + base64_encode(text)
+				+ ":" + std::to_string(tf.rect[0])
+				+ "," + std::to_string(tf.rect[1])
+				+ "," + std::to_string(tf.rect[2])
+				+ "," + std::to_string(tf.rect[3])
+				+ ":" + std::to_string(tf.resolution_x)
+				+ "," + std::to_string(tf.resolution_y);
+			u32 tex_id = tsrc->getTextureId(tex_name);
+			v3s16 rel = abs_pos - origin;
+			q->node_text[rel] = {text, tex_id};
+		}
+	}
+}
+
 void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 {
 	auto mesh_grid = m_client->getMeshGrid();
@@ -221,6 +261,10 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 			block->copyTo(data->m_vmanip);
 	}
 
+	// Use text data collected on the main thread (avoids data race)
+	data->m_node_text = std::move(q->node_text);
+
+	data->m_tsrc = m_client->tsrc();
 	data->setCrack(q->crack_level, q->crack_pos);
 	data->m_generate_minimap = !!m_client->getMinimap();
 	data->m_smooth_lighting = m_cache_smooth_lighting;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -6,6 +6,7 @@
 
 #include <ctime>
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 #include "irrlichttypes_bloated.h"
 #include "threading/mutex_auto_lock.h"
@@ -16,8 +17,10 @@
 class Map;
 class MapBlock;
 class MapBlockMesh;
-struct MeshMakeData;
+#include "mapblock_mesh.h"
 class Client;
+
+struct MeshGrid;
 
 struct QueuedMeshUpdate
 {
@@ -28,6 +31,11 @@ struct QueuedMeshUpdate
 	MeshMakeData *data = nullptr; // This is generated in MeshUpdateQueue::pop()
 	std::vector<MapBlock*> map_blocks;
 	bool urgent = false;
+
+	// Node text collected on the main thread to avoid data races
+	// when reading metadata from the meshgen thread. Texture IDs are
+	// pre-generated on the main thread to avoid blocking roundtrips.
+	std::unordered_map<v3s16, NodeTextEntry> node_text;
 
 	QueuedMeshUpdate() = default;
 	~QueuedMeshUpdate();
@@ -105,6 +113,7 @@ private:
 	bool m_cache_enable_water_reflections;
 
 	void fillDataFromMapBlocks(QueuedMeshUpdate *q);
+	void collectNodeText(QueuedMeshUpdate *q, const MeshGrid &mesh_grid);
 };
 
 struct MeshUpdateResult

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -203,8 +203,40 @@ static size_t getArrayTextureMax(IShaderSource *shdsrc)
 
 //// NodeVisuals
 
+static void putTileTextures(ITextureSource *tsrc, TileSpec &tile)
+{
+	for (auto &layer : tile.layers) {
+		if (layer.texture_id)
+			tsrc->putTexture(layer.texture_id);
+		if (layer.frames) {
+			for (auto &frame : *layer.frames)
+				if (frame.texture_id)
+					tsrc->putTexture(frame.texture_id);
+		}
+	}
+}
+
+static void grabTileTextures(ITextureSource *tsrc, const TileSpec &tile)
+{
+	for (const auto &layer : tile.layers) {
+		if (layer.texture_id)
+			tsrc->grabTexture(layer.texture_id);
+		if (layer.frames) {
+			for (const auto &frame : *layer.frames)
+				if (frame.texture_id)
+					tsrc->grabTexture(frame.texture_id);
+		}
+	}
+}
+
 NodeVisuals::~NodeVisuals()
 {
+	if (tsrc) {
+		for (auto &tile : tiles)
+			putTileTextures(tsrc, tile);
+		for (auto &tile : special_tiles)
+			putTileTextures(tsrc, tile);
+	}
 	if (mesh_ptr)
 		mesh_ptr->drop();
 }
@@ -471,6 +503,13 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 			param_type_2 == CPT2_COLORED_WALLMOUNTED ||
 			param_type_2 == CPT2_COLORED_DEGROTATE)
 		palette = tsrc->getPalette(palette_name);
+
+	// Grab texture references for all tiles
+	this->tsrc = tsrc;
+	for (auto &tile : tiles)
+		grabTileTextures(tsrc, tile);
+	for (auto &tile : special_tiles)
+		grabTileTextures(tsrc, tile);
 }
 
 void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -136,7 +136,7 @@ static void fillTileAttribs(TileLayer *layer, TileAttribContext context,
 		std::vector<FrameSpec> frames = createAnimationFrames(
 				tsrc, tiledef.name, tiledef.animation, frame_length_ms);
 		if (frames.size() > 1) {
-			layer->frames = new std::vector<FrameSpec>(frames);
+			layer->frames = std::make_shared<std::vector<FrameSpec>>(frames);
 			layer->animation_frame_count = layer->frames->size();
 			layer->animation_frame_length_ms = frame_length_ms;
 
@@ -205,14 +205,6 @@ static size_t getArrayTextureMax(IShaderSource *shdsrc)
 
 NodeVisuals::~NodeVisuals()
 {
-	for (u16 j = 0; j < 6; j++) {
-		delete tiles[j].layers[0].frames;
-		delete tiles[j].layers[1].frames;
-	}
-	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++) {
-		delete special_tiles[j].layers[0].frames;
-		delete special_tiles[j].layers[1].frames;
-	}
 	if (mesh_ptr)
 		mesh_ptr->drop();
 }

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -434,6 +434,14 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 
 	MaterialType overlay_material = material_type_with_alpha(material_type);
 
+	// Pre-compute non-array-texture shader for text_face overlay.
+	// Always use TILE_MATERIAL_ALPHA for smooth alpha blending,
+	// regardless of the base node's material type.
+	if (f->text_face.enabled) {
+		text_face_shader_id = shdsrc->getShader(
+			"nodes_shader", TILE_MATERIAL_ALPHA, drawtype, false);
+	}
+
 	GetShaderCallback overlay_shader = [&] (bool array_texture) {
 		return shdsrc->getShader("nodes_shader", overlay_material, drawtype, array_texture);
 	};
@@ -504,7 +512,6 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 			param_type_2 == CPT2_COLORED_DEGROTATE)
 		palette = tsrc->getPalette(palette_name);
 
-	// Grab texture references for all tiles
 	this->tsrc = tsrc;
 	for (auto &tile : tiles)
 		grabTileTextures(tsrc, tile);

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -32,6 +32,7 @@ struct NodeVisuals
 	bool backface_culling = true;
 	scene::SMesh *mesh_ptr = nullptr; // mesh in case of mesh node
 	video::SColor minimap_color;
+	u32 text_face_shader_id = 0; // non-array-texture shader for text_face tiles
 	std::vector<video::SColor> *palette = nullptr;
 
 	// Texture source for reference counting (grab/put)

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -9,6 +9,7 @@
 #include "tile.h"
 
 class Client;
+class ITextureSource;
 struct PreLoadedTextures;
 namespace scene
 {
@@ -32,6 +33,9 @@ struct NodeVisuals
 	scene::SMesh *mesh_ptr = nullptr; // mesh in case of mesh node
 	video::SColor minimap_color;
 	std::vector<video::SColor> *palette = nullptr;
+
+	// Texture source for reference counting (grab/put)
+	ITextureSource *tsrc = nullptr;
 
 	// alpha stays in ContentFeatures due to compatibility code that is necessary,
 	// because it was part of the node definition table in the past.

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -65,6 +65,9 @@ struct TextureInfo
 	std::atomic<u32> refcount{0};
 	bool refcounted = false;
 
+	// Frame number when refcount last reached 0 (for grace period)
+	u64 zero_frame = 0;
+
 	TextureInfo() = default;
 	TextureInfo(video::E_TEXTURE_TYPE type_, std::string name_,
 			std::vector<std::string> images_,
@@ -81,7 +84,8 @@ struct TextureInfo
 		texture(other.texture),
 		sourceImages(std::move(other.sourceImages)),
 		refcount(other.refcount.load(std::memory_order_relaxed)),
-		refcounted(other.refcounted)
+		refcounted(other.refcounted),
+		zero_frame(other.zero_frame)
 	{
 		other.texture = nullptr;
 	}
@@ -97,6 +101,7 @@ struct TextureInfo
 			refcount.store(other.refcount.load(std::memory_order_relaxed),
 				std::memory_order_relaxed);
 			refcounted = other.refcounted;
+			zero_frame = other.zero_frame;
 		}
 		return *this;
 	}
@@ -173,6 +178,10 @@ private:
 
 	// Pruning is only safe once consumers are calling grabTexture/putTexture.
 	bool m_refcounting_active = false;
+	// Frame counter incremented each processQueue call
+	u64 m_frame_counter = 0;
+	// Number of frames to wait before pruning a zero-refcount texture
+	static constexpr u64 PRUNE_GRACE_FRAMES = 10;
 	// Gets or generates an image for a texture string
 	// Caller needs to drop the returned image
 	video::IImage *getOrGenerateImage(const std::string &name,
@@ -578,6 +587,7 @@ void TextureSource::processQueue()
 		m_get_texture_queue.pushResult(request, processRequest(request.key));
 	}
 
+	m_frame_counter++;
 	pruneUnusedTextures();
 }
 
@@ -605,6 +615,8 @@ void TextureSource::putTexture(u32 id)
 		auto &ti = m_textureinfo_cache[id];
 		u32 prev = ti.refcount.fetch_sub(1, std::memory_order_acq_rel);
 		sanity_check(prev > 0);
+		if (prev == 1)
+			ti.zero_frame = m_frame_counter;
 	}
 }
 
@@ -631,12 +643,11 @@ void TextureSource::pruneUnusedTextures()
 		if (ti.refcounted)
 			tracked++;
 		if (ti.texture && ti.refcounted
-				&& ti.refcount.load(std::memory_order_acquire) == 0) {
-			// TODO: enable actual pruning once all texture consumers
-			// are wired up with grab/put. Until then, just count.
-			// driver->removeTexture(ti.texture);
-			// ti.texture = nullptr;
-			// m_name_to_id.erase(ti.name);
+				&& ti.refcount.load(std::memory_order_acquire) == 0
+				&& m_frame_counter - ti.zero_frame >= PRUNE_GRACE_FRAMES) {
+			driver->removeTexture(ti.texture);
+			ti.texture = nullptr;
+			m_name_to_id.erase(ti.name);
 			pruned++;
 		}
 	}

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -11,6 +11,7 @@
 #include "imagesource.h"
 #include "porting.h"
 #include "renderingengine.h"
+#include "profiler.h"
 #include "settings.h"
 #include "texturepaths.h"
 #include "util/thread.h"
@@ -57,6 +58,50 @@ struct TextureInfo
 	video::ITexture *texture = nullptr;
 
 	std::set<std::string> sourceImages{};
+
+	// Reference count for texture garbage collection.
+	// Textures with refcount 0 are candidates for pruning,
+	// but only if they were grabbed at least once (refcounted == true).
+	std::atomic<u32> refcount{0};
+	bool refcounted = false;
+
+	TextureInfo() = default;
+	TextureInfo(video::E_TEXTURE_TYPE type_, std::string name_,
+			std::vector<std::string> images_,
+			video::ITexture *texture_ = nullptr,
+			std::set<std::string> sourceImages_ = {}) :
+		type(type_), name(std::move(name_)),
+		images(std::move(images_)), texture(texture_),
+		sourceImages(std::move(sourceImages_))
+	{}
+	TextureInfo(TextureInfo &&other) noexcept :
+		type(other.type),
+		name(std::move(other.name)),
+		images(std::move(other.images)),
+		texture(other.texture),
+		sourceImages(std::move(other.sourceImages)),
+		refcount(other.refcount.load(std::memory_order_relaxed)),
+		refcounted(other.refcounted)
+	{
+		other.texture = nullptr;
+	}
+	TextureInfo &operator=(TextureInfo &&other) noexcept
+	{
+		if (this != &other) {
+			type = other.type;
+			name = std::move(other.name);
+			images = std::move(other.images);
+			texture = other.texture;
+			other.texture = nullptr;
+			sourceImages = std::move(other.sourceImages);
+			refcount.store(other.refcount.load(std::memory_order_relaxed),
+				std::memory_order_relaxed);
+			refcounted = other.refcounted;
+		}
+		return *this;
+	}
+	TextureInfo(const TextureInfo &) = delete;
+	TextureInfo &operator=(const TextureInfo &) = delete;
 };
 
 // Stores internal information about a texture image.
@@ -120,7 +165,14 @@ public:
 
 	void setImageCaching(bool enabled);
 
+	void grabTexture(u32 id) override;
+	void putTexture(u32 id) override;
+
 private:
+	void pruneUnusedTextures();
+
+	// Pruning is only safe once consumers are calling grabTexture/putTexture.
+	bool m_refcounting_active = false;
 	// Gets or generates an image for a texture string
 	// Caller needs to drop the returned image
 	video::IImage *getOrGenerateImage(const std::string &name,
@@ -525,6 +577,73 @@ void TextureSource::processQueue()
 
 		m_get_texture_queue.pushResult(request, processRequest(request.key));
 	}
+
+	pruneUnusedTextures();
+}
+
+void TextureSource::grabTexture(u32 id)
+{
+	// No lock needed: refcount is atomic, and the vector slot for a
+	// valid id is never moved or deleted while the source exists.
+	if (id == 0)
+		return;
+	MutexAutoLock lock(m_textureinfo_cache_mutex);
+	if (id < m_textureinfo_cache.size()) {
+		auto &ti = m_textureinfo_cache[id];
+		ti.refcount.fetch_add(1, std::memory_order_relaxed);
+		ti.refcounted = true;
+		m_refcounting_active = true;
+	}
+}
+
+void TextureSource::putTexture(u32 id)
+{
+	if (id == 0)
+		return;
+	MutexAutoLock lock(m_textureinfo_cache_mutex);
+	if (id < m_textureinfo_cache.size()) {
+		auto &ti = m_textureinfo_cache[id];
+		u32 prev = ti.refcount.fetch_sub(1, std::memory_order_acq_rel);
+		sanity_check(prev > 0);
+	}
+}
+
+void TextureSource::pruneUnusedTextures()
+{
+	if (!m_refcounting_active)
+		return;
+
+	ScopeProfiler sp(g_profiler, "TextureSource::pruneUnusedTextures()", SPT_AVG);
+
+	sanity_check(std::this_thread::get_id() == m_main_thread);
+
+	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
+	if (!driver)
+		return;
+
+	MutexAutoLock lock(m_textureinfo_cache_mutex);
+
+	u32 total = 0, tracked = 0, pruned = 0;
+	for (u32 id = 1; id < m_textureinfo_cache.size(); id++) {
+		auto &ti = m_textureinfo_cache[id];
+		if (ti.texture)
+			total++;
+		if (ti.refcounted)
+			tracked++;
+		if (ti.texture && ti.refcounted
+				&& ti.refcount.load(std::memory_order_acquire) == 0) {
+			// TODO: enable actual pruning once all texture consumers
+			// are wired up with grab/put. Until then, just count.
+			// driver->removeTexture(ti.texture);
+			// ti.texture = nullptr;
+			// m_name_to_id.erase(ti.name);
+			pruned++;
+		}
+	}
+	if (pruned)
+		infostream << "TextureSource: pruned " << pruned
+			<< " textures (total=" << total
+			<< ", tracked=" << tracked << ")" << std::endl;
 }
 
 void TextureSource::insertSourceImage(const std::string &name, video::IImage *img)

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -114,6 +114,15 @@ public:
 	 * @note Disabling caching will flush the cache.
 	 */
 	virtual void setImageCaching(bool enabled) {};
+
+	/// Increment the reference count for a texture.
+	/// Call this when persistently storing a texture_id.
+	virtual void grabTexture(u32 id) = 0;
+
+	/// Decrement the reference count for a texture.
+	/// Call this when releasing a persistently stored texture_id.
+	/// Textures with zero references may be pruned.
+	virtual void putTexture(u32 id) = 0;
 };
 
 class IWritableTextureSource : public ITextureSource

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -6,6 +6,7 @@
 
 #include "irrlichttypes.h"
 #include <ITexture.h>
+#include <memory>
 #include <vector>
 #include <SMaterial.h>
 
@@ -154,8 +155,7 @@ struct TileLayer
 	/// @see TileLayer::applyMaterialOptions
 	bool need_polygon_offset = false;
 
-	/// @note not owned by this struct
-	std::vector<FrameSpec> *frames = nullptr;
+	std::shared_ptr<std::vector<FrameSpec>> frames;
 
 	/*!
 	 * The color of the tile, or if the tile does not own
@@ -195,10 +195,10 @@ struct AnimationInfo {
 			m_frames(tile.frames)
 	{}
 
-	AnimationInfo(std::vector<FrameSpec> *frames, u16 frame_length_ms) :
+	AnimationInfo(std::shared_ptr<std::vector<FrameSpec>> frames, u16 frame_length_ms) :
 			m_frame_length_ms(frame_length_ms),
 			m_frame_count(frames->size()),
-			m_frames(frames)
+			m_frames(std::move(frames))
 	{}
 
 	size_t getFrameCount() const
@@ -215,8 +215,7 @@ private:
 	u16 m_frame_length_ms = 0;
 	u16 m_frame_count = 1;
 
-	/// @note by default not owned by this struct
-	std::vector<FrameSpec> *m_frames = nullptr;
+	std::shared_ptr<std::vector<FrameSpec>> m_frames;
 };
 
 enum class TileRotation: u8 {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -259,8 +259,25 @@ WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id):
 	}
 }
 
+void WieldMeshSceneNode::putFrameTextures()
+{
+	if (!m_tsrc)
+		return;
+	auto putFrames = [this](const std::shared_ptr<std::vector<FrameSpec>> &frames) {
+		if (!frames)
+			return;
+		for (const auto &frame : *frames)
+			if (frame.texture_id)
+				m_tsrc->putTexture(frame.texture_id);
+	};
+	putFrames(m_wield_image_frames);
+	putFrames(m_wield_overlay_frames);
+}
+
 WieldMeshSceneNode::~WieldMeshSceneNode()
 {
+	putFrameTextures();
+
 	sanity_check(g_extrusion_mesh_cache);
 
 	// Remove node from shadow casters. m_shadow might be an invalid pointer!
@@ -424,7 +441,13 @@ std::vector<FrameSpec> createAnimationFrames(ITextureSource *tsrc,
 
 void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool check_wield_image)
 {
+	// Release old texture references before replacing
+	putFrameTextures();
+	m_wield_image_frames.reset();
+	m_wield_overlay_frames.reset();
+
 	ITextureSource *tsrc = client->getTextureSource();
+	m_tsrc = tsrc;
 	IItemDefManager *idef = client->getItemDefManager();
 	ItemVisualsManager *item_visuals = client->getItemVisualsManager();
 	IShaderSource *shdsrc = client->getShaderSource();
@@ -489,6 +512,17 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		setExtruded(wield_texture, wield_overlay_texture, wield_scale);
 		// initialize the color
 		setColor(video::SColor(0xFFFFFFFF));
+
+		// Grab texture references for animated frames
+		auto grabFrames = [tsrc](const std::shared_ptr<std::vector<FrameSpec>> &frames) {
+			if (!frames)
+				return;
+			for (const auto &frame : *frames)
+				if (frame.texture_id)
+					tsrc->grabTexture(frame.texture_id);
+		};
+		grabFrames(m_wield_image_frames);
+		grabFrames(m_wield_overlay_frames);
 		return;
 	}
 

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -441,7 +441,6 @@ std::vector<FrameSpec> createAnimationFrames(ITextureSource *tsrc,
 
 void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool check_wield_image)
 {
-	// Release old texture references before replacing
 	putFrameTextures();
 	m_wield_image_frames.reset();
 	m_wield_overlay_frames.reset();
@@ -513,7 +512,6 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		// initialize the color
 		setColor(video::SColor(0xFFFFFFFF));
 
-		// Grab texture references for animated frames
 		auto grabFrames = [tsrc](const std::shared_ptr<std::vector<FrameSpec>> &frames) {
 			if (!frames)
 				return;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -455,32 +455,34 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		video::ITexture *wield_overlay_texture = nullptr;
 
 		int frame_length_ms;
-		m_wield_image_frames = createAnimationFrames(tsrc,
-				wield_image.name, wield_image.animation, frame_length_ms);
+		m_wield_image_frames = std::make_shared<std::vector<FrameSpec>>(
+				createAnimationFrames(tsrc,
+				wield_image.name, wield_image.animation, frame_length_ms));
 
 		auto &l0 = m_buffer_info.emplace_back(0);
-		if (m_wield_image_frames.empty()) {
+		if (m_wield_image_frames->empty()) {
 			wield_texture = tsrc->getTexture(wield_image.name);
 		} else {
-			wield_texture = m_wield_image_frames[0].texture;
+			wield_texture = (*m_wield_image_frames)[0].texture;
 			l0.animation_info = std::make_unique<AnimationInfo>(
-				&m_wield_image_frames, frame_length_ms);
+				m_wield_image_frames, frame_length_ms);
 		}
 
 		// Overlay
 		if (!wield_overlay.name.empty()) {
 			int overlay_frame_length_ms;
-			m_wield_overlay_frames = createAnimationFrames(tsrc,
-					wield_overlay.name, wield_overlay.animation, overlay_frame_length_ms);
+			m_wield_overlay_frames = std::make_shared<std::vector<FrameSpec>>(
+					createAnimationFrames(tsrc,
+					wield_overlay.name, wield_overlay.animation, overlay_frame_length_ms));
 
 			// overlay is white, if present
 			auto &l1 = m_buffer_info.emplace_back(1, true, video::SColor(0xFFFFFFFF));
-			if (m_wield_overlay_frames.empty()) {
+			if (m_wield_overlay_frames->empty()) {
 				wield_overlay_texture = tsrc->getTexture(wield_overlay.name);
 			} else {
-				wield_overlay_texture = m_wield_overlay_frames[0].texture;
+				wield_overlay_texture = (*m_wield_overlay_frames)[0].texture;
 				l1.animation_info = std::make_unique<AnimationInfo>(
-					&m_wield_overlay_frames, overlay_frame_length_ms);
+					m_wield_overlay_frames, overlay_frame_length_ms);
 			}
 		}
 

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -163,9 +163,8 @@ private:
 	video::SColor m_base_color;
 
 	// Empty if wield image is empty or not animated
-	// Owned by this class to get AnimationInfo for the mesh buffer info
-	std::vector<FrameSpec> m_wield_image_frames;
-	std::vector<FrameSpec> m_wield_overlay_frames;
+	std::shared_ptr<std::vector<FrameSpec>> m_wield_image_frames;
+	std::shared_ptr<std::vector<FrameSpec>> m_wield_overlay_frames;
 
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -162,9 +162,14 @@ private:
 	 */
 	video::SColor m_base_color;
 
+	// Texture source for reference counting
+	ITextureSource *m_tsrc = nullptr;
+
 	// Empty if wield image is empty or not animated
 	std::shared_ptr<std::vector<FrameSpec>> m_wield_image_frames;
 	std::shared_ptr<std::vector<FrameSpec>> m_wield_overlay_frames;
+
+	void putFrameTextures();
 
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -284,8 +284,17 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 		v3s16 pos = i->first;
 
 		if (map.isValidPosition(pos) &&
-				map.setNodeMetadata(pos, i->second))
+				map.setNodeMetadata(pos, i->second)) {
+			// If this node has text_face, trigger a mesh rebuild
+			// so the rendered text updates immediately.
+			MapNode node = map.getNode(pos);
+			const ContentFeatures &f = m_nodedef->get(node);
+			if (f.text_face.enabled) {
+				v3s16 blockpos = getNodeBlockPos(pos);
+				addUpdateMeshTaskWithEdge(blockpos, false, true);
+			}
 			continue; // Prevent from deleting metadata
+		}
 
 		// Meta couldn't be set, unused metadata
 		delete i->second;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -515,6 +515,18 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, move_resistance);
 	writeU8(os, liquid_move_physics);
 	writeU8(os, post_effect_color_shaded);
+
+	// text_face
+	writeU8(os, text_face.enabled);
+	if (text_face.enabled) {
+		writeU8(os, text_face.tile);
+		writeF32(os, text_face.rect[0]);
+		writeF32(os, text_face.rect[1]);
+		writeF32(os, text_face.rect[2]);
+		writeF32(os, text_face.rect[3]);
+		writeU16(os, text_face.resolution_x);
+		writeU16(os, text_face.resolution_y);
+	}
 }
 
 void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
@@ -647,6 +659,20 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 		// >= 5.8.0-dev
 
 		post_effect_color_shaded = readU8(is);
+
+		if (!canRead(is))
+			break;
+
+		text_face.enabled = readU8(is);
+		if (text_face.enabled) {
+			text_face.tile = readU8(is);
+			text_face.rect[0] = readF32(is);
+			text_face.rect[1] = readF32(is);
+			text_face.rect[2] = readF32(is);
+			text_face.rect[3] = readF32(is);
+			text_face.resolution_x = readU16(is);
+			text_face.resolution_y = readU16(is);
+		}
 
 		//if (!canRead(is))
 		//	break;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -290,6 +290,16 @@ struct TileDef
 //       tiles can be overridden.
 #define CF_SPECIAL_COUNT 6
 
+// Defines how text from node metadata is rendered onto a tile
+struct TextFaceSpec
+{
+	bool enabled = false;
+	u8 tile = 0;              // which tile index gets the text
+	f32 rect[4] = {0, 0, 1, 1}; // text region in tile UV space (x1, y1, x2, y2)
+	u16 resolution_x = 256;   // target texture width for text rendering
+	u16 resolution_y = 256;   // target texture height for text rendering
+};
+
 struct ContentFeatures
 {
 	// PROTOCOL_VERSION >= 37. This is legacy and should not be increased anymore,
@@ -420,6 +430,10 @@ struct ContentFeatures
 	SoundSpec sound_footstep;
 	SoundSpec sound_dig;
 	SoundSpec sound_dug;
+
+	// --- TEXT FACE ---
+
+	TextFaceSpec text_face;
 
 	// --- LEGACY ---
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1031,6 +1031,32 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 	}
 	lua_pop(L, 1);
 
+	// Text face
+	lua_getfield(L, index, "text_face");
+	if (lua_istable(L, -1)) {
+		f.text_face.enabled = true;
+		f.text_face.tile = getintfield_default(L, -1, "tile", 0);
+		lua_getfield(L, -1, "rect");
+		if (lua_istable(L, -1)) {
+			lua_rawgeti(L, -1, 1); // rect[1] = {x=x1, y=y1}
+			if (lua_istable(L, -1)) {
+				f.text_face.rect[0] = getfloatfield_default(L, -1, "x", 0);
+				f.text_face.rect[1] = getfloatfield_default(L, -1, "y", 0);
+			}
+			lua_pop(L, 1);
+			lua_rawgeti(L, -1, 2); // rect[2] = {x=x2, y=y2}
+			if (lua_istable(L, -1)) {
+				f.text_face.rect[2] = getfloatfield_default(L, -1, "x", 1);
+				f.text_face.rect[3] = getfloatfield_default(L, -1, "y", 1);
+			}
+			lua_pop(L, 1);
+		}
+		lua_pop(L, 1); // rect
+		f.text_face.resolution_x = getintfield_default(L, -1, "resolution_x", 256);
+		f.text_face.resolution_y = getintfield_default(L, -1, "resolution_y", 256);
+	}
+	lua_pop(L, 1); // text_face
+
 	// Node immediately placed by client when node is dug
 	getstringfield(L, index, "node_dig_prediction",
 		f.node_dig_prediction);
@@ -1180,6 +1206,30 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	push_simplesoundspec(L, c.sound_dug);
 	lua_setfield(L, -2, "sound_dug");
 	lua_setfield(L, -2, "sounds");
+	if (c.text_face.enabled) {
+		lua_newtable(L);
+		lua_pushinteger(L, c.text_face.tile);
+		lua_setfield(L, -2, "tile");
+		lua_newtable(L); // rect
+		lua_newtable(L); // rect[1]
+		lua_pushnumber(L, c.text_face.rect[0]);
+		lua_setfield(L, -2, "x");
+		lua_pushnumber(L, c.text_face.rect[1]);
+		lua_setfield(L, -2, "y");
+		lua_rawseti(L, -2, 1);
+		lua_newtable(L); // rect[2]
+		lua_pushnumber(L, c.text_face.rect[2]);
+		lua_setfield(L, -2, "x");
+		lua_pushnumber(L, c.text_face.rect[3]);
+		lua_setfield(L, -2, "y");
+		lua_rawseti(L, -2, 2);
+		lua_setfield(L, -2, "rect");
+		lua_pushinteger(L, c.text_face.resolution_x);
+		lua_setfield(L, -2, "resolution_x");
+		lua_pushinteger(L, c.text_face.resolution_y);
+		lua_setfield(L, -2, "resolution_y");
+		lua_setfield(L, -2, "text_face");
+	}
 	lua_pushboolean(L, c.legacy_facedir_simple);
 	lua_setfield(L, -2, "legacy_facedir_simple");
 	lua_pushboolean(L, c.legacy_wallmounted);

--- a/src/unittest/test_servermodmanager.cpp
+++ b/src/unittest/test_servermodmanager.cpp
@@ -111,7 +111,7 @@ void TestServerModManager::testGetMods()
 	auto sm = makeManager(m_worlddir);
 	const auto &mods = sm.getMods();
 	// `ls ./games/devtest/mods | wc -l` + 1 (test mod)
-	UASSERTEQ(std::size_t, mods.size(), 35 + 1);
+	UASSERTEQ(std::size_t, mods.size(), 36 + 1);
 
 	// Ensure we found basenodes mod (part of devtest)
 	// and test_mod (for testing MINETEST_MOD_PATH).


### PR DESCRIPTION
Adds native text rendering on node tile surfaces via a new text_face node definition field and [text| texture modifier.

How it works: Nodes with text_face define which tile gets text (index, UV rect, resolution). Text content is stored in node metadata under the "text" key. During mesh generation, the engine constructs a `[text|` texture modifier string, which renders styled text onto the base tile texture using a render target and the engine's TrueType font system. The composited texture uses a non-array-texture shader fallback since array textures can't be dynamically modified.

Text styling via `\x1b` escape sequences in the text content: font size (s@), face (f@mono), weight (w@bold), color
(c@), background (b@), alignment (a@center). Word wrapping, newlines, and text rotation (0/90/180/270) are   supported. Textures are cached by TextureSource — identical text produces identical cache keys. Mesh rebuilds are triggered automatically when text metadata changes on the client.

The [text| modifier is not specific to nodes — it works on any texture string (entities, HUD, formspec), making it a general-purpose text-to-texture primitive. For entities, mods construct the modifier string directly using core.encode_base64().

Supported drawtypes: normal, nodebox (including connected), signlike, mesh. Excluded: glasslike, glasslike_framed, allfaces (incompatible tile mapping).

Closes #1367 