### PR TITLE
Reflect sun and moon using actual textures or generated moon phase.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -828,7 +828,7 @@ enable_translucent_foliage (Translucent foliage) bool false
 
 #   When enabled, liquid reflections are simulated.
 #
-#   Requires: enable_waving_water, enable_dynamic_shadows
+#   Requires: enable_waving_water
 enable_water_reflections (Liquid reflections) bool false
 
 [*Audio]

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -19,6 +19,10 @@ uniform float crackAnimationLength;
 uniform float crackLevel;
 uniform float crackTextureScale;
 
+uniform vec3 sunLightDirection;
+uniform sampler2D sunReflectionSampler;
+uniform float sunReflectionScale;
+
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow texture
 	uniform sampler2D ShadowMapSampler;
@@ -57,7 +61,6 @@ flat VARYING_ uint varTexLayer;
 CENTROID_ VARYING_ float nightRatio;
 VARYING_ highp vec3 eyeVec;
 
-#ifdef ENABLE_DYNAMIC_SHADOWS
 #if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS && ENABLE_WAVING_WATER)
 vec4 perm(vec4 x)
 {
@@ -105,6 +108,8 @@ vec2 wave_noise(vec3 p, float off) {
 		gnoise(4.0 * p + vec3(-off, off, 0.0)) * 0.2).xz;
 }
 #endif
+
+#ifdef ENABLE_DYNAMIC_SHADOWS
 
 // assuming near is always 1.0
 float getLinearDepth()
@@ -425,6 +430,38 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 #endif
 
+float computeFresnelFactor(vec3 normal, vec3 viewVec)
+{
+	float f = dot(normal, viewVec);
+	// Trig hack: go from dot(viewVec, normal) to dot(viewVec, tangent) for fresnel effect
+	return clamp(pow(1.0 - f * f, 8.0), 0.0, 1.0) * 0.8 + 0.2;
+}
+
+#if defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS
+vec3 sampleSunMoonReflection(vec3 viewVec, vec3 fNormal, vec3 sunDir)
+{
+	vec3 reflectedView = reflect(viewVec, fNormal);
+	float cosAngle = dot(reflectedView, sunDir);
+
+	if (cosAngle > 0.0) {
+		vec3 toSun = reflectedView - sunDir * cosAngle;
+		vec3 uBasis = normalize(cross(sunDir, vec3(0.0, 1.0, 0.0)));
+		vec3 vBasis = normalize(cross(cross(sunDir, vec3(0.0, 1.0, 0.0)), sunDir));
+		float sideSign = sign(sunDir.x);
+		vec2 sunUV = vec2(
+			sideSign * dot(toSun, uBasis),
+			sideSign * dot(toSun, vBasis))
+			/ sunReflectionScale + 0.5;
+
+		if (sunUV.x > 0.0 && sunUV.x < 1.0 && sunUV.y > 0.0 && sunUV.y < 1.0) {
+			vec4 sunSample = texture2D(sunReflectionSampler, sunUV);
+			return sunSample.rgb * sunSample.a * 4.0;
+		}
+	}
+	return vec3(0.0);
+}
+#endif
+
 // maps [0, N] to [0, 1] like GL_REPEAT would
 vec2 uv_repeat(vec2 v)
 {
@@ -468,6 +505,12 @@ void main(void)
 	}
 
 	vec4 col = vec4(base.rgb * varColor.rgb, 1.0);
+
+#if defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS
+	float water_fresnel = 0.0;
+	float water_shadow = 0.0;
+	vec3 water_normal = vNormal;
+#endif
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// Fragment normal, can differ from vNormal which is derived from vertex normals.
@@ -539,7 +582,8 @@ void main(void)
 		vec3 viewVec = normalize(worldPosition + cameraOffset - cameraPosition);
 
 		// Water reflections
-#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS && ENABLE_WAVING_WATER)
+#if (defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS)
+#if ENABLE_WAVING_WATER
 		vec3 wavePos = worldPosition * vec3(2.0, 0.0, 2.0);
 		float off = animationTimer * WATER_WAVE_SPEED * 10.0;
 		wavePos.x /= WATER_WAVE_LENGTH * 3.0;
@@ -549,22 +593,10 @@ void main(void)
 		vec2 gradient = wave_noise(wavePos, off);
 		fNormal = normalize(normalize(fNormal) + vec3(gradient.x, 0., gradient.y) * WATER_WAVE_HEIGHT * abs(fNormal.y) * 0.25);
 		reflect_ray = -normalize(v_LightDirection - fNormal * dot(v_LightDirection, fNormal) * 2.0);
-		float fresnel_factor = dot(fNormal, viewVec);
-
-		float brightness_factor = 1.0 - adjusted_night_ratio;
-
-		// A little trig hack. We go from the dot product of viewVec and normal to the dot product of viewVec and tangent to apply a fresnel effect.
-		fresnel_factor = clamp(pow(1.0 - fresnel_factor * fresnel_factor, 8.0), 0.0, 1.0) * 0.8 + 0.2;
-		col.rgb *= 0.5;
-		vec3 reflection_color = mix(vec3(max(fogColor.r, max(fogColor.g, fogColor.b))), fogColor.rgb, f_shadow_strength);
-
-		// Sky reflection
-		col.rgb += reflection_color * pow(fresnel_factor, 2.0) * 0.5 * brightness_factor;
-		vec3 water_reflect_color = 12.0 * dayLight * fresnel_factor * mtsmoothstep(0.85, 0.9, pow(clamp(dot(reflect_ray, viewVec), 0.0, 1.0), 32.0)) * max(1.0 - shadow_uncorrected, 0.0);
-
-		// This line exists to prevent ridiculously bright reflection colors.
-		water_reflect_color /= clamp(max(water_reflect_color.r, max(water_reflect_color.g, water_reflect_color.b)) * 0.375, 1.0, 400.0);
-		col.rgb += water_reflect_color * f_adj_shadow_strength * brightness_factor;
+#endif
+		water_normal = fNormal;
+		water_fresnel = computeFresnelFactor(fNormal, viewVec);
+		water_shadow = shadow_uncorrected;
 #endif
 
 #if (defined(ENABLE_NODE_SPECULAR) && !MATERIAL_WATER_REFLECTIONS)
@@ -584,6 +616,45 @@ void main(void)
 		// Simulate translucent foliage.
 		col.rgb += 4.0 * dayLight * base.rgb * normalize(base.rgb * varColor.rgb * varColor.rgb) * f_adj_shadow_strength * pow(max(-dot(v_LightDirection, viewVec), 0.0), 4.0) * max(1.0 - shadow_uncorrected, 0.0);
 #endif
+	}
+#endif
+
+#if defined(ENABLE_WATER_REFLECTIONS) && MATERIAL_WATER_REFLECTIONS
+	{
+		vec3 viewVec = normalize(worldPosition + cameraOffset - cameraPosition);
+
+#if !defined(ENABLE_DYNAMIC_SHADOWS)
+#if ENABLE_WAVING_WATER
+		vec3 wavePos = worldPosition * vec3(2.0, 0.0, 2.0);
+		float off = animationTimer * WATER_WAVE_SPEED * 10.0;
+		wavePos.x /= WATER_WAVE_LENGTH * 3.0;
+		wavePos.z /= WATER_WAVE_LENGTH * 2.0;
+
+		vec2 gradient = wave_noise(wavePos, off);
+		water_normal = normalize(normalize(water_normal) + vec3(gradient.x, 0., gradient.y) * WATER_WAVE_HEIGHT * abs(water_normal.y) * 0.25);
+#endif
+		water_fresnel = computeFresnelFactor(water_normal, viewVec);
+#endif
+
+		float brightness_factor = 1.0 - nightRatio;
+
+		col.rgb *= 0.5;
+#ifdef ENABLE_DYNAMIC_SHADOWS
+		vec3 reflection_color = mix(vec3(max(fogColor.r, max(fogColor.g, fogColor.b))), fogColor.rgb, f_shadow_strength);
+#else
+		vec3 reflection_color = fogColor.rgb;
+#endif
+		col.rgb += reflection_color * pow(water_fresnel, 2.0) * 0.5 * brightness_factor;
+
+		if (sunReflectionScale > 0.0) {
+			vec3 bodyLight = mix(dayLight, vec3(0.5, 0.57, 0.65), nightRatio);
+			vec3 sunMoon = sampleSunMoonReflection(viewVec, water_normal, sunLightDirection);
+#ifdef ENABLE_DYNAMIC_SHADOWS
+			col.rgb += sunMoon * water_fresnel * bodyLight * max(1.0 - water_shadow, 0.0);
+#else
+			col.rgb += sunMoon * water_fresnel * bodyLight;
+#endif
+		}
 	}
 #endif
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -1109,6 +1109,13 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			});
 			material.Wireframe = m_control.show_wireframe;
 
+			if (m_sun_reflection_texture) {
+				auto &sun_layer = material.TextureLayers[TEXTURE_LAYER_SUN_REFLECTION];
+				sun_layer.Texture = m_sun_reflection_texture;
+				sun_layer.MinFilter = video::ETMINF_LINEAR_MIPMAP_NEAREST;
+				sun_layer.MagFilter = video::ETMAGF_LINEAR;
+			}
+
 			// pass the shadow map texture to the buffer texture
 			ShadowRenderer *shadow = m_rendering_engine->get_shadow_renderer();
 			if (shadow && shadow->is_active()) {
@@ -1130,6 +1137,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 				++array_texture_use;
 
 			material.TextureLayers[ShadowRenderer::TEXTURE_LAYER_SHADOW].Texture = nullptr;
+			material.TextureLayers[TEXTURE_LAYER_SUN_REFLECTION].Texture = nullptr;
 		}
 
 		m.setTranslation(descriptor.m_pos);

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -71,6 +71,9 @@ public:
 
 	void updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset, video::SColor light_color);
 
+	static constexpr int TEXTURE_LAYER_SUN_REFLECTION = 2;
+	void setSunReflectionTexture(video::ITexture *tex) { m_sun_reflection_texture = tex; }
+
 	/*
 		Forcefully get a sector from somewhere
 	*/
@@ -167,6 +170,7 @@ private:
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
 	video::SColor m_camera_light_color = video::SColor(0xFFFFFFFF);
+	video::ITexture *m_sun_reflection_texture = nullptr;
 	bool m_needs_update_transparent_meshes = true;
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -109,6 +109,9 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	CachedPixelShaderSetting<float> m_moon_brightness_pixel{"moonBrightness"};
 	CachedPixelShaderSetting<float>
 		m_volumetric_light_strength_pixel{"volumetricLightStrength"};
+	CachedPixelShaderSetting<float, 3> m_light_direction_pixel{"sunLightDirection"};
+	CachedPixelShaderSetting<s32> m_sun_texture_pixel{"sunReflectionSampler"};
+	CachedPixelShaderSetting<float> m_sun_texture_scale_pixel{"sunReflectionScale"};
 
 	static constexpr std::array<const char*, 1> SETTING_CALLBACKS = {
 		"exposure_compensation",
@@ -256,6 +259,29 @@ public:
 			float volumetric_light_strength = lighting.volumetric_light_strength;
 			m_volumetric_light_strength_pixel.set(&volumetric_light_strength, services);
 		}
+
+		{
+			float wicked_tod = getWickedTimeOfDay(m_client->getEnv().getTimeOfDay() / 24000.f);
+			bool is_day = wicked_tod > 0.25f && wicked_tod < 0.75f;
+			v3f light_dir = (is_day && m_sky->getSunVisible())
+				? m_sky->getSunDirection()
+				: (m_sky->getMoonVisible() ? m_sky->getMoonDirection() : v3f(0, -1, 0));
+			m_light_direction_pixel.set(light_dir, services);
+		}
+
+		{
+			float wicked_tod = getWickedTimeOfDay(m_client->getEnv().getTimeOfDay() / 24000.f);
+			bool is_day = wicked_tod > 0.25f && wicked_tod < 0.75f;
+			float body_scale = 0.0f;
+			if (is_day && m_sky->getSunVisible() && m_sky->getSunTexture())
+				body_scale = 0.25f;
+			else if (m_sky->getMoonVisible() && m_sky->getMoonTexture())
+				body_scale = 0.63f;
+			m_sun_texture_scale_pixel.set(&body_scale, services);
+
+			s32 layer = 2;
+			m_sun_texture_pixel.set(&layer, services);
+		}
 	}
 
 	void onSetMaterial(const video::SMaterial &material) override
@@ -358,6 +384,7 @@ public:
 			case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
 			case TILE_MATERIAL_WAVING_LIQUID_BASIC:
 			case TILE_MATERIAL_LIQUID_TRANSPARENT:
+			case TILE_MATERIAL_LIQUID_OPAQUE:
 				constants["MATERIAL_WATER_REFLECTIONS"] = 1;
 				break;
 			default:
@@ -3445,6 +3472,18 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	sky->update(time_of_day_smooth, time_brightness, direct_brightness,
 			sunlight_seen, camera->getCameraMode(), player->getYaw(),
 			player->getPitch());
+
+	// Set sun/moon texture for water surface reflections.
+	{
+		float wicked_tod = getWickedTimeOfDay(time_of_day_smooth);
+		bool is_day = wicked_tod > 0.25f && wicked_tod < 0.75f;
+		video::ITexture *body_tex = nullptr;
+		if (is_day && sky->getSunVisible())
+			body_tex = sky->getSunTexture();
+		else if (sky->getMoonVisible())
+			body_tex = sky->getMoonTexture();
+		client->getEnv().getClientMap().setSunReflectionTexture(body_tex);
+	}
 
 	/*
 		Update clouds

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -212,6 +212,9 @@ public:
 	{
 		constants["ENABLE_TONE_MAPPING"] = g_settings->getBool("tone_mapping") ? 1 : 0;
 
+		if (g_settings->getBool("enable_water_reflections"))
+			constants["ENABLE_WATER_REFLECTIONS"] = 1;
+
 		if (g_settings->getBool("enable_dynamic_shadows")) {
 			constants["ENABLE_DYNAMIC_SHADOWS"] = 1;
 			if (g_settings->getBool("shadow_map_color"))
@@ -219,9 +222,6 @@ public:
 
 			if (g_settings->getBool("shadow_poisson_filter"))
 				constants["POISSON_FILTER"] = 1;
-
-			if (g_settings->getBool("enable_water_reflections"))
-				constants["ENABLE_WATER_REFLECTIONS"] = 1;
 
 			if (g_settings->getBool("enable_translucent_foliage"))
 				constants["ENABLE_TRANSLUCENT_FOLIAGE"] = 1;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -84,6 +84,8 @@ Sky::Sky(s32 id, RenderingEngine *rendering_engine, ITextureSource *tsrc, IShade
 	m_sky_params.body_orbit_tilt = g_settings->getFloat("shadow_sky_body_orbit_tilt", -60., 60.);
 	m_sky_params.fog_start = rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f);
 
+	generateReflectionTextures(rendering_engine->get_video_driver());
+
 	setStarCount(1000);
 }
 
@@ -721,6 +723,53 @@ static void getTextureAsImage(video::IImage *&dst, const std::string &name, ITex
 			texture->getColorFormat(), texture->getSize(),
 			texture->lock(video::ETLM_READ_ONLY));
 		texture->unlock();
+	}
+}
+
+void Sky::generateReflectionTextures(video::IVideoDriver *driver)
+{
+	const u32 size = 64;
+	const float center = (size - 1) * 0.5f;
+
+	auto generate = [&](const float sizes[], int nlayers, const float alphas[],
+			const char *name) -> video::ITexture * {
+		video::IImage *img = driver->createImage(video::ECF_A8R8G8B8,
+			core::dimension2du(size, size));
+		img->fill(video::SColor(0, 255, 255, 255));
+
+		for (u32 y = 0; y < size; y++) {
+			for (u32 x = 0; x < size; x++) {
+				float fx = (x - center) / center;
+				float fy = (y - center) / center;
+				float dist = std::max(std::fabs(fx), std::fabs(fy));
+
+				float a = 0.0f;
+				for (int i = 0; i < nlayers; i++) {
+					if (dist <= sizes[i]) {
+						a = alphas[i] + a * (1.0f - alphas[i]);
+					}
+				}
+				a = std::min(a, 1.0f);
+				img->setPixel(x, y, video::SColor(
+					(u32)(a * 255), 255, 255, 255));
+			}
+		}
+
+		video::ITexture *tex = driver->addTexture(name, img);
+		img->drop();
+		return tex;
+	};
+
+	{
+		const float sizes[] = {1.0f, 1.0f/1.7f*1.2f, 1.0f/1.7f, 1.0f/1.7f*0.7f};
+		const float alphas[] = {0.05f, 0.15f, 1.0f, 1.0f};
+		m_sun_reflection_texture = generate(sizes, 4, alphas, "__sun_reflection");
+	}
+
+	{
+		const float sizes[] = {1.0f, 1.0f/1.9f*1.3f, 1.0f/1.9f, 1.0f/1.9f*0.6f};
+		const float alphas[] = {0.05f, 0.15f, 1.0f, 1.0f};
+		m_moon_reflection_texture = generate(sizes, 4, alphas, "__moon_reflection");
 	}
 }
 

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -64,6 +64,7 @@ public:
 	void setSunriseVisible(bool glow_visible) { m_sun_params.sunrise_visible = glow_visible; }
 	void setSunriseTexture(const std::string &sunglow_texture, ITextureSource* tsrc);
 	v3f getSunDirection();
+	video::ITexture *getSunTexture() const { return m_sun_texture ? m_sun_texture : m_sun_reflection_texture; }
 
 	void setMoonVisible(bool moon_visible) { m_moon_params.visible = moon_visible; }
 	bool getMoonVisible() const { return m_moon_params.visible; }
@@ -71,6 +72,7 @@ public:
 		const std::string &moon_tonemap, ITextureSource *tsrc);
 	void setMoonScale(f32 moon_scale) { m_moon_params.scale = moon_scale; }
 	v3f getMoonDirection();
+	video::ITexture *getMoonTexture() const { return m_moon_texture ? m_moon_texture : m_moon_reflection_texture; }
 
 	void setStarsVisible(bool stars_visible) { m_star_params.visible = stars_visible; }
 	void setStarCount(u16 star_count);
@@ -213,9 +215,12 @@ private:
 
 	video::ITexture *m_sun_texture = nullptr;
 	video::ITexture *m_moon_texture = nullptr;
+	video::ITexture *m_sun_reflection_texture = nullptr;
+	video::ITexture *m_moon_reflection_texture = nullptr;
 	video::IImage *m_sun_tonemap = nullptr;
 	video::IImage *m_moon_tonemap = nullptr;
 
+	void generateReflectionTextures(video::IVideoDriver *driver);
 	void updateStars();
 
 	void draw_sun(video::IVideoDriver *driver, const video::SColor &suncolor,


### PR DESCRIPTION
This patch replaces the "placeholder" sun reflection in water. For this to work, you must have waving water enabled. Previously this only worked when shadows were enabled, but, with this change, it no longer depends on shadows being enabled or not.

The sun/moon reflection uses the actual texture that the game uses. I've used Mineclonia to test it and tweak sizes (they're a tiny tiny bit larger in the reflection but I think it's reasonable, because smaller looks weird really quick) and test that the actual reflections are correct (this part took quite a while).

Mineclonia relies on the generated sun texture (a bunch of squares stacked on top of each other) so this has been tested with both variants - texture and generated sun/moon.

A bunch of new shader stuff is needed to make this work, this patch pulls all of those changes in. The noise functions previously only in the shadow ifdefs are now also needed outside of it.