### PR TITLE
make finding gamepad settings easier in search

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2475,7 +2475,7 @@ serverlist_file (Serverlist file) [client] string favoriteservers.json
 [*Gamepads] [client]
 
 #    Enable joysticks. Requires a restart to take effect
-enable_joysticks (Enable joysticks) bool false
+enable_joysticks (Enable joysticks/gamepads) bool false
 
 #    The identifier of the joystick to use
 joystick_id (Joystick ID) int 0 0 255


### PR DESCRIPTION
Makes it possible to search for gamepad or joystick to bring up the related advanced options.

fixes #17069

- Goal of the PR
- Make it easy to find gamepad options in the settings.
- 
- How does the PR work?
- Adds gamepad to the joystick menu setting.
- 
- Does it resolve any reported issue?
- The one I just reported a few minutes ago. :)
- 
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- Uh, UI/UX
- 
- If not a bug fix, why is this PR needed? What usecases does it solve?
- If you have used an LLM/AI to help with code or assets, you must disclose this.
- No AI used to add one word to settings


## How to test

Look at settings.txt and see gamepad listed, search in menu for gamepad see relevant menu options shown.
