### PR TITLE
Permit scrollbars to be styled

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3424,7 +3424,8 @@ Elements
       units the thumb spans out of the range of the scrollbar values.
     * Example: If a scrollbar has a `min` of 1 and a `max` of 100, a thumbsize of 10
       would span a tenth of the scrollbar space.
-    * If this is set to zero or less, the value will be reset to `1`.
+    * If set to less than zero, the value will be reset to `1`.
+    * If set to zero, the thumb size will be the same as the thickness of the scrollbar (i.e. the thumb will always be a square).
 * `arrows=<show/hide/default>`
     * Whether to show the arrow buttons on the scrollbar. `default` hides the arrows
       when the scrollbar gets too small, but shows them otherwise.
@@ -3634,6 +3635,23 @@ Some types may inherit styles from parent types.
 * textlist
 * vertlabel, inherits from label
 
+### Pseudo-Elements
+
+Certain elements, like scrollbars, can create implicit pseudo-elements of different types.
+These pseudo-elements may be styled either with the appropriate `style_type` rule or with
+an ordinary `style` rule. In the latter case, the pseudo-element's name is its parent's
+name suffixed with `.` and the pseudo-element's identifier (e.g. `myscrollbar.up`). If
+a pseudo-element is of a type that creates its own pseudo-elements, those pseudo-elements
+are named in the same way, e.g. `mytextarea.scrollbar.up`.
+
+Current pseudo-elements (by parent type):
+
+* scrollbar
+    * `.up` (image_button): The up (or right) arrow button of the scrollbar, if arrows are enabled.
+    * `.down` (image_button): The down (or left) arrow button of the scrollbar, if arrows are enabled.
+* textarea, hypertext, textlist, table
+    * `.scrollbar` (scrollbar): The implicit scrollbar created when the contents of the element
+      overflow its bounds.
 
 ### Valid Properties
 
@@ -3730,6 +3748,19 @@ Some types may inherit styles from parent types.
     * sound - a sound to be played when triggered.
 * scrollbar
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+    * border - boolean, set to false to hide the default track and thumb. Defaults to true.
+    * bgcolor - color, sets the scrollbar's tint.
+    * bgimg - The background image of the scrollbar's track.
+    * bgimg_middle - Makes the bgimg render in 9-sliced mode and defines the middle rect.
+    * fgimg - The image of the scrollbar's thumb. Note: If `fgimg_middle` is not specified, this
+      will implicitly behave as if `thumbsize=0` were set.
+    * fgimg_middle - Makes the fgimg render in 9-sliced mode and defines the middle rect.
+        * Note that if this is not specified, the scrollbar thumb will not be stretched
+          to reflect the size of the scrollbar's range, equivalently to the `thumbsize=0`
+          scrollbar option.
+    * padding - rect. The space, in pixels, with which to pad the scrollbar's track background.
+    * size - integer, sets the thickness (in pixels) of implicit scrollbars (those attached to
+      `hypertext[]` or `textarea[]` elements).
 * tabheader
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * sound - a sound to be played when a different tab is selected.

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -79,8 +79,10 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 
 	core::rect<s32> scrollbarrect = RelativeRect;
 	scrollbarrect.UpperLeftCorner.X += RelativeRect.getWidth() - VScrollBarWidth;
-	VScrollBar = new GUIScrollBar(Environment, getParent(), -1,
+	m_vscrollbar = new GUIScrollBar(Environment, getParent(), -1,
 			scrollbarrect, false, true, m_tsrc);
+
+	VScrollBar = m_vscrollbar;
 
 	VScrollBar->setVisible(false);
 	VScrollBar->setSmallStep(3 * fontHeight);
@@ -92,4 +94,19 @@ void GUIEditBoxWithScrollBar::setBackgroundColor(const video::SColor &bg_color)
 {
 	m_bg_color = bg_color;
 	m_bg_color_used = true;
+}
+
+void GUIEditBoxWithScrollBar::setScrollbarStyle(
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles)
+{
+	if (styles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::SIZE)) {
+		VScrollBarWidth = styles[StyleSpec::STATE_DEFAULT].getIntArray(StyleSpec::SIZE, {0, 0, 0, 0})[0];
+
+		core::rect<s32> scrollbarrect = RelativeRect;
+		scrollbarrect.UpperLeftCorner.X += RelativeRect.getWidth() - VScrollBarWidth;
+		VScrollBar->setRelativePosition(scrollbarrect);
+	}
+	m_vscrollbar->setStyles(styles, up_arrow_styles, down_arrow_styles);
 }

--- a/src/gui/guiEditBoxWithScrollbar.h
+++ b/src/gui/guiEditBoxWithScrollbar.h
@@ -6,6 +6,8 @@
 #define GUIEDITBOXWITHSCROLLBAR_HEADER
 
 #include "CGUIEditBox.h"
+#include "StyleSpec.h"
+#include "guiScrollBar.h"
 
 class ISimpleTextureSource;
 
@@ -27,9 +29,15 @@ public:
 	//! Change the background color
 	void setBackgroundColor(const video::SColor &bg_color);
 
+	void setScrollbarStyle(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles);
+
 protected:
 	//! create a Vertical ScrollBar
 	void createVScrollBar();
+
+	GUIScrollBar* m_vscrollbar;
 
 	bool m_bg_color_used;
 	video::SColor m_bg_color;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -683,8 +683,14 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 	GUIScrollBar *e = new GUIScrollBar(Environment, data->current_parent,
 			spec.fid, rect, is_horizontal, true, m_tsrc);
 
-	auto style = getDefaultStyleForElement("scrollbar", name);
-	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+	auto style = getStyleForElement("scrollbar", name);
+	// FIXME: There's no way to access the GUIFormSpecMenu instance from the element class,
+	// so we are compelled to look up styling information for the arrow buttons here
+	// and pass it down.
+	auto up_arrow_style = getStyleForElement("button", name + ".up");
+	auto down_arrow_style = getStyleForElement("button", name + ".down");
+	e->setNotClipped(style[StyleSpec::STATE_DEFAULT].getBool(StyleSpec::NOCLIP, false));
+	e->setStyles(style, up_arrow_style, down_arrow_style);
 	e->setArrowsVisible(data->scrollbar_options.arrow_visiblity);
 
 	s32 max = data->scrollbar_options.max;
@@ -702,7 +708,10 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 	s32 scrollbar_size = is_horizontal ? dim.X : dim.Y;
 
-	e->setPageSize(scrollbar_size * (max - min + 1) / data->scrollbar_options.thumb_size);
+	if (data->scrollbar_options.thumb_size == 0)
+		e->setPageSize(S32_MAX);
+	else
+		e->setPageSize(scrollbar_size * (max - min + 1) / data->scrollbar_options.thumb_size);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -747,7 +756,7 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 			continue;
 		} else if (options[0] == "thumbsize") {
 			int value = stoi(options[1]);
-			data->scrollbar_options.thumb_size = value <= 0 ? 1 : value;
+			data->scrollbar_options.thumb_size = value < 0 ? 1 : value;
 			continue;
 		} else if (options[0] == "arrows") {
 			auto value = trim(options[1]);
@@ -1234,6 +1243,11 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 			rect, m_tsrc);
 
+	auto scrollbar_style = getStyleForElement("scrollbar", spec.fname + ".scrollbar");
+	auto up_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.up");
+	auto down_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.down");
+	e->setScrollbarStyle(scrollbar_style, up_arrow_styles, down_arrow_styles);
+
 	// Apply styling before calculating the cell sizes
 	auto style = getDefaultStyleForElement("table", name);
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1310,6 +1324,11 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	//now really show list
 	GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 			rect, m_tsrc);
+
+	auto scrollbar_style = getStyleForElement("scrollbar", spec.fname + ".scrollbar");
+	auto up_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.up");
+	auto down_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.down");
+	e->setScrollbarStyle(scrollbar_style, up_arrow_styles, down_arrow_styles);
 
 	if (spec.fname == m_focused_element) {
 		Environment->setFocus(e);
@@ -1535,8 +1554,13 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 
 	gui::IGUIEditBox *e = nullptr;
 	if (is_multiline) {
-		e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true, Environment,
+		auto textarea = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true, Environment,
 				data->current_parent, spec.fid, rect, m_tsrc, is_editable, true);
+		auto scrollbar_style = getStyleForElement("scrollbar", spec.fname + ".scrollbar");
+		auto up_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.up");
+		auto down_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.down");
+		textarea->setScrollbarStyle(scrollbar_style, up_arrow_styles, down_arrow_styles);
+		e = textarea;
 	} else if (is_editable) {
 		e = Environment->addEditBox(spec.fdefault.c_str(), rect, true,
 				data->current_parent, spec.fid);
@@ -1759,6 +1783,11 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	GUIHyperText *e = new GUIHyperText(spec.flabel.c_str(), Environment,
 			data->current_parent, spec.fid, rect, m_client, m_tsrc);
 	e->drop();
+
+	auto scrollbar_style = getStyleForElement("scrollbar", spec.fname + ".scrollbar");
+	auto up_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.up");
+	auto down_arrow_styles = getStyleForElement("button", spec.fname + ".scrollbar.down");
+	e->setScrollbarStyle(scrollbar_style, up_arrow_styles, down_arrow_styles);
 
 	m_fields.push_back(spec);
 }

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1176,3 +1176,19 @@ void GUIHyperText::draw()
 	// draw children
 	IGUIElement::draw();
 }
+
+void GUIHyperText::setScrollbarStyle(
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles)
+{
+	if (styles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::SIZE)) {
+		m_scrollbar_width = styles[StyleSpec::STATE_DEFAULT].getIntArray(StyleSpec::SIZE, {0, 0, 0, 0})[0];
+
+		core::rect<s32> rect = core::rect<s32>(
+				RelativeRect.getWidth() - m_scrollbar_width, 0,
+				RelativeRect.getWidth(), RelativeRect.getHeight());
+		m_vscrollbar->setRelativePosition(rect);
+	}
+	m_vscrollbar->setStyles(styles, up_arrow_styles, down_arrow_styles);
+}

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -11,6 +11,7 @@
 #include <IGUIElement.h>
 #include <IGUIEnvironment.h>
 #include "irr_v3d.h"
+#include "StyleSpec.h"
 
 
 class ISimpleTextureSource;
@@ -201,6 +202,10 @@ public:
 
 	bool OnEvent(const SEvent &event);
 
+	void setScrollbarStyle(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles);
+
 protected:
 	// GUI members
 	ISimpleTextureSource *m_tsrc;
@@ -208,7 +213,7 @@ protected:
 	TextDrawer m_drawer;
 
 	// Positioning
-	u32 m_scrollbar_width;
+	u32 m_scrollbar_width = 0;
 	core::rect<s32> m_display_text_rect;
 	core::position2d<s32> m_text_scrollpos;
 

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -10,11 +10,15 @@ which includes automatic scaling of the thumb slider and hiding of
 the arrow buttons where there is insufficient space.
 */
 
+#include "irrMath.h"
+#include "client/guiscalingfilter.h"
 #include "guiScrollBar.h"
 #include "guiButton.h"
+#include "guiButtonImage.h"
 #include "porting.h"
 #include "settings.h"
 #include <IGUISkin.h>
+#include "IVideoDriver.h"
 
 GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 		core::rect<s32> rectangle, bool horizontal, bool auto_scale,
@@ -32,6 +36,15 @@ GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s3
 	setTabStop(true);
 	setTabOrder(-1);
 	setPos(0);
+
+	auto skin = Environment->getSkin();
+	TrackColor = skin->getColor(EGDC_SCROLLBAR);
+
+	for (size_t i = 0; i < 4; i++) {
+		video::SColor base =
+			skin->getColor((gui::EGUI_DEFAULT_COLOR)i);
+		ThumbColors[i] = base;
+	}
 }
 
 bool GUIScrollBar::OnEvent(const SEvent &event)
@@ -151,15 +164,45 @@ void GUIScrollBar::draw()
 	if (!skin)
 		return;
 
+	video::IVideoDriver* driver = Environment->getVideoDriver();
+
 	video::SColor icon_color = skin->getColor(
 			isEnabled() ? EGDC_WINDOW_SYMBOL : EGDC_GRAY_WINDOW_SYMBOL);
 	if (icon_color != current_icon_color)
 		refreshControls();
 
-	slider_rect = AbsoluteRect;
-	skin->draw2DRectangle(this, skin->getColor(EGDC_SCROLLBAR), slider_rect,
-			&AbsoluteClippingRect);
+	track_rect = AbsoluteRect;
+	if (is_horizontal) {
+		track_rect.UpperLeftCorner.X  += TrackPadding.UpperLeftCorner.X;
+		track_rect.UpperLeftCorner.Y  += TrackPadding.UpperLeftCorner.Y;
+		track_rect.LowerRightCorner.X += TrackPadding.LowerRightCorner.X;
+		track_rect.LowerRightCorner.Y += TrackPadding.LowerRightCorner.Y;
+	} else {
+		track_rect.UpperLeftCorner.X  += TrackPadding.UpperLeftCorner.Y;
+		track_rect.UpperLeftCorner.Y  += TrackPadding.UpperLeftCorner.X;
+		track_rect.LowerRightCorner.X += TrackPadding.LowerRightCorner.Y;
+		track_rect.LowerRightCorner.Y += TrackPadding.LowerRightCorner.X;
+	}
 
+	if (DrawBorder)
+		skin->draw2DRectangle(this, TrackColor, track_rect,
+				&AbsoluteClippingRect);
+
+	if (TrackTexture.Texture) {
+		core::rect<s32> sourceRect = core::rect<s32>(core::position2di(0,0), TrackTexture.Texture->getOriginalSize());
+		video::SColor image_colors[] = { BgColor, BgColor, BgColor, BgColor };
+		if (TrackTexture.MiddleRect.getArea() == 0) {
+			driver->draw2DImage(TrackTexture.Texture.get(),
+					track_rect, sourceRect,
+					&AbsoluteClippingRect, image_colors, true);
+		} else {
+			draw2DImage9Slice(driver, TrackTexture.Texture.get(),
+					track_rect, sourceRect,
+					TrackTexture.MiddleRect, &AbsoluteClippingRect, image_colors);
+		}
+	}
+
+	slider_rect = AbsoluteRect;
 	if (core::isnotzero(range())) {
 		if (is_horizontal) {
 			slider_rect.UpperLeftCorner.X = AbsoluteRect.UpperLeftCorner.X +
@@ -172,7 +215,23 @@ void GUIScrollBar::draw()
 			slider_rect.LowerRightCorner.Y =
 					slider_rect.UpperLeftCorner.Y + thumb_size;
 		}
-		skin->draw3DButtonPaneStandard(this, slider_rect, &AbsoluteClippingRect);
+		if (DrawBorder)
+			skin->drawColored3DButtonPaneStandard(this, slider_rect, &AbsoluteClippingRect, ThumbColors);
+
+		if (ThumbTexture.Texture) {
+			core::rect<s32> sourceRect = core::rect<s32>(core::position2di(0,0), ThumbTexture.Texture->getOriginalSize());
+			video::SColor image_colors[] = { BgColor, BgColor, BgColor, BgColor };
+			if (ThumbTexture.MiddleRect.getArea() == 0) {
+				driver->draw2DImage(ThumbTexture.Texture.get(),
+						slider_rect,
+						sourceRect, &AbsoluteClippingRect,
+						image_colors, true);
+			} else {
+				draw2DImage9Slice(driver, ThumbTexture.Texture.get(),
+						slider_rect,
+						sourceRect, ThumbTexture.MiddleRect, &AbsoluteClippingRect, image_colors);
+			}
+		}
 	}
 	IGUIElement::draw();
 }
@@ -278,7 +337,9 @@ void GUIScrollBar::setPosRaw(const s32 pos)
 		thumb_area = RelativeRect.getHeight() - border_size * 2;
 	}
 
-	if (is_auto_scaling)
+	if (StaticThumb)
+		thumb_size = 0;
+	else if (is_auto_scaling)
 		thumb_size = (s32)std::fmin(S32_MAX,
 				thumb_area / (f32(page_size) / f32(thumb_area + border_size * 2)));
 
@@ -404,12 +465,15 @@ void GUIScrollBar::refreshControls()
 		border_size = RelativeRect.getWidth() < h * 4 ? 0 : h;
 		if (!up_button) {
 			core::rect<s32> up_button_rect(0, 0, h, h);
-			up_button = GUIButton::addButton(Environment, up_button_rect, m_tsrc,
+			up_button = GUIButtonImage::addButton(Environment, up_button_rect, m_tsrc,
 					this, -1, L"");
 			up_button->setSubElement(true);
 			up_button->setTabStop(false);
 		}
-		if (sprites) {
+		// Logical up corresponds to visual down in horizontal orientation.
+		if (DownArrowStyles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::FGIMG)) {
+			up_button->setSpriteBank(nullptr);
+		} else if (sprites) {
 			up_button->setSpriteBank(sprites);
 			up_button->setSprite(EGBS_BUTTON_UP,
 					s32(skin->getIcon(EGDI_CURSOR_LEFT)),
@@ -426,12 +490,15 @@ void GUIScrollBar::refreshControls()
 					RelativeRect.getWidth() - h, 0,
 					RelativeRect.getWidth(), h
 				);
-			down_button = GUIButton::addButton(Environment, down_button_rect, m_tsrc,
+			down_button = GUIButtonImage::addButton(Environment, down_button_rect, m_tsrc,
 					this, -1, L"");
 			down_button->setSubElement(true);
 			down_button->setTabStop(false);
 		}
-		if (sprites) {
+		// Logical down corresponds to visual up in horizontal orientation.
+		if (UpArrowStyles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::FGIMG)) {
+			down_button->setSpriteBank(nullptr);
+		} else if (sprites) {
 			down_button->setSpriteBank(sprites);
 			down_button->setSprite(EGBS_BUTTON_UP,
 					s32(skin->getIcon(EGDI_CURSOR_RIGHT)),
@@ -450,12 +517,14 @@ void GUIScrollBar::refreshControls()
 		border_size = RelativeRect.getHeight() < w * 4 ? 0 : w;
 		if (!up_button) {
 			core::rect<s32> up_button_rect(0, 0, w, w);
-			up_button = GUIButton::addButton(Environment, up_button_rect, m_tsrc,
+			up_button = GUIButtonImage::addButton(Environment, up_button_rect, m_tsrc,
 					this, -1, L"");
 			up_button->setSubElement(true);
 			up_button->setTabStop(false);
 		}
-		if (sprites) {
+		if (UpArrowStyles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::FGIMG)) {
+			up_button->setSpriteBank(nullptr);
+		} else if (sprites) {
 			up_button->setSpriteBank(sprites);
 			up_button->setSprite(EGBS_BUTTON_UP,
 					s32(skin->getIcon(EGDI_CURSOR_UP)),
@@ -472,12 +541,14 @@ void GUIScrollBar::refreshControls()
 					0, RelativeRect.getHeight() - w,
 					w, RelativeRect.getHeight()
 				);
-			down_button = GUIButton::addButton(Environment, down_button_rect, m_tsrc,
+			down_button = GUIButtonImage::addButton(Environment, down_button_rect, m_tsrc,
 					this, -1, L"");
 			down_button->setSubElement(true);
 			down_button->setTabStop(false);
 		}
-		if (sprites) {
+		if (DownArrowStyles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::FGIMG)) {
+			down_button->setSpriteBank(nullptr);
+		} else if (sprites) {
 			down_button->setSpriteBank(sprites);
 			down_button->setSprite(EGBS_BUTTON_UP,
 					s32(skin->getIcon(EGDI_CURSOR_DOWN)),
@@ -507,6 +578,112 @@ void GUIScrollBar::refreshControls()
 			border_size = RelativeRect.getWidth();
 	}
 
+	// Note: The styling targets are named in accordance with the buttons' visual layout
+	// ('up' is on the top or the right). However, the variables here are named based
+	// on the buttons' logical function ('up' decrements, 'down' increments).
+	// Since the value of a horizontal scrollbar increases to the right, the 'up'
+	// visual position corresponds to the 'down' logical function, and vice versa.
+	up_button->setStyles(is_horizontal ? DownArrowStyles : UpArrowStyles);
+	down_button->setStyles(is_horizontal ? UpArrowStyles : DownArrowStyles);
+
 	up_button->setVisible(visible);
 	down_button->setVisible(visible);
+}
+
+void GUIScrollBar::setColor(video::SColor color)
+{
+	BgColor = color;
+
+	auto skin = Environment->getSkin();
+	TrackColor = skin->getColor(EGDC_SCROLLBAR).getInterpolated(BgColor, 0.65f);
+
+	float d = 0.65f;
+	for (size_t i = 0; i < 4; i++) {
+		video::SColor base = Environment->getSkin()->getColor((gui::EGUI_DEFAULT_COLOR)i);
+		ThumbColors[i] = base.getInterpolated(color, d);
+	}
+}
+
+void GUIScrollBar::setTrackImage(video::ITexture* image)
+{
+	image->grab();
+
+	if (TrackTexture.Texture)
+		TrackTexture.Texture->drop();
+
+	TrackTexture.Texture.reset(image);
+}
+
+void GUIScrollBar::setThumbImage(video::ITexture* image)
+{
+	image->grab();
+
+	if (ThumbTexture.Texture)
+		ThumbTexture.Texture->drop();
+
+	ThumbTexture.Texture.reset(image);
+}
+
+void GUIScrollBar::setFromStyle(const StyleSpec& style)
+{
+	DrawBorder = style.getBool(StyleSpec::BORDER, true);
+
+	if (style.isNotDefault(StyleSpec::BGCOLOR)) {
+		setColor(style.getColor(StyleSpec::BGCOLOR, video::SColor(255,255,255,255)));
+	}
+
+	TrackTexture.MiddleRect = style.getRect(StyleSpec::BGIMG_MIDDLE, core::rect<s32>());
+
+	if (style.isNotDefault(StyleSpec::BGIMG)) {
+		video::ITexture *texture = style.getTexture(StyleSpec::BGIMG,
+				m_tsrc);
+		if (TrackTexture.MiddleRect.getArea() == 0) {
+			setTrackImage(guiScalingImageButton(
+					Environment->getVideoDriver(), texture,
+							AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+		} else {
+			setTrackImage(texture);
+		}
+	}
+
+	if (style.isNotDefault(StyleSpec::PADDING)) {
+		TrackPadding = style.getRect(StyleSpec::PADDING, core::rect<s32>());
+		TrackPadding.UpperLeftCorner.X =
+				core::s32_clamp(TrackPadding.UpperLeftCorner.X, 0, AbsoluteRect.getWidth() / 2);
+		TrackPadding.UpperLeftCorner.Y =
+				core::s32_clamp(TrackPadding.UpperLeftCorner.Y, 0, AbsoluteRect.getHeight() / 2);
+		TrackPadding.LowerRightCorner.X =
+				core::s32_clamp(TrackPadding.LowerRightCorner.X, -AbsoluteRect.getWidth() / 2, 0);
+		TrackPadding.LowerRightCorner.Y =
+				core::s32_clamp(TrackPadding.LowerRightCorner.Y, -AbsoluteRect.getHeight() / 2, 0);
+	}
+
+	ThumbTexture.MiddleRect = style.getRect(StyleSpec::FGIMG_MIDDLE, core::rect<s32>());
+
+	if (style.isNotDefault(StyleSpec::FGIMG)) {
+		video::ITexture *texture = style.getTexture(StyleSpec::FGIMG,
+				m_tsrc);
+		if (ThumbTexture.MiddleRect.getArea() == 0) {
+			setThumbImage(guiScalingImageButton(
+					Environment->getVideoDriver(), texture,
+							AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+			// If a thumb image is given and the thumb middle is unspecified, we assume
+			// that the user wishes to disable stretching of the thumb so as not to
+			// break the image.
+			StaticThumb = true;
+		} else {
+			setThumbImage(texture);
+		}
+	}
+}
+
+void GUIScrollBar::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles)
+{
+	Styles = styles;
+	UpArrowStyles = up_arrow_styles;
+	DownArrowStyles = down_arrow_styles;
+	setFromStyle(StyleSpec::getStyleFromStatePropagation(Styles, StyleSpec::STATE_DEFAULT));
+	refreshControls();
 }

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -15,6 +15,9 @@ the arrow buttons where there is insufficient space.
 #include <optional>
 #include <IGUIEnvironment.h>
 #include <IGUIScrollBar.h>
+#include "StyleSpec.h"
+#include "guiButton.h"
+#include "irr_ptr.h"
 
 class ISimpleTextureSource;
 
@@ -33,6 +36,12 @@ public:
 		HIDE,
 		SHOW,
 		DEFAULT
+	};
+
+	struct ScrollBarImage {
+		irr_ptr<video::ITexture> Texture;
+		core::rect<s32> SourceRect;
+		core::rect<s32> MiddleRect;
 	};
 
 	virtual void draw() override;
@@ -65,13 +74,21 @@ public:
 	void setPageSize(s32 size) override;
 	void setArrowsVisible(ArrowVisibility visible);
 
+	void setColor(video::SColor color);
+	void setTrackImage(video::ITexture* image);
+	void setThumbImage(video::ITexture* image);
+	void setFromStyle(const StyleSpec& style);
+	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles);
+
 private:
 	void refreshControls();
 	s32 getPosFromMousePos(const core::position2di &p) const;
 	f32 range() const { return f32(max_pos - min_pos); }
 
-	IGUIButton *up_button;
-	IGUIButton *down_button;
+	GUIButton *up_button;
+	GUIButton *down_button;
 	ArrowVisibility arrow_visibility = DEFAULT;
 	bool is_dragging;
 	bool is_horizontal;
@@ -92,8 +109,26 @@ private:
 	s32 page_size;
 	s32 border_size;
 
+	std::array<StyleSpec, StyleSpec::NUM_STATES> Styles;
+	std::array<StyleSpec, StyleSpec::NUM_STATES> UpArrowStyles;
+	std::array<StyleSpec, StyleSpec::NUM_STATES> DownArrowStyles;
+
+	core::rect<s32> track_rect;
 	core::rect<s32> slider_rect;
 	video::SColor current_icon_color;
+
+	core::rect<s32> TrackPadding;
+
+	ScrollBarImage TrackTexture;
+	ScrollBarImage ThumbTexture;
+
+	video::SColor BgColor = video::SColor(0xFF,0xFF,0xFF,0xFF);
+
+	video::SColor TrackColor;
+	video::SColor ThumbColors[4];
+
+	bool DrawBorder = true;
+	bool StaticThumb = false;
 
 	ISimpleTextureSource *m_tsrc;
 

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -42,9 +42,9 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 		m_rowheight = MYMAX(m_rowheight, 1);
 	}
 
-	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
+	m_scrollbar_width = skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
 	core::rect<s32> scrollbarrect = RelativeRect;
-	scrollbarrect.UpperLeftCorner.X += RelativeRect.getWidth() - s;
+	scrollbarrect.UpperLeftCorner.X += RelativeRect.getWidth() - m_scrollbar_width;
 
 	m_scrollbar = new GUIScrollBar(Environment, getParent(), -1,
 			scrollbarrect, false, true, tsrc);
@@ -677,8 +677,7 @@ void GUITable::draw()
 
 	core::rect<s32> row_rect(AbsoluteRect);
 	if (m_scrollbar->isVisible())
-		row_rect.LowerRightCorner.X -=
-			skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
+		row_rect.LowerRightCorner.X -= m_scrollbar_width;
 	row_rect.UpperLeftCorner.Y += row_min * m_rowheight - scrollpos;
 	row_rect.LowerRightCorner.Y = row_rect.UpperLeftCorner.Y + m_rowheight;
 
@@ -1265,4 +1264,19 @@ void GUITable::alignContent(Cell *cell, s32 xmax, s32 content_width, s32 align)
 		cell->xpos = cell->xmin;
 		cell->xmax = cell->xmin + content_width;
 	}
+}
+
+void GUITable::setScrollbarStyle(
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+		const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles)
+{
+	if (styles[StyleSpec::STATE_DEFAULT].isNotDefault(StyleSpec::SIZE)) {
+		m_scrollbar_width = styles[StyleSpec::STATE_DEFAULT].getIntArray(StyleSpec::SIZE, {0, 0, 0, 0})[0];
+
+		core::rect<s32> rect = RelativeRect;
+		rect.UpperLeftCorner.X += RelativeRect.getWidth() - m_scrollbar_width;
+		m_scrollbar->setRelativePosition(rect);
+	}
+	m_scrollbar->setStyles(styles, up_arrow_styles, down_arrow_styles);
 }

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -127,6 +127,10 @@ public:
 	/* Irrlicht event handler */
 	virtual bool OnEvent(const SEvent &event);
 
+	void setScrollbarStyle(const std::array<StyleSpec, StyleSpec::NUM_STATES>& styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& up_arrow_styles,
+			const std::array<StyleSpec, StyleSpec::NUM_STATES>& down_arrow_styles);
+
 protected:
 	enum ColumnType {
 		COLUMN_TYPE_TEXT,
@@ -187,6 +191,7 @@ protected:
 	s32 m_rowheight = 1;
 	gui::IGUIFont *m_font = nullptr;
 	GUIScrollBar *m_scrollbar = nullptr;
+	u32 m_scrollbar_width = 0;
 
 	// Allocated strings and images
 	std::vector<core::stringw> m_strings;


### PR DESCRIPTION
- Goal of the PR
  - To permit scrollbars in formspecs to be themed.
- How does the PR work?
  - `style` and `style_type` rules can now affect scrollbars in more ways than just `noclip`. GUIScrollBar is modified to reflect styling properties, and various formspec element classes are modified to pass styling information to their implicit scrollbars. All style properties used by scrollbars are defined already, so there is no change in that regard.
- Does it resolve any reported issue?
  - This fixes #9692 .
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - This PR is a prerequisite for a new main menu (2.3), unless it is superseded by a new UI API, though it relates to UI improvements in general.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - Among other things, it is now possible to provide a background and thumb image to a scrollbar, tint the default border of a scrollbar, and let the thumb have a fixed size.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  - Grok wrote a lot of the test code included below. It also helped me figure out how the source code works, and offered pointers on how C++ works.

## To do

This PR is ready for review.

A few questions to consider:
- Is the documentation satisfactory?
- Is the implementation used for pseudo-elements acceptable?
- Are `up`/`down` good names for the scrollbar buttons?
- Should an `fgimg` without an `fgimg_middle` implicitly cause `scrollbaroptions[thumbsize=0]`?
- Is anything missing that should go here? (#13991 ?)

## How to test

Create and load a mod with the following code in MTG, then run `/scrollbardemo`:
```
local modname = minetest.get_current_modname()
local modpath = minetest.get_modpath(modname)

-- Helper to escape formspec strings
local esc = minetest.formspec_escape

-- A long dummy list for scrolling
local function long_list(sep, num)
    local items = {}
    for i = 1, num or 80 do
        table.insert(items, "Line " .. i .. "   • some content • lorem ipsum dolor")
    end
    return table.concat(items, sep or ",\n")
end

local function get_demo_formspec()
    return "formspec_version[6]" ..
    "size[16,10]" ..

    -- 1. Default (no custom style)
    "label[0.2,0.2;1. Default styling.]" ..
    "textarea[0.2,0.6;3.8,4;ta_default;;Some very long text that needs scrolling...\n" ..
        "Line 2\nLine 3\n...\n"..long_list().."]" ..

    -- 2. Custom color + thin size
    "style[ta_color.scrollbar;bgcolor=#ff880044;size=12]" ..
    "textarea[4.2,0.2;3.8,1;;;2. Thin implicit scrollbar, orange tint.]" ..
    "textarea[4.2,1.1;3.8,3.5;ta_color;;Long scrolling content...\n"..long_list().."\n...]" ..

    -- 3. Image track + image thumb (9-slice style)
    "style[ta_image.scrollbar;" ..
        "border=false;" ..
        "bgimg=default_glass.png;" ..
        "bgimg_middle=4;" ..
        "fgimg=default_tree_top.png;" ..
        "fgimg_middle=4;" ..
        "padding=8;" ..
        "size=24]" ..
    "label[8.2,0.2;3.8,1;3. Glass track, 9-slice thumb, padding.]" ..
    "textarea[8.2,1.1;3.8,3.5;ta_image;;" .. long_list("\n", 10) .. "]" ..

    -- 4. Textlist with custom scrollbar (wide purple thumb, arrows styled)
    "style[tl_custom.scrollbar;bgcolor=#aa44ff88;fgimg=default_lava.png;" ..
        "fgimg_middle=6,6,12,12]" ..
    "style[tl_custom.scrollbar.up;fgimg=default_paper.png;bgimg=default_wood.png]" ..
    "style[tl_custom.scrollbar.down;fgimg=default_mese_crystal.png]" ..
    "label[12.2,0.2;3.8,1;4. Textlist, purple tint, images, styled arrows.]" ..
    "textlist[12.2,1.1;3.8,3.5;tl_custom;" .. long_list(",") .. ";1;false]" ..

    -- 5. Explicit scrollbar with arrows=show, thumbsize=0 (square thumb)
    "scrollbaroptions[arrows=show;thumbsize=0]" ..
    "style[explicit_sb;border=false;bgcolor=#4488ff;fgimg=default_mineral_diamond.png]" ..
    "style[explicit_sb.up;border=false;fgimg=default_book.png]" ..
    "scrollbar[0.2,5.2;15,0.6;horizontal;explicit_sb;400]" ..
    "label[0.2,5;5. Explicit horizontal scrollbar (image thumb, borderless, arrow styles).]" ..

    -- 6. Table with custom thin scrollbar
    "style[table_demo.scrollbar;size=10;bgcolor=#88ff4488;bgimg=default_snow.png;border=false]" ..
    "tablecolumns[text;text;text;text]" ..
    "table[0.2,6.2;7.8,3.6;table_demo;" ..
        "Header1,Header2,Header3," ..
        "Cell A1,Cell B1,Cell C1," ..
        "Cell A2,Cell B2 with longer text,Cell C2," ..
        "A3,B3,C3," ..
        long_list(",_,_,") ..
    ";1]"
end

minetest.register_chatcommand("scrollbardemo", {
    description = "Show scrollbar styling demo formspec",
    func = function(name)
        minetest.show_formspec(name, modname .. ":demo", get_demo_formspec())
    end,
})
```
