### PR TITLE
Formspec: fix dropping held items by clicking outside

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4054,6 +4054,14 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 	}
 }
 
+bool GUIFormSpecMenu::remapClickOutside(const SEvent &event)
+{
+	// Don't remap a click outside the formspec to ESC when holding an item.
+	if (m_selected_item)
+		return false;
+	return GUIModalMenu::remapClickOutside(event);
+}
+
 bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 {
 	// This must be done first so that GUIModalMenu can set m_pointer_type

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -289,6 +289,8 @@ public:
 	static double getImgsize(v2u32 avail_screensize, double screen_dpi, double gui_scaling);
 
 protected:
+	bool remapClickOutside(const SEvent &event) override;
+
 	v2s32 getBasePos() const
 	{
 			return padding + offset + AbsoluteRect.UpperLeftCorner;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -123,15 +123,6 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 	if (isChild(hovered, this))
 		return false;
 
-	// Dropping items is also done by tapping outside the formspec. If an item
-	// is selected, make sure it is dropped without closing the formspec.
-	// We have to explicitly restrict this to GUIInventoryList because other
-	// GUI elements like text fields like to absorb events for no reason.
-	GUIInventoryList *focused = dynamic_cast<GUIInventoryList *>(Environment->getFocus());
-	if (focused && focused->OnEvent(event))
-		// Return true since the event was handled, even if it wasn't handled by us.
-		return true;
-
 	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
 		m_last_click_outside = current;
 		return true;

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -80,6 +80,8 @@ protected:
 	// This is set to true if the menu is currently processing a second-touch event.
 	bool m_second_touch = false;
 
+	virtual bool remapClickOutside(const SEvent &event);
+
 private:
 	IMenuManager *m_menumgr;
 	/* If true, remap a click outside the formspec to ESC. This is so that, for
@@ -88,7 +90,6 @@ private:
 	 * the mainmenu to prevent Minetest from closing unexpectedly.
 	 */
 	bool m_remap_click_outside;
-	bool remapClickOutside(const SEvent &event);
 	PointerAction m_last_click_outside{};
 
 	// This might be necessary to expose to the implementation if it


### PR DESCRIPTION
When items are picked up via right-click, middle-click, or mouse wheel (none of which change GUI focus), clicking outside the formspec closes it instead of dropping the held item. This happens because remapClickOutside() only delegates to GUIInventoryList when it has focus, but focus is only set on left mouse down.

Add a virtual hasModalInteraction() hook so GUIFormSpecMenu can signal that it has an ongoing interaction (held item). When true, remapClickOutside() backs off and lets the normal event dispatch route the click to the formspec's inventory drop handling code.

Fixes #16952