### PR TITLE
Fix crash in handleCommand_Init2 when received in wrong client state

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -271,6 +271,13 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	session_t peer_id = pkt->getPeerId();
 	verbosestream << "Server: Got TOSERVER_INIT2 from " << peer_id << std::endl;
 
+	RemoteClient *client = getClientNoEx(peer_id, CS_Invalid);
+	if (!client || client->getState() != CS_AwaitingInit2) {
+		actionstream << "Server: Ignoring TOSERVER_INIT2 in wrong state from "
+			<< peer_id << std::endl;
+		return;
+	}
+
 	m_clients.event(peer_id, CSE_GotInit2);
 	u16 protocol_version = m_clients.getProtocolVersion(peer_id);
 
@@ -295,9 +302,6 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 
 	// Send media announcement
 	sendMediaAnnouncement(peer_id, lang);
-
-	RemoteClient *client = getClient(peer_id, CS_InitDone);
-	assert(client);
 
 	// Keep client language for server translations
 	client->setLangCode(lang);


### PR DESCRIPTION
TOSERVER_INIT2 is registered as TOSERVER_STATE_NOT_CONNECTED, so it bypasses all client state checks in ProcessData. When received from a client already in CS_Active (or any state other than CS_AwaitingInit2), the CSE_GotInit2 event triggers an invalid state transition that can crash the server.

Add an explicit state check to early-return if the client is not in CS_AwaitingInit2.