### PR TITLE
Document that the hand item can't be an ItemStack

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2128,6 +2128,8 @@ The following items are predefined and have special properties.
     * It can be overridden to change those properties:
         * globally using `core.override_item`
         * per-player using the special `"hand"` inventory list
+    * It cannot be used as an ItemStack object, because `""` represents the empty stack.
+      Therefore, it can't be stored in an inventory.
 
 Amount and wear
 ---------------


### PR DESCRIPTION
Fixes #16828

Using `""` as an ItemStack causes too many problems. I tried to fix part of it #16830, but it's not worth it, there is too much ambiguity.

Note that the documentation is (currently) not entirely true, because you can get a hand Itemstack by using
``` lua
local stack = ItemStack("")
stack:set_count(1)
stack:get_meta():set_string("test", "test")
```
But clients will strip this away in `ItemStack::deSerialize`, so it's a bug to be fixed in either case.

As SmallJoker wrote, ideally the hand item should be renamed to `"hand"`, but this would break compatibility.

## To do

Ready for Review.
