### PR TITLE
Refactor rollback: IRollbackManager, RollbackMgr, SQLite3 backend

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2294,6 +2294,7 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 #    If enabled, node and inventory actions are recorded for rollback.
 #    This option is only read on server start. Note that the engine will not
 #    automatically clean old entries from the rollback database.
+#    The storage backend is configured per-world in the file "world.mt".
 enable_rollback_recording (Rollback recording) bool false
 
 [**Server/Env Performance] [server]

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7504,6 +7504,9 @@ Item handling
 Rollback
 --------
 
+These functions require rollback recording to be enabled on the server (`enable_rollback_recording = true`).
+See [`world.mt` documentation](world_format.md) for selecting the rollback storage backend.
+
 * `core.rollback_get_node_actions(pos, range, seconds, limit)`:
   returns `{{actor, pos, time, oldnode, newnode}, ...}`
     * Find who has done something to a node, or near a node

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -163,6 +163,7 @@ content. The convention is `<modname>.<setting>`.
     readonly_backend = sqlite3    - optionally read-only seed DB (DB file _must_ be located in "readonly" subfolder)
     auth_backend = sqlite3        - which DB backend to use for authentication data
     mod_storage_backend = sqlite3 - which DB backend to use for mod storage
+    rollback_backend = sqlite3    - which DB backend to use for rollback. If unset, defaults to `sqlite3`.
     load_mod_<mod> = false        - whether <mod> is to be loaded in this world
     blocksize = 32                - mapblock size, only written if it's non-standard (16)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,6 +453,7 @@ static void print_help(const OptionList &allowed_options)
 		{"players", ServerEnvironment::getPlayerDatabaseBackends()},
 		{"auth", ServerEnvironment::getAuthDatabaseBackends()},
 		{"mod storage", Server::getModStorageDatabaseBackends()},
+		{"rollback", Server::getRollbackBackends()},
 	};
 
 	std::cout << "Supported database backends:";

--- a/src/rollback_interface.h
+++ b/src/rollback_interface.h
@@ -102,17 +102,17 @@ public:
 	virtual bool isActorGuess() = 0;
 	virtual void setActor(const std::string &actor, bool is_guess) = 0;
 	virtual std::string getSuspect(v3s16 p, float nearness_shortcut,
-	                               float min_nearness) = 0;
+		float min_nearness) = 0;
 
 	virtual ~IRollbackManager() = default;;
 	virtual void flush() = 0;
 	// Get all actors that did something to position p, but not further than
 	// <seconds> in history
 	virtual std::list<RollbackAction> getNodeActors(v3s16 pos, int range,
-	                time_t seconds, int limit) = 0;
+		time_t seconds, int limit) = 0;
 	// Get actions to revert <seconds> of history made by <actor>
 	virtual std::list<RollbackAction> getRevertActions(const std::string &actor,
-	                time_t seconds) = 0;
+		time_t seconds) = 0;
 };
 
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -27,7 +27,7 @@
 #include "serverenvironment.h"
 #include "servermap.h"
 #include "server/player_sao.h"
-#include "server/rollback.h"
+#include "server/rollback_sqlite3.h"
 #include "server/serveractiveobject.h"
 #include "server/serverinventorymgr.h"
 #include "server/serverlist.h"
@@ -466,6 +466,27 @@ Server::~Server()
 	}
 }
 
+IRollbackManager *Server::createRollbackManager()
+{
+	Settings world_mt;
+	const std::string world_mt_path = m_path_world + DIR_DELIM + "world.mt";
+	if (!world_mt.readConfigFile(world_mt_path.c_str()))
+		throw BaseException("Cannot read world.mt!");
+
+	std::string backend = "sqlite3"; // fallback value
+	world_mt.getNoEx("rollback_backend", backend);
+
+	if (backend == "sqlite3") {
+		verbosestream << "Rollback: using backend \"sqlite3\"" << std::endl;
+		return new RollbackMgrSQLite3(m_path_world, this);
+	}
+
+	auto supported = getRollbackBackends();
+	throw ServerError("Rollback backend \"" + backend +
+		"\" is not supported; supported backends are " +
+		str_join(supported, ", ") + ".");
+}
+
 void Server::init()
 {
 	infostream << "Server created for gameid \"" << m_gamespec.id << "\"";
@@ -577,8 +598,8 @@ void Server::init()
 	m_emerge->initMapgens(servermap.getMapgenParams());
 
 	if (g_settings->getBool("enable_rollback_recording")) {
-		// Create rollback manager
-		m_rollback = new RollbackManager(m_path_world, this);
+		// Create rollback manager (default sqlite3, world-configurable in world.mt).
+		m_rollback = createRollbackManager();
 	}
 
 	// Give environment reference to scripting api
@@ -4433,6 +4454,13 @@ std::vector<std::string> Server::getModStorageDatabaseBackends()
 #endif
 	ret.emplace_back("files");
 	ret.emplace_back("dummy");
+	return ret;
+}
+
+std::vector<std::string> Server::getRollbackBackends()
+{
+	std::vector<std::string> ret;
+	ret.emplace_back("sqlite3");
 	return ret;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -445,7 +445,10 @@ public:
 	// map key = binary sha1, map value = file path
 	std::unordered_map<std::string, std::string> getMediaList();
 
+	IRollbackManager *createRollbackManager();
+
 	static std::vector<std::string> getModStorageDatabaseBackends();
+	static std::vector<std::string> getRollbackBackends();
 
 	static ModStorageDatabase *openModStorageDatabase(const std::string &world_path);
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -10,6 +10,7 @@ set(common_server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/rollback.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/rollback_sqlite3.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverinventorymgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverlist.cpp

--- a/src/server/rollback.cpp
+++ b/src/server/rollback.cpp
@@ -2,654 +2,142 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
-#include "rollback.h"
-#include "exceptions.h"
-#include <list>
-#include "log.h"
+#include "server/rollback.h"
+
+#include <ctime>
+#include <stdexcept>
+
 #include "gamedef.h"
-#include "nodedef.h"
-#include "util/string.h"
 #include "util/numeric.h"
-#include "inventorymanager.h" // deserializing InventoryLocations
-#include "sqlite3.h"
-#include "filesys.h"
 
-#define POINTS_PER_NODE (16.0f)
-
-#define SQLRES(f, good) \
-	if ((f) != (good)) {\
-		throw FileNotGoodException(std::string("RollbackManager: " \
-			"SQLite3 error (" __FILE__ ":" TOSTRING(__LINE__) \
-			"): ") + sqlite3_errmsg(db)); \
-	}
-#define SQLOK(f) SQLRES(f, SQLITE_OK)
-
-#define SQLOK_ERRSTREAM(s, m)                             \
-	if ((s) != SQLITE_OK) {                               \
-		errorstream << "RollbackManager: " << (m) << ": " \
-			<< sqlite3_errmsg(db) << std::endl;           \
-	}
-
-#define FINALIZE_STATEMENT(statement) \
-	SQLOK_ERRSTREAM(sqlite3_finalize(statement), "Failed to finalize " #statement)
-
-class ItemStackRow : public ItemStack {
-public:
-	ItemStackRow & operator = (const ItemStack & other)
-	{
-		*static_cast<ItemStack *>(this) = other;
-		return *this;
-	}
-
-	int id = 0;
-};
-
-struct ActionRow {
-	int          id = 0;
-	int          actor;
-	time_t       timestamp;
-	int          type;
-	std::string  location, list;
-	int          index, add;
-	ItemStackRow stack;
-	int          nodeMeta;
-	int          x, y, z;
-	int          oldNode;
-	int          oldParam1, oldParam2;
-	std::string  oldMeta;
-	int          newNode;
-	int          newParam1, newParam2;
-	std::string  newMeta;
-	int          guessed;
-};
-
-
-struct Entity {
-	int         id;
-	std::string name;
-};
-
-
-
-RollbackManager::RollbackManager(const std::string & world_path,
-		IGameDef * gamedef_) :
+RollbackMgr::RollbackMgr(IGameDef *gamedef_) :
 	gamedef(gamedef_)
 {
-	verbosestream << "RollbackManager::RollbackManager(" << world_path
-		<< ")" << std::endl;
-
-	database_path = world_path + DIR_DELIM "rollback.sqlite";
-
-	initDatabase();
 }
 
-
-RollbackManager::~RollbackManager()
+void RollbackMgr::reportAction(const RollbackAction &action_)
 {
+	// Ignore if not important
+	if (!action_.isImportant(gamedef))
+		return;
+
+	RollbackAction action = action_;
+	action.unix_time = time(0);
+
+	// Figure out actor
+	action.actor = current_actor;
+	action.actor_is_guess = current_actor_is_guess;
+
+	if (action.actor.empty()) { // If actor is not known, find out suspect or cancel
+		v3s16 p;
+		if (!action.getPosition(&p))
+			return;
+
+		action.actor = getSuspect(p, 83, 1);
+		if (action.actor.empty())
+			return;
+
+		action.actor_is_guess = true;
+	}
+
+	addActionInternal(action);
+}
+
+std::string RollbackMgr::getActor()
+{
+	return current_actor;
+}
+
+bool RollbackMgr::isActorGuess()
+{
+	return current_actor_is_guess;
+}
+
+void RollbackMgr::setActor(const std::string &actor, bool is_guess)
+{
+	current_actor = actor;
+	current_actor_is_guess = is_guess;
+}
+
+std::string RollbackMgr::getSuspect(v3s16 p, float nearness_shortcut,
+		float min_nearness)
+{
+	if (!current_actor.empty()) {
+		return current_actor;
+	}
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - (100 - min_nearness);
+	RollbackAction likely_suspect;
+	float likely_suspect_nearness = 0;
+
+	for (auto i = action_latest_buffer.rbegin(); i != action_latest_buffer.rend(); ++i) {
+		if (i->unix_time < first_time) {
+			break;
+		}
+		if (i->actor.empty()) {
+			continue;
+		}
+		// Find position of suspect or continue
+		v3s16 suspect_p;
+		if (!i->getPosition(&suspect_p)) {
+			continue;
+		}
+
+		float f = getSuspectNearness(i->actor_is_guess, suspect_p, i->unix_time, p, cur_time);
+		if (f >= min_nearness && f > likely_suspect_nearness) {
+			likely_suspect_nearness = f;
+			likely_suspect = *i;
+			if (likely_suspect_nearness >= nearness_shortcut)
+				break;
+		}
+	}
+	// No likely suspect was found
+	if (likely_suspect_nearness == 0) {
+		return "";
+	}
+	// Likely suspect was found
+	return likely_suspect.actor;
+}
+
+void RollbackMgr::flushBufferContents()
+{
+	if (action_todisk_buffer.empty())
+		return;
+
+	for (const auto &a : action_todisk_buffer) {
+		if (a.actor.empty())
+			continue;
+		persistAction(a);
+	}
+	action_todisk_buffer.clear();
+}
+
+std::list<RollbackAction> RollbackMgr::getNodeActors(
+		v3s16 pos, int range, time_t seconds, int limit)
+{
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - seconds;
 	flush();
-
-	FINALIZE_STATEMENT(stmt_insert);
-	FINALIZE_STATEMENT(stmt_replace);
-	FINALIZE_STATEMENT(stmt_select);
-	FINALIZE_STATEMENT(stmt_select_range);
-	FINALIZE_STATEMENT(stmt_select_withActor);
-	FINALIZE_STATEMENT(stmt_knownActor_select);
-	FINALIZE_STATEMENT(stmt_knownActor_insert);
-	FINALIZE_STATEMENT(stmt_knownNode_select);
-	FINALIZE_STATEMENT(stmt_knownNode_insert);
-
-	SQLOK_ERRSTREAM(sqlite3_close(db), "Could not close db");
+	return getActionsSince_range(first_time, pos, range, limit);
 }
 
-
-void RollbackManager::registerNewActor(const int id, const std::string &name)
+std::list<RollbackAction> RollbackMgr::getRevertActions(
+		const std::string &actor_filter, time_t seconds)
 {
-	Entity actor = {id, name};
-	knownActors.push_back(actor);
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - seconds;
+	flush();
+	return getActionsSince(first_time, actor_filter);
 }
-
-
-void RollbackManager::registerNewNode(const int id, const std::string &name)
-{
-	Entity node = {id, name};
-	knownNodes.push_back(node);
-}
-
-
-int RollbackManager::getActorId(const std::string &name)
-{
-	for (auto iter = knownActors.begin();
-			iter != knownActors.end(); ++iter) {
-		if (iter->name == name) {
-			return iter->id;
-		}
-	}
-
-	SQLOK(sqlite3_bind_text(stmt_knownActor_insert, 1, name.c_str(), name.size(), NULL));
-	SQLRES(sqlite3_step(stmt_knownActor_insert), SQLITE_DONE);
-	SQLOK(sqlite3_reset(stmt_knownActor_insert));
-
-	int id = sqlite3_last_insert_rowid(db);
-	registerNewActor(id, name);
-
-	return id;
-}
-
-
-int RollbackManager::getNodeId(const std::string &name)
-{
-	for (auto iter = knownNodes.begin();
-			iter != knownNodes.end(); ++iter) {
-		if (iter->name == name) {
-			return iter->id;
-		}
-	}
-
-	SQLOK(sqlite3_bind_text(stmt_knownNode_insert, 1, name.c_str(), name.size(), NULL));
-	SQLRES(sqlite3_step(stmt_knownNode_insert), SQLITE_DONE);
-	SQLOK(sqlite3_reset(stmt_knownNode_insert));
-
-	int id = sqlite3_last_insert_rowid(db);
-	registerNewNode(id, name);
-
-	return id;
-}
-
-
-const char * RollbackManager::getActorName(const int id)
-{
-	for (auto iter = knownActors.begin();
-			iter != knownActors.end(); ++iter) {
-		if (iter->id == id) {
-			return iter->name.c_str();
-		}
-	}
-
-	return "";
-}
-
-
-const char * RollbackManager::getNodeName(const int id)
-{
-	for (auto iter = knownNodes.begin();
-			iter != knownNodes.end(); ++iter) {
-		if (iter->id == id) {
-			return iter->name.c_str();
-		}
-	}
-
-	return "";
-}
-
-
-bool RollbackManager::createTables()
-{
-	SQLOK(sqlite3_exec(db,
-		"CREATE TABLE IF NOT EXISTS `actor` (\n"
-		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"
-		"	`name` TEXT NOT NULL\n"
-		");\n"
-		"CREATE TABLE IF NOT EXISTS `node` (\n"
-		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"
-		"	`name` TEXT NOT NULL\n"
-		");\n"
-		"CREATE TABLE IF NOT EXISTS `action` (\n"
-		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-		"	`actor` INTEGER NOT NULL,\n"
-		"	`timestamp` TIMESTAMP NOT NULL,\n"
-		"	`type` INTEGER NOT NULL,\n"
-		"	`list` TEXT,\n"
-		"	`index` INTEGER,\n"
-		"	`add` INTEGER,\n"
-		"	`stackNode` INTEGER,\n"
-		"	`stackQuantity` INTEGER,\n"
-		"	`nodeMeta` INTEGER,\n"
-		"	`x` INT,\n"
-		"	`y` INT,\n"
-		"	`z` INT,\n"
-		"	`oldNode` INTEGER,\n"
-		"	`oldParam1` INTEGER,\n"
-		"	`oldParam2` INTEGER,\n"
-		"	`oldMeta` TEXT,\n"
-		"	`newNode` INTEGER,\n"
-		"	`newParam1` INTEGER,\n"
-		"	`newParam2` INTEGER,\n"
-		"	`newMeta` TEXT,\n"
-		"	`guessedActor` INTEGER,\n"
-		"	FOREIGN KEY (`actor`) REFERENCES `actor`(`id`),\n"
-		"	FOREIGN KEY (`stackNode`) REFERENCES `node`(`id`),\n"
-		"	FOREIGN KEY (`oldNode`)   REFERENCES `node`(`id`),\n"
-		"	FOREIGN KEY (`newNode`)   REFERENCES `node`(`id`)\n"
-		");\n"
-		// We run queries with the following filters:
-		// - `timestamp` >= ? AND `actor` = ?
-		// - `timestamp` >= ?
-		// - `timestamp` >= ? AND <range query on X, Y, Z>
-		"CREATE INDEX IF NOT EXISTS `actionIndex` ON `action`(`x`,`y`,`z`,`timestamp`,`actor`);\n"
-		"CREATE INDEX IF NOT EXISTS `actionTimestampActorIndex` ON `action`(`timestamp`,`actor`);\n",
-		NULL, NULL, NULL));
-
-	return true;
-}
-
-
-bool RollbackManager::initDatabase()
-{
-	verbosestream << "RollbackManager: Database connection setup" << std::endl;
-
-	SQLOK(sqlite3_open_v2(database_path.c_str(), &db,
-			SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL));
-
-	createTables();
-
-	SQLOK(sqlite3_prepare_v2(db,
-		"INSERT INTO `action` (\n"
-		"	`actor`, `timestamp`, `type`,\n"
-		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodeMeta`,\n"
-		"	`x`, `y`, `z`,\n"
-		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
-		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
-		"	`guessedActor`\n"
-		") VALUES (\n"
-		"	?, ?, ?,\n"
-		"	?, ?, ?, ?, ?, ?,\n"
-		"	?, ?, ?,\n"
-		"	?, ?, ?, ?,\n"
-		"	?, ?, ?, ?,\n"
-		"	?"
-		");",
-		-1, &stmt_insert, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db,
-		"REPLACE INTO `action` (\n"
-		"	`actor`, `timestamp`, `type`,\n"
-		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodeMeta`,\n"
-		"	`x`, `y`, `z`,\n"
-		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
-		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
-		"	`guessedActor`, `id`\n"
-		") VALUES (\n"
-		"	?, ?, ?,\n"
-		"	?, ?, ?, ?, ?, ?,\n"
-		"	?, ?, ?,\n"
-		"	?, ?, ?, ?,\n"
-		"	?, ?, ?, ?,\n"
-		"	?, ?\n"
-		");",
-		-1, &stmt_replace, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db,
-		"SELECT\n"
-		"	`actor`, `timestamp`, `type`,\n"
-		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
-		"	`x`, `y`, `z`,\n"
-		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
-		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
-		"	`guessedActor`\n"
-		" FROM `action`\n"
-		" WHERE `timestamp` >= ?\n"
-		" ORDER BY `timestamp` DESC, `id` DESC",
-		-1, &stmt_select, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db,
-		"SELECT\n"
-		"	`actor`, `timestamp`, `type`,\n"
-		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
-		"	`x`, `y`, `z`,\n"
-		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
-		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
-		"	`guessedActor`\n"
-		"FROM `action`\n"
-		"WHERE `timestamp` >= ?\n"
-		"	AND `x` IS NOT NULL\n"
-		"	AND `y` IS NOT NULL\n"
-		"	AND `z` IS NOT NULL\n"
-		"	AND `x` BETWEEN ? AND ?\n"
-		"	AND `y` BETWEEN ? AND ?\n"
-		"	AND `z` BETWEEN ? AND ?\n"
-		"ORDER BY `timestamp` DESC, `id` DESC\n"
-		"LIMIT 0,?",
-		-1, &stmt_select_range, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db,
-		"SELECT\n"
-		"	`actor`, `timestamp`, `type`,\n"
-		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
-		"	`x`, `y`, `z`,\n"
-		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
-		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
-		"	`guessedActor`\n"
-		"FROM `action`\n"
-		"WHERE `timestamp` >= ?\n"
-		"	AND `actor` = ?\n"
-		"ORDER BY `timestamp` DESC, `id` DESC\n",
-		-1, &stmt_select_withActor, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db, "SELECT `id`, `name` FROM `actor`",
-			-1, &stmt_knownActor_select, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db, "INSERT INTO `actor` (`name`) VALUES (?)",
-			-1, &stmt_knownActor_insert, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db, "SELECT `id`, `name` FROM `node`",
-			-1, &stmt_knownNode_select, NULL));
-
-	SQLOK(sqlite3_prepare_v2(db, "INSERT INTO `node` (`name`) VALUES (?)",
-			-1, &stmt_knownNode_insert, NULL));
-
-	verbosestream << "SQL prepared statements setup correctly" << std::endl;
-
-	while (sqlite3_step(stmt_knownActor_select) == SQLITE_ROW) {
-		registerNewActor(
-		        sqlite3_column_int(stmt_knownActor_select, 0),
-		        reinterpret_cast<const char *>(sqlite3_column_text(stmt_knownActor_select, 1))
-		);
-	}
-	SQLOK(sqlite3_reset(stmt_knownActor_select));
-
-	while (sqlite3_step(stmt_knownNode_select) == SQLITE_ROW) {
-		registerNewNode(
-		        sqlite3_column_int(stmt_knownNode_select, 0),
-		        reinterpret_cast<const char *>(sqlite3_column_text(stmt_knownNode_select, 1))
-		);
-	}
-	SQLOK(sqlite3_reset(stmt_knownNode_select));
-
-	return true;
-}
-
-
-bool RollbackManager::registerRow(const ActionRow & row)
-{
-	sqlite3_stmt * stmt_do = (row.id) ? stmt_replace : stmt_insert;
-
-	bool nodeMeta = false;
-
-	SQLOK(sqlite3_bind_int  (stmt_do, 1, row.actor));
-	SQLOK(sqlite3_bind_int64(stmt_do, 2, row.timestamp));
-	SQLOK(sqlite3_bind_int  (stmt_do, 3, row.type));
-
-	if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
-		const std::string & loc = row.location;
-		nodeMeta = (loc.substr(0, 9) == "nodemeta:");
-
-		SQLOK(sqlite3_bind_text(stmt_do, 4, row.list.c_str(), row.list.size(), NULL));
-		SQLOK(sqlite3_bind_int (stmt_do, 5, row.index));
-		SQLOK(sqlite3_bind_int (stmt_do, 6, row.add));
-		SQLOK(sqlite3_bind_int (stmt_do, 7, row.stack.id));
-		SQLOK(sqlite3_bind_int (stmt_do, 8, row.stack.count));
-		SQLOK(sqlite3_bind_int (stmt_do, 9, (int) nodeMeta));
-
-		if (nodeMeta) {
-			std::string::size_type p1, p2;
-			p1 = loc.find(':') + 1;
-			p2 = loc.find(',');
-			std::string x = loc.substr(p1, p2 - p1);
-			p1 = p2 + 1;
-			p2 = loc.find(',', p1);
-			std::string y = loc.substr(p1, p2 - p1);
-			std::string z = loc.substr(p2 + 1);
-			SQLOK(sqlite3_bind_int(stmt_do, 10, atoi(x.c_str())));
-			SQLOK(sqlite3_bind_int(stmt_do, 11, atoi(y.c_str())));
-			SQLOK(sqlite3_bind_int(stmt_do, 12, atoi(z.c_str())));
-		}
-	} else {
-		SQLOK(sqlite3_bind_null(stmt_do, 4));
-		SQLOK(sqlite3_bind_null(stmt_do, 5));
-		SQLOK(sqlite3_bind_null(stmt_do, 6));
-		SQLOK(sqlite3_bind_null(stmt_do, 7));
-		SQLOK(sqlite3_bind_null(stmt_do, 8));
-		SQLOK(sqlite3_bind_null(stmt_do, 9));
-	}
-
-	if (row.type == RollbackAction::TYPE_SET_NODE) {
-		SQLOK(sqlite3_bind_int (stmt_do, 10, row.x));
-		SQLOK(sqlite3_bind_int (stmt_do, 11, row.y));
-		SQLOK(sqlite3_bind_int (stmt_do, 12, row.z));
-		SQLOK(sqlite3_bind_int (stmt_do, 13, row.oldNode));
-		SQLOK(sqlite3_bind_int (stmt_do, 14, row.oldParam1));
-		SQLOK(sqlite3_bind_int (stmt_do, 15, row.oldParam2));
-		SQLOK(sqlite3_bind_text(stmt_do, 16, row.oldMeta.c_str(), row.oldMeta.size(), NULL));
-		SQLOK(sqlite3_bind_int (stmt_do, 17, row.newNode));
-		SQLOK(sqlite3_bind_int (stmt_do, 18, row.newParam1));
-		SQLOK(sqlite3_bind_int (stmt_do, 19, row.newParam2));
-		SQLOK(sqlite3_bind_text(stmt_do, 20, row.newMeta.c_str(), row.newMeta.size(), NULL));
-		SQLOK(sqlite3_bind_int (stmt_do, 21, row.guessed ? 1 : 0));
-	} else {
-		if (!nodeMeta) {
-			SQLOK(sqlite3_bind_null(stmt_do, 10));
-			SQLOK(sqlite3_bind_null(stmt_do, 11));
-			SQLOK(sqlite3_bind_null(stmt_do, 12));
-		}
-		SQLOK(sqlite3_bind_null(stmt_do, 13));
-		SQLOK(sqlite3_bind_null(stmt_do, 14));
-		SQLOK(sqlite3_bind_null(stmt_do, 15));
-		SQLOK(sqlite3_bind_null(stmt_do, 16));
-		SQLOK(sqlite3_bind_null(stmt_do, 17));
-		SQLOK(sqlite3_bind_null(stmt_do, 18));
-		SQLOK(sqlite3_bind_null(stmt_do, 19));
-		SQLOK(sqlite3_bind_null(stmt_do, 20));
-		SQLOK(sqlite3_bind_null(stmt_do, 21));
-	}
-
-	if (row.id) {
-		SQLOK(sqlite3_bind_int(stmt_do, 22, row.id));
-	}
-
-	int written = sqlite3_step(stmt_do);
-
-	SQLOK(sqlite3_reset(stmt_do));
-
-	return written == SQLITE_DONE;
-}
-
-
-const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt* stmt)
-{
-	std::list<ActionRow> rows;
-	const unsigned char * text;
-	size_t size;
-
-	while (sqlite3_step(stmt) == SQLITE_ROW) {
-		ActionRow row;
-
-		row.actor     = sqlite3_column_int  (stmt, 0);
-		row.timestamp = sqlite3_column_int64(stmt, 1);
-		row.type      = sqlite3_column_int  (stmt, 2);
-		row.nodeMeta  = 0;
-
-		if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
-			text = sqlite3_column_text (stmt, 3);
-			size = sqlite3_column_bytes(stmt, 3);
-			row.list        = std::string(reinterpret_cast<const char*>(text), size);
-			row.index       = sqlite3_column_int(stmt, 4);
-			row.add         = sqlite3_column_int(stmt, 5);
-			row.stack.id    = sqlite3_column_int(stmt, 6);
-			row.stack.count = sqlite3_column_int(stmt, 7);
-			row.nodeMeta    = sqlite3_column_int(stmt, 8);
-		}
-
-		if (row.type == RollbackAction::TYPE_SET_NODE || row.nodeMeta) {
-			row.x = sqlite3_column_int(stmt,  9);
-			row.y = sqlite3_column_int(stmt, 10);
-			row.z = sqlite3_column_int(stmt, 11);
-		}
-
-		if (row.type == RollbackAction::TYPE_SET_NODE) {
-			row.oldNode   = sqlite3_column_int(stmt, 12);
-			row.oldParam1 = sqlite3_column_int(stmt, 13);
-			row.oldParam2 = sqlite3_column_int(stmt, 14);
-			text = sqlite3_column_text (stmt, 15);
-			size = sqlite3_column_bytes(stmt, 15);
-			row.oldMeta   = std::string(reinterpret_cast<const char*>(text), size);
-			row.newNode   = sqlite3_column_int(stmt, 16);
-			row.newParam1 = sqlite3_column_int(stmt, 17);
-			row.newParam2 = sqlite3_column_int(stmt, 18);
-			text = sqlite3_column_text(stmt, 19);
-			size = sqlite3_column_bytes(stmt, 19);
-			row.newMeta   = std::string(reinterpret_cast<const char*>(text), size);
-			row.guessed   = sqlite3_column_int(stmt, 20);
-		}
-
-		if (row.nodeMeta) {
-			row.location = "nodemeta:";
-			row.location += itos(row.x);
-			row.location += ',';
-			row.location += itos(row.y);
-			row.location += ',';
-			row.location += itos(row.z);
-		} else {
-			row.location = getActorName(row.actor);
-		}
-
-		rows.push_back(row);
-	}
-
-	SQLOK(sqlite3_reset(stmt));
-
-	return rows;
-}
-
-
-ActionRow RollbackManager::actionRowFromRollbackAction(const RollbackAction & action)
-{
-	ActionRow row;
-
-	row.actor     = getActorId(action.actor);
-	row.timestamp = action.unix_time;
-	row.type      = action.type;
-
-	if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
-		row.location = action.inventory_location;
-		row.list     = action.inventory_list;
-		row.index    = action.inventory_index;
-		row.add      = action.inventory_add;
-		row.stack    = action.inventory_stack;
-		row.stack.id = getNodeId(row.stack.name);
-	} else {
-		row.x         = action.p.X;
-		row.y         = action.p.Y;
-		row.z         = action.p.Z;
-		row.oldNode   = getNodeId(action.n_old.name);
-		row.oldParam1 = action.n_old.param1;
-		row.oldParam2 = action.n_old.param2;
-		row.oldMeta   = action.n_old.meta;
-		row.newNode   = getNodeId(action.n_new.name);
-		row.newParam1 = action.n_new.param1;
-		row.newParam2 = action.n_new.param2;
-		row.newMeta   = action.n_new.meta;
-		row.guessed   = action.actor_is_guess;
-	}
-
-	return row;
-}
-
-
-const std::list<RollbackAction> RollbackManager::rollbackActionsFromActionRows(
-		const std::list<ActionRow> & rows)
-{
-	std::list<RollbackAction> actions;
-
-	for (const ActionRow &row : rows) {
-		RollbackAction action;
-		action.actor     = (row.actor) ? getActorName(row.actor) : "";
-		action.unix_time = row.timestamp;
-		action.type      = static_cast<RollbackAction::Type>(row.type);
-
-		switch (action.type) {
-		case RollbackAction::TYPE_MODIFY_INVENTORY_STACK:
-			action.inventory_location = row.location;
-			action.inventory_list     = row.list;
-			action.inventory_index    = row.index;
-			action.inventory_add      = row.add;
-			action.inventory_stack    = row.stack;
-			if (action.inventory_stack.name.empty()) {
-				action.inventory_stack.name = getNodeName(row.stack.id);
-			}
-			break;
-
-		case RollbackAction::TYPE_SET_NODE:
-			action.p            = v3s16(row.x, row.y, row.z);
-			action.n_old.name   = getNodeName(row.oldNode);
-			action.n_old.param1 = row.oldParam1;
-			action.n_old.param2 = row.oldParam2;
-			action.n_old.meta   = row.oldMeta;
-			action.n_new.name   = getNodeName(row.newNode);
-			action.n_new.param1 = row.newParam1;
-			action.n_new.param2 = row.newParam2;
-			action.n_new.meta   = row.newMeta;
-			break;
-
-		default:
-			assert(false);
-			break;
-		}
-
-		actions.push_back(action);
-	}
-
-	return actions;
-}
-
-
-const std::list<ActionRow> RollbackManager::getRowsSince(time_t firstTime, const std::string & actor)
-{
-	sqlite3_stmt *stmt_stmt = actor.empty() ? stmt_select : stmt_select_withActor;
-	sqlite3_bind_int64(stmt_stmt, 1, firstTime);
-
-	if (!actor.empty()) {
-		sqlite3_bind_int(stmt_stmt, 2, getActorId(actor));
-	}
-
-	const std::list<ActionRow> & rows = actionRowsFromSelect(stmt_stmt);
-	sqlite3_reset(stmt_stmt);
-
-	return rows;
-}
-
-
-const std::list<ActionRow> RollbackManager::getRowsSince_range(
-		time_t start_time, v3s16 p, int range, int limit)
-{
-
-	sqlite3_bind_int64(stmt_select_range, 1, start_time);
-	sqlite3_bind_int  (stmt_select_range, 2, static_cast<int>(p.X - range));
-	sqlite3_bind_int  (stmt_select_range, 3, static_cast<int>(p.X + range));
-	sqlite3_bind_int  (stmt_select_range, 4, static_cast<int>(p.Y - range));
-	sqlite3_bind_int  (stmt_select_range, 5, static_cast<int>(p.Y + range));
-	sqlite3_bind_int  (stmt_select_range, 6, static_cast<int>(p.Z - range));
-	sqlite3_bind_int  (stmt_select_range, 7, static_cast<int>(p.Z + range));
-	sqlite3_bind_int  (stmt_select_range, 8, limit);
-
-	const std::list<ActionRow> & rows = actionRowsFromSelect(stmt_select_range);
-	sqlite3_reset(stmt_select_range);
-
-	return rows;
-}
-
-
-const std::list<RollbackAction> RollbackManager::getActionsSince_range(
-		time_t start_time, v3s16 p, int range, int limit)
-{
-	return rollbackActionsFromActionRows(getRowsSince_range(start_time, p, range, limit));
-}
-
-
-const std::list<RollbackAction> RollbackManager::getActionsSince(
-		time_t start_time, const std::string & actor)
-{
-	return rollbackActionsFromActionRows(getRowsSince(start_time, actor));
-}
-
 
 // Get nearness factor for subject's action for this action
 // Return value: 0 = impossible, >0 = factor
-float RollbackManager::getSuspectNearness(bool is_guess, v3s16 suspect_p,
+float RollbackMgr::getSuspectNearness(bool is_guess, v3s16 suspect_p,
 		time_t suspect_t, v3s16 action_p, time_t action_t)
 {
 	// Suspect cannot cause things in the past
 	if (action_t < suspect_t) {
-		return 0;        // 0 = cannot be
+		return 0;
 	}
 	// Start from 100
 	int f = 100;
@@ -662,154 +150,46 @@ float RollbackManager::getSuspectNearness(bool is_guess, v3s16 suspect_p,
 		f /= 2;
 	}
 	// Limit to 0
-	f = MYMAX(f, 0);
+	if (f < 0) {
+		f = 0;
+	}
 	return f;
 }
 
-
-void RollbackManager::reportAction(const RollbackAction &action_)
-{
-	// Ignore if not important
-	if (!action_.isImportant(gamedef)) {
-		return;
-	}
-
-	RollbackAction action = action_;
-	action.unix_time = time(0);
-
-	// Figure out actor
-	action.actor = current_actor;
-	action.actor_is_guess = current_actor_is_guess;
-
-	if (action.actor.empty()) { // If actor is not known, find out suspect or cancel
-		v3s16 p;
-		if (!action.getPosition(&p)) {
-			return;
-		}
-
-		action.actor = getSuspect(p, 83, 1);
-		if (action.actor.empty()) {
-			return;
-		}
-
-		action.actor_is_guess = true;
-	}
-
-	addAction(action);
-}
-
-std::string RollbackManager::getActor()
-{
-	return current_actor;
-}
-
-bool RollbackManager::isActorGuess()
-{
-	return current_actor_is_guess;
-}
-
-void RollbackManager::setActor(const std::string & actor, bool is_guess)
-{
-	current_actor = actor;
-	current_actor_is_guess = is_guess;
-}
-
-std::string RollbackManager::getSuspect(v3s16 p, float nearness_shortcut,
-		float min_nearness)
-{
-	if (!current_actor.empty()) {
-		return current_actor;
-	}
-	time_t cur_time = time(0);
-	time_t first_time = cur_time - (100 - min_nearness);
-	RollbackAction likely_suspect;
-	float likely_suspect_nearness = 0;
-	for (auto i = action_latest_buffer.rbegin();
-	     i != action_latest_buffer.rend(); ++i) {
-		if (i->unix_time < first_time) {
-			break;
-		}
-		if (i->actor.empty()) {
-			continue;
-		}
-		// Find position of suspect or continue
-		v3s16 suspect_p;
-		if (!i->getPosition(&suspect_p)) {
-			continue;
-		}
-		float f = getSuspectNearness(i->actor_is_guess, suspect_p,
-					     i->unix_time, p, cur_time);
-		if (f >= min_nearness && f > likely_suspect_nearness) {
-			likely_suspect_nearness = f;
-			likely_suspect = *i;
-			if (likely_suspect_nearness >= nearness_shortcut) {
-				break;
-			}
-		}
-	}
-	// No likely suspect was found
-	if (likely_suspect_nearness == 0) {
-		return "";
-	}
-	// Likely suspect was found
-	return likely_suspect.actor;
-}
-
-
-void RollbackManager::flush()
-{
-	sqlite3_exec(db, "BEGIN", NULL, NULL, NULL);
-
-	for (auto iter = action_todisk_buffer.begin();
-			iter != action_todisk_buffer.end();
-			++iter) {
-		if (iter->actor.empty()) {
-			continue;
-		}
-
-		registerRow(actionRowFromRollbackAction(*iter));
-	}
-
-	sqlite3_exec(db, "COMMIT", NULL, NULL, NULL);
-	action_todisk_buffer.clear();
-}
-
-
-void RollbackManager::addAction(const RollbackAction & action)
+void RollbackMgr::addActionInternal(const RollbackAction &action)
 {
 	action_todisk_buffer.push_back(action);
 	action_latest_buffer.push_back(action);
 
 	// Flush to disk sometimes
-	if (action_todisk_buffer.size() >= 500) {
+	if (action_todisk_buffer.size() >= BUFFER_LIMIT)
 		flush();
-	}
 	// Cut off latest log sometimes
-	while (action_latest_buffer.size() >= 500) {
+	while (action_latest_buffer.size() >= BUFFER_LIMIT)
 		action_latest_buffer.pop_front();
-	}
 }
 
-std::list<RollbackAction> RollbackManager::getNodeActors(v3s16 pos, int range,
-		time_t seconds, int limit)
+void RollbackMgr::parseNodemetaLocation(const std::string &loc, int &x, int &y, int &z)
 {
-	time_t cur_time = time(0);
-	time_t first_time = cur_time - seconds;
+	// Format: "nodemeta:x,y,z"
+	if (loc.size() < 9 || loc.compare(0, 9, "nodemeta:") != 0)
+		throw std::invalid_argument("Invalid nodemeta location format");
 
-	flush();
+	std::string::size_type p1 = loc.find(':') + 1;
+	std::string::size_type p2 = loc.find(',');
+	if (p2 == std::string::npos)
+		throw std::invalid_argument("Invalid nodemeta location format");
 
-	return getActionsSince_range(first_time, pos, range, limit);
+	std::string x_str = loc.substr(p1, p2 - p1);
+	p1 = p2 + 1;
+	p2 = loc.find(',', p1);
+	if (p2 == std::string::npos)
+		throw std::invalid_argument("Invalid nodemeta location format");
+
+	std::string y_str = loc.substr(p1, p2 - p1);
+	std::string z_str = loc.substr(p2 + 1);
+
+	x = atoi(x_str.c_str());
+	y = atoi(y_str.c_str());
+	z = atoi(z_str.c_str());
 }
-
-std::list<RollbackAction> RollbackManager::getRevertActions(
-		const std::string &actor_filter,
-		time_t seconds)
-{
-	time_t cur_time = time(0);
-	time_t first_time = cur_time - seconds;
-
-	flush();
-
-	return getActionsSince(first_time, actor_filter);
-}
-

--- a/src/server/rollback.h
+++ b/src/server/rollback.h
@@ -1,67 +1,65 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+//
+// Shared logic for rollback backends (SQLite/PostgreSQL).
+// This exists to avoid copy-pasting the same buffering/suspect logic into each backend.
 
 #pragma once
 
-#include <string>
-#include "irr_v3d.h"
-#include "rollback_interface.h"
-#include <list>
-#include <vector>
 #include <deque>
-#include "sqlite3.h"
+#include <list>
+#include <string>
+#include <vector>
+
+#include "rollback_interface.h"
 
 class IGameDef;
 
-struct ActionRow;
-struct Entity;
-
-class RollbackManager final : public IRollbackManager
+class RollbackMgr : public IRollbackManager
 {
 public:
-	RollbackManager(const std::string & world_path, IGameDef * gamedef);
-	~RollbackManager();
+	~RollbackMgr() override = default;
 
-	void reportAction(const RollbackAction & action_);
-	std::string getActor();
-	bool isActorGuess();
-	void setActor(const std::string & actor, bool is_guess);
-	std::string getSuspect(v3s16 p, float nearness_shortcut,
-			float min_nearness);
-	void flush();
+	// IRollbackManager
+	void reportAction(const RollbackAction &action_) override;
+	std::string getActor() override;
+	bool isActorGuess() override;
+	void setActor(const std::string &actor, bool is_guess) override;
+	std::string getSuspect(v3s16 p, float nearness_shortcut, float min_nearness) override;
+	virtual void flush() = 0;
+	std::list<RollbackAction> getNodeActors(v3s16 pos, int range, time_t seconds, int limit) override;
+	std::list<RollbackAction> getRevertActions(const std::string &actor_filter, time_t seconds) override;
 
-	void addAction(const RollbackAction & action);
-	std::list<RollbackAction> getNodeActors(v3s16 pos, int range,
-			time_t seconds, int limit);
-	std::list<RollbackAction> getRevertActions(
-			const std::string & actor_filter, time_t seconds);
-
-private:
-	void registerNewActor(const int id, const std::string & name);
-	void registerNewNode(const int id, const std::string & name);
-	int getActorId(const std::string & name);
-	int getNodeId(const std::string & name);
-	const char * getActorName(const int id);
-	const char * getNodeName(const int id);
-	bool createTables();
-	bool initDatabase();
-	bool registerRow(const ActionRow & row);
-	const std::list<ActionRow> actionRowsFromSelect(sqlite3_stmt * stmt);
-	ActionRow actionRowFromRollbackAction(const RollbackAction & action);
-	const std::list<RollbackAction> rollbackActionsFromActionRows(
-			const std::list<ActionRow> & rows);
-	const std::list<ActionRow> getRowsSince(time_t firstTime,
-			const std::string & actor);
-	const std::list<ActionRow> getRowsSince_range(time_t firstTime, v3s16 p,
-			int range, int limit);
-	const std::list<RollbackAction> getActionsSince_range(time_t firstTime, v3s16 p,
-			int range, int limit);
-	const std::list<RollbackAction> getActionsSince(time_t firstTime,
-			const std::string & actor = "");
+protected:
+	explicit RollbackMgr(IGameDef *gamedef_);
 	static float getSuspectNearness(bool is_guess, v3s16 suspect_p,
-		time_t suspect_t, v3s16 action_p, time_t action_t);
+			time_t suspect_t, v3s16 action_p, time_t action_t);
 
+	void addActionInternal(const RollbackAction &action);
+
+	// Helper for derived classes to flush buffer contents
+	// Derived classes handle transactions/persistence as needed
+	void flushBufferContents();
+
+public:
+	// Helper to parse nodemeta location format: "nodemeta:x,y,z"
+	// Throws std::invalid_argument on invalid format
+	static void parseNodemetaLocation(const std::string &loc, int &x, int &y, int &z);
+
+protected:
+
+	// Backend-specific hooks
+	virtual void beginSaveActions() = 0;
+	virtual void endSaveActions() = 0;
+	virtual void rollbackSaveActions() = 0;
+	virtual void persistAction(const RollbackAction &a) = 0;
+	virtual std::list<RollbackAction> getActionsSince(time_t firstTime, const std::string &actor_filter) = 0;
+	virtual std::list<RollbackAction> getActionsSince_range(time_t firstTime, v3s16 p, int range, int limit) = 0;
+
+protected:
+	static constexpr float POINTS_PER_NODE = 16.0f;
+	static constexpr size_t BUFFER_LIMIT = 500;
 
 	IGameDef *gamedef = nullptr;
 
@@ -70,19 +68,6 @@ private:
 
 	std::vector<RollbackAction> action_todisk_buffer;
 	std::deque<RollbackAction> action_latest_buffer;
-
-	std::string database_path;
-	sqlite3 *db = nullptr;
-	sqlite3_stmt *stmt_insert = nullptr;
-	sqlite3_stmt *stmt_replace = nullptr;
-	sqlite3_stmt *stmt_select = nullptr;
-	sqlite3_stmt *stmt_select_range = nullptr;
-	sqlite3_stmt *stmt_select_withActor = nullptr;
-	sqlite3_stmt *stmt_knownActor_select = nullptr;
-	sqlite3_stmt *stmt_knownActor_insert = nullptr;
-	sqlite3_stmt *stmt_knownNode_select = nullptr;
-	sqlite3_stmt *stmt_knownNode_insert = nullptr;
-
-	std::vector<Entity> knownActors;
-	std::vector<Entity> knownNodes;
 };
+
+

--- a/src/server/rollback_sqlite3.cpp
+++ b/src/server/rollback_sqlite3.cpp
@@ -1,0 +1,815 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#include "rollback_sqlite3.h"
+#include "exceptions.h"
+#include <list>
+#include "log.h"
+#include "gamedef.h"
+#include "nodedef.h"
+#include "util/string.h"
+#include "util/numeric.h"
+#include "inventorymanager.h" // deserializing InventoryLocations
+#include "sqlite3.h"
+#include "filesys.h"
+
+#define POINTS_PER_NODE (16.0f)
+
+#define SQLRES(f, good) \
+	if ((f) != (good)) {\
+		throw FileNotGoodException(std::string("RollbackMgrSqlite3: " \
+			"SQLite3 error (" __FILE__ ":" TOSTRING(__LINE__) \
+			"): ") + sqlite3_errmsg(db)); \
+	}
+#define SQLOK(f) SQLRES(f, SQLITE_OK)
+
+#define SQLOK_ERRSTREAM(s, m)                             \
+	if ((s) != SQLITE_OK) {                               \
+		errorstream << "RollbackMgrSqlite3: " << (m) << ": " \
+			<< sqlite3_errmsg(db) << std::endl;           \
+	}
+
+#define FINALIZE_STATEMENT(statement) \
+	SQLOK_ERRSTREAM(sqlite3_finalize(statement), "Failed to finalize " #statement)
+
+class ItemStackRow : public ItemStack {
+public:
+	ItemStackRow & operator = (const ItemStack & other)
+	{
+		*static_cast<ItemStack *>(this) = other;
+		return *this;
+	}
+
+	int id = 0;
+};
+
+struct ActionRow {
+	int          id = 0;
+	int          actor;
+	time_t       timestamp;
+	int          type;
+	std::string  location, list;
+	int          index, add;
+	ItemStackRow stack;
+	int          nodeMeta;
+	int          x, y, z;
+	int          oldNode;
+	int          oldParam1, oldParam2;
+	std::string  oldMeta;
+	int          newNode;
+	int          newParam1, newParam2;
+	std::string  newMeta;
+	int          guessed;
+};
+
+
+struct Entity {
+	int         id;
+	std::string name;
+};
+
+
+
+RollbackMgrSQLite3::RollbackMgrSQLite3(const std::string & world_path,
+		IGameDef * gamedef_) :
+	gamedef(gamedef_)
+{
+	verbosestream << "RollbackMgrSQLite3::RollbackMgrSQLite3(" << world_path
+		<< ")" << std::endl;
+
+	database_path = world_path + DIR_DELIM "rollback.sqlite";
+
+	initDatabase();
+}
+
+
+RollbackMgrSQLite3::~RollbackMgrSQLite3()
+{
+	flush();
+
+	FINALIZE_STATEMENT(stmt_insert);
+	FINALIZE_STATEMENT(stmt_replace);
+	FINALIZE_STATEMENT(stmt_select);
+	FINALIZE_STATEMENT(stmt_select_range);
+	FINALIZE_STATEMENT(stmt_select_withActor);
+	FINALIZE_STATEMENT(stmt_knownActor_select);
+	FINALIZE_STATEMENT(stmt_knownActor_insert);
+	FINALIZE_STATEMENT(stmt_knownNode_select);
+	FINALIZE_STATEMENT(stmt_knownNode_insert);
+
+	SQLOK_ERRSTREAM(sqlite3_close(db), "Could not close db");
+}
+
+
+void RollbackMgrSQLite3::registerNewActor(const int id, const std::string &name)
+{
+	Entity actor = {id, name};
+	knownActors.push_back(actor);
+}
+
+
+void RollbackMgrSQLite3::registerNewNode(const int id, const std::string &name)
+{
+	Entity node = {id, name};
+	knownNodes.push_back(node);
+}
+
+
+int RollbackMgrSQLite3::getActorId(const std::string &name)
+{
+	for (auto iter = knownActors.begin();
+			iter != knownActors.end(); ++iter) {
+		if (iter->name == name) {
+			return iter->id;
+		}
+	}
+
+	SQLOK(sqlite3_bind_text(stmt_knownActor_insert, 1, name.c_str(), name.size(), NULL));
+	SQLRES(sqlite3_step(stmt_knownActor_insert), SQLITE_DONE);
+	SQLOK(sqlite3_reset(stmt_knownActor_insert));
+
+	int id = sqlite3_last_insert_rowid(db);
+	registerNewActor(id, name);
+
+	return id;
+}
+
+
+int RollbackMgrSQLite3::getNodeId(const std::string &name)
+{
+	for (auto iter = knownNodes.begin();
+			iter != knownNodes.end(); ++iter) {
+		if (iter->name == name) {
+			return iter->id;
+		}
+	}
+
+	SQLOK(sqlite3_bind_text(stmt_knownNode_insert, 1, name.c_str(), name.size(), NULL));
+	SQLRES(sqlite3_step(stmt_knownNode_insert), SQLITE_DONE);
+	SQLOK(sqlite3_reset(stmt_knownNode_insert));
+
+	int id = sqlite3_last_insert_rowid(db);
+	registerNewNode(id, name);
+
+	return id;
+}
+
+
+const char * RollbackMgrSQLite3::getActorName(const int id)
+{
+	for (auto iter = knownActors.begin();
+			iter != knownActors.end(); ++iter) {
+		if (iter->id == id) {
+			return iter->name.c_str();
+		}
+	}
+
+	return "";
+}
+
+
+const char * RollbackMgrSQLite3::getNodeName(const int id)
+{
+	for (auto iter = knownNodes.begin();
+			iter != knownNodes.end(); ++iter) {
+		if (iter->id == id) {
+			return iter->name.c_str();
+		}
+	}
+
+	return "";
+}
+
+
+bool RollbackMgrSQLite3::createTables()
+{
+	SQLOK(sqlite3_exec(db,
+		"CREATE TABLE IF NOT EXISTS `actor` (\n"
+		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"
+		"	`name` TEXT NOT NULL\n"
+		");\n"
+		"CREATE TABLE IF NOT EXISTS `node` (\n"
+		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"
+		"	`name` TEXT NOT NULL\n"
+		");\n"
+		"CREATE TABLE IF NOT EXISTS `action` (\n"
+		"	`id` INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+		"	`actor` INTEGER NOT NULL,\n"
+		"	`timestamp` TIMESTAMP NOT NULL,\n"
+		"	`type` INTEGER NOT NULL,\n"
+		"	`list` TEXT,\n"
+		"	`index` INTEGER,\n"
+		"	`add` INTEGER,\n"
+		"	`stackNode` INTEGER,\n"
+		"	`stackQuantity` INTEGER,\n"
+		"	`nodeMeta` INTEGER,\n"
+		"	`x` INT,\n"
+		"	`y` INT,\n"
+		"	`z` INT,\n"
+		"	`oldNode` INTEGER,\n"
+		"	`oldParam1` INTEGER,\n"
+		"	`oldParam2` INTEGER,\n"
+		"	`oldMeta` TEXT,\n"
+		"	`newNode` INTEGER,\n"
+		"	`newParam1` INTEGER,\n"
+		"	`newParam2` INTEGER,\n"
+		"	`newMeta` TEXT,\n"
+		"	`guessedActor` INTEGER,\n"
+		"	FOREIGN KEY (`actor`) REFERENCES `actor`(`id`),\n"
+		"	FOREIGN KEY (`stackNode`) REFERENCES `node`(`id`),\n"
+		"	FOREIGN KEY (`oldNode`)   REFERENCES `node`(`id`),\n"
+		"	FOREIGN KEY (`newNode`)   REFERENCES `node`(`id`)\n"
+		");\n"
+		// We run queries with the following filters:
+		// - `timestamp` >= ? AND `actor` = ?
+		// - `timestamp` >= ?
+		// - `timestamp` >= ? AND <range query on X, Y, Z>
+		"CREATE INDEX IF NOT EXISTS `actionIndex` ON `action`(`x`,`y`,`z`,`timestamp`,`actor`);\n"
+		"CREATE INDEX IF NOT EXISTS `actionTimestampActorIndex` ON `action`(`timestamp`,`actor`);\n",
+		NULL, NULL, NULL));
+
+	return true;
+}
+
+
+bool RollbackMgrSQLite3::initDatabase()
+{
+	verbosestream << "RollbackMgrSQLite3: Database connection setup" << std::endl;
+
+	SQLOK(sqlite3_open_v2(database_path.c_str(), &db,
+			SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL));
+
+	createTables();
+
+	SQLOK(sqlite3_prepare_v2(db,
+		"INSERT INTO `action` (\n"
+		"	`actor`, `timestamp`, `type`,\n"
+		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodeMeta`,\n"
+		"	`x`, `y`, `z`,\n"
+		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
+		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
+		"	`guessedActor`\n"
+		") VALUES (\n"
+		"	?, ?, ?,\n"
+		"	?, ?, ?, ?, ?, ?,\n"
+		"	?, ?, ?,\n"
+		"	?, ?, ?, ?,\n"
+		"	?, ?, ?, ?,\n"
+		"	?"
+		");",
+		-1, &stmt_insert, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db,
+		"REPLACE INTO `action` (\n"
+		"	`actor`, `timestamp`, `type`,\n"
+		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodeMeta`,\n"
+		"	`x`, `y`, `z`,\n"
+		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
+		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
+		"	`guessedActor`, `id`\n"
+		") VALUES (\n"
+		"	?, ?, ?,\n"
+		"	?, ?, ?, ?, ?, ?,\n"
+		"	?, ?, ?,\n"
+		"	?, ?, ?, ?,\n"
+		"	?, ?, ?, ?,\n"
+		"	?, ?\n"
+		");",
+		-1, &stmt_replace, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db,
+		"SELECT\n"
+		"	`actor`, `timestamp`, `type`,\n"
+		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
+		"	`x`, `y`, `z`,\n"
+		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
+		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
+		"	`guessedActor`\n"
+		" FROM `action`\n"
+		" WHERE `timestamp` >= ?\n"
+		" ORDER BY `timestamp` DESC, `id` DESC",
+		-1, &stmt_select, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db,
+		"SELECT\n"
+		"	`actor`, `timestamp`, `type`,\n"
+		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
+		"	`x`, `y`, `z`,\n"
+		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
+		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
+		"	`guessedActor`\n"
+		"FROM `action`\n"
+		"WHERE `timestamp` >= ?\n"
+		"	AND `x` IS NOT NULL\n"
+		"	AND `y` IS NOT NULL\n"
+		"	AND `z` IS NOT NULL\n"
+		"	AND `x` BETWEEN ? AND ?\n"
+		"	AND `y` BETWEEN ? AND ?\n"
+		"	AND `z` BETWEEN ? AND ?\n"
+		"ORDER BY `timestamp` DESC, `id` DESC\n"
+		"LIMIT 0,?",
+		-1, &stmt_select_range, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db,
+		"SELECT\n"
+		"	`actor`, `timestamp`, `type`,\n"
+		"	`list`, `index`, `add`, `stackNode`, `stackQuantity`, `nodemeta`,\n"
+		"	`x`, `y`, `z`,\n"
+		"	`oldNode`, `oldParam1`, `oldParam2`, `oldMeta`,\n"
+		"	`newNode`, `newParam1`, `newParam2`, `newMeta`,\n"
+		"	`guessedActor`\n"
+		"FROM `action`\n"
+		"WHERE `timestamp` >= ?\n"
+		"	AND `actor` = ?\n"
+		"ORDER BY `timestamp` DESC, `id` DESC\n",
+		-1, &stmt_select_withActor, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db, "SELECT `id`, `name` FROM `actor`",
+			-1, &stmt_knownActor_select, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db, "INSERT INTO `actor` (`name`) VALUES (?)",
+			-1, &stmt_knownActor_insert, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db, "SELECT `id`, `name` FROM `node`",
+			-1, &stmt_knownNode_select, NULL));
+
+	SQLOK(sqlite3_prepare_v2(db, "INSERT INTO `node` (`name`) VALUES (?)",
+			-1, &stmt_knownNode_insert, NULL));
+
+	verbosestream << "SQL prepared statements setup correctly" << std::endl;
+
+	while (sqlite3_step(stmt_knownActor_select) == SQLITE_ROW) {
+		registerNewActor(
+			sqlite3_column_int(stmt_knownActor_select, 0),
+			reinterpret_cast<const char *>(sqlite3_column_text(stmt_knownActor_select, 1))
+		);
+	}
+	SQLOK(sqlite3_reset(stmt_knownActor_select));
+
+	while (sqlite3_step(stmt_knownNode_select) == SQLITE_ROW) {
+		registerNewNode(
+			sqlite3_column_int(stmt_knownNode_select, 0),
+			reinterpret_cast<const char *>(sqlite3_column_text(stmt_knownNode_select, 1))
+		);
+	}
+	SQLOK(sqlite3_reset(stmt_knownNode_select));
+
+	return true;
+}
+
+
+bool RollbackMgrSQLite3::registerRow(const ActionRow & row)
+{
+	sqlite3_stmt * stmt_do = (row.id) ? stmt_replace : stmt_insert;
+
+	bool nodeMeta = false;
+
+	SQLOK(sqlite3_bind_int  (stmt_do, 1, row.actor));
+	SQLOK(sqlite3_bind_int64(stmt_do, 2, row.timestamp));
+	SQLOK(sqlite3_bind_int  (stmt_do, 3, row.type));
+
+	if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
+		const std::string & loc = row.location;
+		nodeMeta = (loc.substr(0, 9) == "nodemeta:");
+
+		SQLOK(sqlite3_bind_text(stmt_do, 4, row.list.c_str(), row.list.size(), NULL));
+		SQLOK(sqlite3_bind_int (stmt_do, 5, row.index));
+		SQLOK(sqlite3_bind_int (stmt_do, 6, row.add));
+		SQLOK(sqlite3_bind_int (stmt_do, 7, row.stack.id));
+		SQLOK(sqlite3_bind_int (stmt_do, 8, row.stack.count));
+		SQLOK(sqlite3_bind_int (stmt_do, 9, (int) nodeMeta));
+
+		if (nodeMeta) {
+			std::string::size_type p1, p2;
+			p1 = loc.find(':') + 1;
+			p2 = loc.find(',');
+			std::string x = loc.substr(p1, p2 - p1);
+			p1 = p2 + 1;
+			p2 = loc.find(',', p1);
+			std::string y = loc.substr(p1, p2 - p1);
+			std::string z = loc.substr(p2 + 1);
+			SQLOK(sqlite3_bind_int(stmt_do, 10, atoi(x.c_str())));
+			SQLOK(sqlite3_bind_int(stmt_do, 11, atoi(y.c_str())));
+			SQLOK(sqlite3_bind_int(stmt_do, 12, atoi(z.c_str())));
+		}
+	} else {
+		SQLOK(sqlite3_bind_null(stmt_do, 4));
+		SQLOK(sqlite3_bind_null(stmt_do, 5));
+		SQLOK(sqlite3_bind_null(stmt_do, 6));
+		SQLOK(sqlite3_bind_null(stmt_do, 7));
+		SQLOK(sqlite3_bind_null(stmt_do, 8));
+		SQLOK(sqlite3_bind_null(stmt_do, 9));
+	}
+
+	if (row.type == RollbackAction::TYPE_SET_NODE) {
+		SQLOK(sqlite3_bind_int (stmt_do, 10, row.x));
+		SQLOK(sqlite3_bind_int (stmt_do, 11, row.y));
+		SQLOK(sqlite3_bind_int (stmt_do, 12, row.z));
+		SQLOK(sqlite3_bind_int (stmt_do, 13, row.oldNode));
+		SQLOK(sqlite3_bind_int (stmt_do, 14, row.oldParam1));
+		SQLOK(sqlite3_bind_int (stmt_do, 15, row.oldParam2));
+		SQLOK(sqlite3_bind_text(stmt_do, 16, row.oldMeta.c_str(), row.oldMeta.size(), NULL));
+		SQLOK(sqlite3_bind_int (stmt_do, 17, row.newNode));
+		SQLOK(sqlite3_bind_int (stmt_do, 18, row.newParam1));
+		SQLOK(sqlite3_bind_int (stmt_do, 19, row.newParam2));
+		SQLOK(sqlite3_bind_text(stmt_do, 20, row.newMeta.c_str(), row.newMeta.size(), NULL));
+		SQLOK(sqlite3_bind_int (stmt_do, 21, row.guessed ? 1 : 0));
+	} else {
+		if (!nodeMeta) {
+			SQLOK(sqlite3_bind_null(stmt_do, 10));
+			SQLOK(sqlite3_bind_null(stmt_do, 11));
+			SQLOK(sqlite3_bind_null(stmt_do, 12));
+		}
+		SQLOK(sqlite3_bind_null(stmt_do, 13));
+		SQLOK(sqlite3_bind_null(stmt_do, 14));
+		SQLOK(sqlite3_bind_null(stmt_do, 15));
+		SQLOK(sqlite3_bind_null(stmt_do, 16));
+		SQLOK(sqlite3_bind_null(stmt_do, 17));
+		SQLOK(sqlite3_bind_null(stmt_do, 18));
+		SQLOK(sqlite3_bind_null(stmt_do, 19));
+		SQLOK(sqlite3_bind_null(stmt_do, 20));
+		SQLOK(sqlite3_bind_null(stmt_do, 21));
+	}
+
+	if (row.id) {
+		SQLOK(sqlite3_bind_int(stmt_do, 22, row.id));
+	}
+
+	int written = sqlite3_step(stmt_do);
+
+	SQLOK(sqlite3_reset(stmt_do));
+
+	return written == SQLITE_DONE;
+}
+
+
+const std::list<ActionRow> RollbackMgrSQLite3::actionRowsFromSelect(sqlite3_stmt* stmt)
+{
+	std::list<ActionRow> rows;
+	const unsigned char * text;
+	size_t size;
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		ActionRow row;
+
+		row.actor     = sqlite3_column_int  (stmt, 0);
+		row.timestamp = sqlite3_column_int64(stmt, 1);
+		row.type      = sqlite3_column_int  (stmt, 2);
+		row.nodeMeta  = 0;
+
+		if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
+			text = sqlite3_column_text (stmt, 3);
+			size = sqlite3_column_bytes(stmt, 3);
+			row.list        = std::string(reinterpret_cast<const char*>(text), size);
+			row.index       = sqlite3_column_int(stmt, 4);
+			row.add         = sqlite3_column_int(stmt, 5);
+			row.stack.id    = sqlite3_column_int(stmt, 6);
+			row.stack.count = sqlite3_column_int(stmt, 7);
+			row.nodeMeta    = sqlite3_column_int(stmt, 8);
+		}
+
+		if (row.type == RollbackAction::TYPE_SET_NODE || row.nodeMeta) {
+			row.x = sqlite3_column_int(stmt,  9);
+			row.y = sqlite3_column_int(stmt, 10);
+			row.z = sqlite3_column_int(stmt, 11);
+		}
+
+		if (row.type == RollbackAction::TYPE_SET_NODE) {
+			row.oldNode   = sqlite3_column_int(stmt, 12);
+			row.oldParam1 = sqlite3_column_int(stmt, 13);
+			row.oldParam2 = sqlite3_column_int(stmt, 14);
+			text = sqlite3_column_text (stmt, 15);
+			size = sqlite3_column_bytes(stmt, 15);
+			row.oldMeta   = std::string(reinterpret_cast<const char*>(text), size);
+			row.newNode   = sqlite3_column_int(stmt, 16);
+			row.newParam1 = sqlite3_column_int(stmt, 17);
+			row.newParam2 = sqlite3_column_int(stmt, 18);
+			text = sqlite3_column_text(stmt, 19);
+			size = sqlite3_column_bytes(stmt, 19);
+			row.newMeta   = std::string(reinterpret_cast<const char*>(text), size);
+			row.guessed   = sqlite3_column_int(stmt, 20);
+		}
+
+		if (row.nodeMeta) {
+			row.location = "nodemeta:";
+			row.location += itos(row.x);
+			row.location += ',';
+			row.location += itos(row.y);
+			row.location += ',';
+			row.location += itos(row.z);
+		} else {
+			row.location = getActorName(row.actor);
+		}
+
+		rows.push_back(row);
+	}
+
+	SQLOK(sqlite3_reset(stmt));
+
+	return rows;
+}
+
+
+ActionRow RollbackMgrSQLite3::actionRowFromRollbackAction(const RollbackAction & action)
+{
+	ActionRow row;
+
+	row.actor     = getActorId(action.actor);
+	row.timestamp = action.unix_time;
+	row.type      = action.type;
+
+	if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
+		row.location = action.inventory_location;
+		row.list     = action.inventory_list;
+		row.index    = action.inventory_index;
+		row.add      = action.inventory_add;
+		row.stack    = action.inventory_stack;
+		row.stack.id = getNodeId(row.stack.name);
+	} else {
+		row.x         = action.p.X;
+		row.y         = action.p.Y;
+		row.z         = action.p.Z;
+		row.oldNode   = getNodeId(action.n_old.name);
+		row.oldParam1 = action.n_old.param1;
+		row.oldParam2 = action.n_old.param2;
+		row.oldMeta   = action.n_old.meta;
+		row.newNode   = getNodeId(action.n_new.name);
+		row.newParam1 = action.n_new.param1;
+		row.newParam2 = action.n_new.param2;
+		row.newMeta   = action.n_new.meta;
+		row.guessed   = action.actor_is_guess;
+	}
+
+	return row;
+}
+
+
+const std::list<RollbackAction> RollbackMgrSQLite3::rollbackActionsFromActionRows(
+		const std::list<ActionRow> & rows)
+{
+	std::list<RollbackAction> actions;
+
+	for (const ActionRow &row : rows) {
+		RollbackAction action;
+		action.actor     = (row.actor) ? getActorName(row.actor) : "";
+		action.unix_time = row.timestamp;
+		action.type      = static_cast<RollbackAction::Type>(row.type);
+
+		switch (action.type) {
+		case RollbackAction::TYPE_MODIFY_INVENTORY_STACK:
+			action.inventory_location = row.location;
+			action.inventory_list     = row.list;
+			action.inventory_index    = row.index;
+			action.inventory_add      = row.add;
+			action.inventory_stack    = row.stack;
+			if (action.inventory_stack.name.empty()) {
+				action.inventory_stack.name = getNodeName(row.stack.id);
+			}
+			break;
+
+		case RollbackAction::TYPE_SET_NODE:
+			action.p            = v3s16(row.x, row.y, row.z);
+			action.n_old.name   = getNodeName(row.oldNode);
+			action.n_old.param1 = row.oldParam1;
+			action.n_old.param2 = row.oldParam2;
+			action.n_old.meta   = row.oldMeta;
+			action.n_new.name   = getNodeName(row.newNode);
+			action.n_new.param1 = row.newParam1;
+			action.n_new.param2 = row.newParam2;
+			action.n_new.meta   = row.newMeta;
+			break;
+
+		default:
+			assert(false);
+			break;
+		}
+
+		actions.push_back(action);
+	}
+
+	return actions;
+}
+
+
+const std::list<ActionRow> RollbackMgrSQLite3::getRowsSince(time_t firstTime, const std::string & actor)
+{
+	sqlite3_stmt *stmt_stmt = actor.empty() ? stmt_select : stmt_select_withActor;
+	sqlite3_bind_int64(stmt_stmt, 1, firstTime);
+
+	if (!actor.empty()) {
+		sqlite3_bind_int(stmt_stmt, 2, getActorId(actor));
+	}
+
+	const std::list<ActionRow> & rows = actionRowsFromSelect(stmt_stmt);
+	sqlite3_reset(stmt_stmt);
+
+	return rows;
+}
+
+
+const std::list<ActionRow> RollbackMgrSQLite3::getRowsSince_range(
+		time_t start_time, v3s16 p, int range, int limit)
+{
+
+	sqlite3_bind_int64(stmt_select_range, 1, start_time);
+	sqlite3_bind_int  (stmt_select_range, 2, static_cast<int>(p.X - range));
+	sqlite3_bind_int  (stmt_select_range, 3, static_cast<int>(p.X + range));
+	sqlite3_bind_int  (stmt_select_range, 4, static_cast<int>(p.Y - range));
+	sqlite3_bind_int  (stmt_select_range, 5, static_cast<int>(p.Y + range));
+	sqlite3_bind_int  (stmt_select_range, 6, static_cast<int>(p.Z - range));
+	sqlite3_bind_int  (stmt_select_range, 7, static_cast<int>(p.Z + range));
+	sqlite3_bind_int  (stmt_select_range, 8, limit);
+
+	const std::list<ActionRow> & rows = actionRowsFromSelect(stmt_select_range);
+	sqlite3_reset(stmt_select_range);
+
+	return rows;
+}
+
+
+const std::list<RollbackAction> RollbackMgrSQLite3::getActionsSince_range(
+		time_t start_time, v3s16 p, int range, int limit)
+{
+	return rollbackActionsFromActionRows(getRowsSince_range(start_time, p, range, limit));
+}
+
+
+const std::list<RollbackAction> RollbackMgrSQLite3::getActionsSince(
+		time_t start_time, const std::string & actor)
+{
+	return rollbackActionsFromActionRows(getRowsSince(start_time, actor));
+}
+
+
+// Get nearness factor for subject's action for this action
+// Return value: 0 = impossible, >0 = factor
+float RollbackMgrSQLite3::getSuspectNearness(bool is_guess, v3s16 suspect_p,
+		time_t suspect_t, v3s16 action_p, time_t action_t)
+{
+	// Suspect cannot cause things in the past
+	if (action_t < suspect_t) {
+		return 0;        // 0 = cannot be
+	}
+	// Start from 100
+	int f = 100;
+	// Distance (1 node = -x points)
+	f -= POINTS_PER_NODE * intToFloat(suspect_p, 1).getDistanceFrom(intToFloat(action_p, 1));
+	// Time (1 second = -x points)
+	f -= 1 * (action_t - suspect_t);
+	// If is a guess, halve the points
+	if (is_guess) {
+		f /= 2;
+	}
+	// Limit to 0
+	f = MYMAX(f, 0);
+	return f;
+}
+
+
+void RollbackMgrSQLite3::reportAction(const RollbackAction &action_)
+{
+	// Ignore if not important
+	if (!action_.isImportant(gamedef)) {
+		return;
+	}
+
+	RollbackAction action = action_;
+	action.unix_time = time(0);
+
+	// Figure out actor
+	action.actor = current_actor;
+	action.actor_is_guess = current_actor_is_guess;
+
+	if (action.actor.empty()) { // If actor is not known, find out suspect or cancel
+		v3s16 p;
+		if (!action.getPosition(&p)) {
+			return;
+		}
+
+		action.actor = getSuspect(p, 83, 1);
+		if (action.actor.empty()) {
+			return;
+		}
+
+		action.actor_is_guess = true;
+	}
+
+	addAction(action);
+}
+
+std::string RollbackMgrSQLite3::getActor()
+{
+	return current_actor;
+}
+
+bool RollbackMgrSQLite3::isActorGuess()
+{
+	return current_actor_is_guess;
+}
+
+void RollbackMgrSQLite3::setActor(const std::string & actor, bool is_guess)
+{
+	current_actor = actor;
+	current_actor_is_guess = is_guess;
+}
+
+std::string RollbackMgrSQLite3::getSuspect(v3s16 p, float nearness_shortcut,
+		float min_nearness)
+{
+	if (!current_actor.empty()) {
+		return current_actor;
+	}
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - (100 - min_nearness);
+	RollbackAction likely_suspect;
+	float likely_suspect_nearness = 0;
+	for (auto i = action_latest_buffer.rbegin();
+		i != action_latest_buffer.rend(); ++i) {
+		if (i->unix_time < first_time) {
+			break;
+		}
+		if (i->actor.empty()) {
+			continue;
+		}
+		// Find position of suspect or continue
+		v3s16 suspect_p;
+		if (!i->getPosition(&suspect_p)) {
+			continue;
+		}
+		float f = getSuspectNearness(i->actor_is_guess, suspect_p,
+			i->unix_time, p, cur_time);
+		if (f >= min_nearness && f > likely_suspect_nearness) {
+			likely_suspect_nearness = f;
+			likely_suspect = *i;
+			if (likely_suspect_nearness >= nearness_shortcut) {
+				break;
+			}
+		}
+	}
+	// No likely suspect was found
+	if (likely_suspect_nearness == 0) {
+		return "";
+	}
+	// Likely suspect was found
+	return likely_suspect.actor;
+}
+
+
+void RollbackMgrSQLite3::flush()
+{
+	sqlite3_exec(db, "BEGIN", NULL, NULL, NULL);
+
+	for (auto iter = action_todisk_buffer.begin();
+			iter != action_todisk_buffer.end();
+			++iter) {
+		if (iter->actor.empty()) {
+			continue;
+		}
+
+		registerRow(actionRowFromRollbackAction(*iter));
+	}
+
+	sqlite3_exec(db, "COMMIT", NULL, NULL, NULL);
+	action_todisk_buffer.clear();
+}
+
+
+void RollbackMgrSQLite3::addAction(const RollbackAction & action)
+{
+	action_todisk_buffer.push_back(action);
+	action_latest_buffer.push_back(action);
+
+	// Flush to disk sometimes
+	if (action_todisk_buffer.size() >= 500) {
+		flush();
+	}
+	// Cut off latest log sometimes
+	while (action_latest_buffer.size() >= 500) {
+		action_latest_buffer.pop_front();
+	}
+}
+
+std::list<RollbackAction> RollbackMgrSQLite3::getNodeActors(v3s16 pos, int range,
+		time_t seconds, int limit)
+{
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - seconds;
+
+	flush();
+
+	return getActionsSince_range(first_time, pos, range, limit);
+}
+
+std::list<RollbackAction> RollbackMgrSQLite3::getRevertActions(
+		const std::string &actor_filter,
+		time_t seconds)
+{
+	time_t cur_time = time(0);
+	time_t first_time = cur_time - seconds;
+
+	flush();
+
+	return getActionsSince(first_time, actor_filter);
+}
+

--- a/src/server/rollback_sqlite3.h
+++ b/src/server/rollback_sqlite3.h
@@ -1,0 +1,88 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#pragma once
+
+#include <string>
+#include "irr_v3d.h"
+#include "rollback_interface.h"
+#include <list>
+#include <vector>
+#include <deque>
+#include "sqlite3.h"
+
+class IGameDef;
+
+struct ActionRow;
+struct Entity;
+
+class RollbackMgrSQLite3 final : public IRollbackManager
+{
+public:
+	RollbackMgrSQLite3(const std::string & world_path, IGameDef * gamedef);
+	~RollbackMgrSQLite3();
+
+	void reportAction(const RollbackAction & action_);
+	std::string getActor();
+	bool isActorGuess();
+	void setActor(const std::string & actor, bool is_guess);
+	std::string getSuspect(v3s16 p, float nearness_shortcut,
+			float min_nearness);
+	void flush();
+
+	void addAction(const RollbackAction & action);
+	std::list<RollbackAction> getNodeActors(v3s16 pos, int range,
+			time_t seconds, int limit);
+	std::list<RollbackAction> getRevertActions(
+			const std::string & actor_filter, time_t seconds);
+
+private:
+	void registerNewActor(const int id, const std::string & name);
+	void registerNewNode(const int id, const std::string & name);
+	int getActorId(const std::string & name);
+	int getNodeId(const std::string & name);
+	const char * getActorName(const int id);
+	const char * getNodeName(const int id);
+	bool createTables();
+	bool initDatabase();
+	bool registerRow(const ActionRow & row);
+	const std::list<ActionRow> actionRowsFromSelect(sqlite3_stmt * stmt);
+	ActionRow actionRowFromRollbackAction(const RollbackAction & action);
+	const std::list<RollbackAction> rollbackActionsFromActionRows(
+			const std::list<ActionRow> & rows);
+	const std::list<ActionRow> getRowsSince(time_t firstTime,
+			const std::string & actor);
+	const std::list<ActionRow> getRowsSince_range(time_t firstTime, v3s16 p,
+			int range, int limit);
+	const std::list<RollbackAction> getActionsSince_range(time_t firstTime, v3s16 p,
+			int range, int limit);
+	const std::list<RollbackAction> getActionsSince(time_t firstTime,
+			const std::string & actor = "");
+	static float getSuspectNearness(bool is_guess, v3s16 suspect_p,
+		time_t suspect_t, v3s16 action_p, time_t action_t);
+
+
+	IGameDef *gamedef = nullptr;
+
+	std::string current_actor;
+	bool current_actor_is_guess = false;
+
+	std::vector<RollbackAction> action_todisk_buffer;
+	std::deque<RollbackAction> action_latest_buffer;
+
+	std::string database_path;
+	sqlite3 *db = nullptr;
+	sqlite3_stmt *stmt_insert = nullptr;
+	sqlite3_stmt *stmt_replace = nullptr;
+	sqlite3_stmt *stmt_select = nullptr;
+	sqlite3_stmt *stmt_select_range = nullptr;
+	sqlite3_stmt *stmt_select_withActor = nullptr;
+	sqlite3_stmt *stmt_knownActor_select = nullptr;
+	sqlite3_stmt *stmt_knownActor_insert = nullptr;
+	sqlite3_stmt *stmt_knownNode_select = nullptr;
+	sqlite3_stmt *stmt_knownNode_insert = nullptr;
+
+	std::vector<Entity> knownActors;
+	std::vector<Entity> knownNodes;
+};

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -33,6 +33,7 @@ set(unittest_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_objdef.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_profiler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_random.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_rollback_backend_base.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_schematic.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_scriptapi.cpp

--- a/src/unittest/test_rollback_backend_base.cpp
+++ b/src/unittest/test_rollback_backend_base.cpp
@@ -1,0 +1,109 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 James Dornan <james@catch22.com>
+
+#include "test.h"
+
+#include "server/rollback.h"
+
+#include <ctime>
+#include <stdexcept>
+
+class DummyRollbackBackend final : public RollbackMgr
+{
+public:
+	explicit DummyRollbackBackend(IGameDef *gamedef) : RollbackMgr(gamedef) {}
+
+	void pushAction(const RollbackAction &a) { addActionInternal(a); }
+	size_t latestSize() const { return action_latest_buffer.size(); }
+
+private:
+	void beginSaveActions() override {}
+	void endSaveActions() override {}
+	void rollbackSaveActions() override {}
+	void persistAction(const RollbackAction &a) override { (void)a; }
+	void flush() override {}
+	std::list<RollbackAction> getActionsSince(time_t, const std::string &) override { return {}; }
+	std::list<RollbackAction> getActionsSince_range(time_t, v3s16, int, int) override { return {}; }
+};
+
+class TestRollbackBackendBase : public TestBase
+{
+public:
+	TestRollbackBackendBase() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestRollbackBackendBase"; }
+
+	void runTests(IGameDef *gamedef) override;
+
+	void testBufferCapping();
+	void testParseNodemetaLocationValid();
+	void testParseNodemetaLocationInvalid();
+
+private:
+	IGameDef *m_gamedef = nullptr;
+};
+
+static TestRollbackBackendBase g_test_instance;
+
+void TestRollbackBackendBase::runTests(IGameDef *gamedef)
+{
+	m_gamedef = gamedef;
+	TEST(testBufferCapping);
+	TEST(testParseNodemetaLocationValid);
+	TEST(testParseNodemetaLocationInvalid);
+}
+
+void TestRollbackBackendBase::testBufferCapping()
+{
+	DummyRollbackBackend rb(m_gamedef);
+
+	RollbackAction a;
+	a.unix_time = time(nullptr);
+	a.actor = "tester";
+	a.type = RollbackAction::TYPE_SET_NODE;
+	a.p = v3s16(0, 0, 0);
+
+	for (int i = 0; i < 2000; i++)
+		rb.pushAction(a);
+
+	UASSERTEQ(size_t, rb.latestSize(), 500);
+}
+
+void TestRollbackBackendBase::testParseNodemetaLocationValid()
+{
+	int x, y, z;
+
+	RollbackMgr::parseNodemetaLocation("nodemeta:1,2,3", x, y, z);
+	UASSERTEQ(int, x, 1);
+	UASSERTEQ(int, y, 2);
+	UASSERTEQ(int, z, 3);
+
+	RollbackMgr::parseNodemetaLocation("nodemeta:-1,-2,-3", x, y, z);
+	UASSERTEQ(int, x, -1);
+	UASSERTEQ(int, y, -2);
+	UASSERTEQ(int, z, -3);
+
+	RollbackMgr::parseNodemetaLocation("nodemeta:0,0,0", x, y, z);
+	UASSERTEQ(int, x, 0);
+	UASSERTEQ(int, y, 0);
+	UASSERTEQ(int, z, 0);
+}
+
+void TestRollbackBackendBase::testParseNodemetaLocationInvalid()
+{
+	int x, y, z;
+
+	EXCEPTION_CHECK(std::invalid_argument,
+		RollbackMgr::parseNodemetaLocation("invalid:1,2,3", x, y, z));
+
+	EXCEPTION_CHECK(std::invalid_argument,
+		RollbackMgr::parseNodemetaLocation("nodemeta:1", x, y, z));
+
+	EXCEPTION_CHECK(std::invalid_argument,
+		RollbackMgr::parseNodemetaLocation("nodemeta:1,2", x, y, z));
+
+	EXCEPTION_CHECK(std::invalid_argument,
+		RollbackMgr::parseNodemetaLocation("", x, y, z));
+}
+
+


### PR DESCRIPTION
Splits rollback into shared logic (`RollbackMgr` in `src/server/rollback.cpp`) and a SQLite-specific implementation (`src/server/rollback_sqlite3.*`). The server still uses `rollback_backend` from `world.mt`; this PR only supports `sqlite3` (default).

Rollback is no longer implemented as one SQLite-centric file; storage is isolated so other backends can be added later without duplicating the shared pieces.

**Review notes**

- Intended to preserve existing behavior: buffer flush/action ordering and `getNodeActors` query ordering are kept consistent with upstream.
- Adds a small unit test for the shared backend plumbing.

**Docs**

- `world.mt` / help text clarifies where the rollback backend is chosen; `enable_rollback_recording` comments point at `world.mt` for storage.

**AI**

Used Cursor/LLM assistance for edits and refactoring.