### PR TITLE
ServerMap: serialize map blocks without holding m_db.mutex

### DIFF
--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -665,18 +665,14 @@ MapDatabase *ServerMap::createDatabase(
 
 void ServerMap::beginSave()
 {
-	sanity_check(!m_in_map_save_batch);
-	m_in_map_save_batch = true;
+	MutexAutoLock dblock(m_db.mutex);
+	m_db.dbase->beginSave();
 }
 
 void ServerMap::endSave()
 {
 	MutexAutoLock dblock(m_db.mutex);
-	if (m_map_save_transaction_active) {
-		m_db.dbase->endSave();
-		m_map_save_transaction_active = false;
-	}
-	m_in_map_save_batch = false;
+	m_db.dbase->endSave();
 }
 
 bool ServerMap::saveBlock(MapBlock *block)
@@ -684,19 +680,13 @@ bool ServerMap::saveBlock(MapBlock *block)
 	std::string blob = serializeMapBlock(block, m_map_compression_level);
 
 	MutexAutoLock dblock(m_db.mutex);
-	if (m_in_map_save_batch) {
-		if (!m_map_save_transaction_active) {
-			m_db.dbase->beginSave();
-			m_map_save_transaction_active = true;
-		}
-		return saveSerializedMapBlock(block, m_db.dbase, blob);
-	}
 	return saveSerializedMapBlock(block, m_db.dbase, blob);
 }
 
 std::string ServerMap::serializeMapBlock(MapBlock *block, int compression_level)
 {
 	u8 version = SER_FMT_VER_HIGHEST_WRITE;
+	// FIXME: zero copy possible in c++20 or with custom rdbuf
 	std::ostringstream o(std::ios_base::binary);
 	o.write((char *) &version, 1);
 	block->serialize(o, version, true, compression_level);
@@ -715,6 +705,8 @@ bool ServerMap::saveSerializedMapBlock(
 bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_level)
 {
 	std::string blob = serializeMapBlock(block, compression_level);
+	// Server-side saves use saveBlock(MapBlock*) so m_db.mutex protects the database.
+	// This overload is for callers that supply their own MapDatabase (e.g. client local map).
 	return saveSerializedMapBlock(block, db, blob);
 }
 

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -530,8 +530,7 @@ void ServerMap::save(ModifiedState save_level)
 	u32 block_count = 0;
 	u32 block_count_all = 0; // Number of blocks in memory
 
-	// Don't do anything with sqlite unless something is really saved
-	bool save_started = false;
+	std::vector<std::pair<MapBlock *, std::string>> pending_saves;
 
 	for (auto &sector_it : m_sectors) {
 		MapSector *sector = sector_it.second;
@@ -543,22 +542,23 @@ void ServerMap::save(ModifiedState save_level)
 			block_count_all++;
 
 			if(block->getModified() >= (u32)save_level) {
-				// Lazy beginSave()
-				if(!save_started) {
-					beginSave();
-					save_started = true;
-				}
-
 				modprofiler.add(block->getModifiedReasonString(), 1);
 
-				saveBlock(block);
+				pending_saves.emplace_back(
+						block, serializeMapBlock(block, m_map_compression_level));
 				block_count++;
 			}
 		}
 	}
 
-	if(save_started)
-		endSave();
+	if (!pending_saves.empty()) {
+		MutexAutoLock dblock(m_db.mutex);
+		m_db.dbase->beginSave();
+		for (auto &entry : pending_saves) {
+			saveSerializedMapBlock(entry.first, m_db.dbase, entry.second);
+		}
+		m_db.dbase->endSave();
+	}
 
 	/*
 		Only print if something happened or saved whole map
@@ -665,45 +665,57 @@ MapDatabase *ServerMap::createDatabase(
 
 void ServerMap::beginSave()
 {
-	MutexAutoLock dblock(m_db.mutex);
-	m_db.dbase->beginSave();
+	sanity_check(!m_in_map_save_batch);
+	m_in_map_save_batch = true;
 }
 
 void ServerMap::endSave()
 {
 	MutexAutoLock dblock(m_db.mutex);
-	m_db.dbase->endSave();
+	if (m_map_save_transaction_active) {
+		m_db.dbase->endSave();
+		m_map_save_transaction_active = false;
+	}
+	m_in_map_save_batch = false;
 }
 
 bool ServerMap::saveBlock(MapBlock *block)
 {
-	// FIXME: serialization happens under mutex
+	std::string blob = serializeMapBlock(block, m_map_compression_level);
+
 	MutexAutoLock dblock(m_db.mutex);
-	return saveBlock(block, m_db.dbase, m_map_compression_level);
+	if (m_in_map_save_batch) {
+		if (!m_map_save_transaction_active) {
+			m_db.dbase->beginSave();
+			m_map_save_transaction_active = true;
+		}
+		return saveSerializedMapBlock(block, m_db.dbase, blob);
+	}
+	return saveSerializedMapBlock(block, m_db.dbase, blob);
+}
+
+std::string ServerMap::serializeMapBlock(MapBlock *block, int compression_level)
+{
+	u8 version = SER_FMT_VER_HIGHEST_WRITE;
+	std::ostringstream o(std::ios_base::binary);
+	o.write((char *) &version, 1);
+	block->serialize(o, version, true, compression_level);
+	return o.str();
+}
+
+bool ServerMap::saveSerializedMapBlock(
+		MapBlock *block, MapDatabase *db, std::string_view data)
+{
+	bool ret = db->saveBlock(block->getPos(), data);
+	if (ret)
+		block->resetModified();
+	return ret;
 }
 
 bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_level)
 {
-	v3s16 p3d = block->getPos();
-
-	// Format used for writing
-	u8 version = SER_FMT_VER_HIGHEST_WRITE;
-
-	/*
-		[0] u8 serialization version
-		[1] data
-	*/
-	std::ostringstream o(std::ios_base::binary);
-	o.write((char*) &version, 1);
-	block->serialize(o, version, true, compression_level);
-
-	// FIXME: zero copy possible in c++20 or with custom rdbuf
-	bool ret = db->saveBlock(p3d, o.str());
-	if (ret) {
-		// We just wrote it to the disk so clear modified flag
-		block->resetModified();
-	}
-	return ret;
+	std::string blob = serializeMapBlock(block, compression_level);
+	return saveSerializedMapBlock(block, db, blob);
 }
 
 void ServerMap::deSerializeBlock(MapBlock *block, std::istream &is)

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -201,6 +203,14 @@ private:
 	bool m_map_metadata_changed = true;
 
 	MapDatabaseAccessor m_db;
+
+	/// Set between beginSave and endSave (e.g. Map::timerUpdate)
+	bool m_in_map_save_batch = false;
+	bool m_map_save_transaction_active = false;
+
+	static std::string serializeMapBlock(MapBlock *block, int compression_level);
+	static bool saveSerializedMapBlock(
+			MapBlock *block, MapDatabase *db, std::string_view data);
 
 	// Map metrics
 	MetricGaugePtr m_loaded_blocks_gauge;

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -204,10 +204,6 @@ private:
 
 	MapDatabaseAccessor m_db;
 
-	/// Set between beginSave and endSave (e.g. Map::timerUpdate)
-	bool m_in_map_save_batch = false;
-	bool m_map_save_transaction_active = false;
-
 	static std::string serializeMapBlock(MapBlock *block, int compression_level);
 	static bool saveSerializedMapBlock(
 			MapBlock *block, MapDatabase *db, std::string_view data);


### PR DESCRIPTION
Map block **serialization and compression** used to run **while holding** `m_db.mutex`, which also guards loads and other DB access. This change **builds each block’s blob first**, then takes the mutex only for the actual `MapDatabase` write. Periodic `ServerMap::save()` batches dirty blocks into a vector, then uses **one** lock scope for `beginSave` → writes → `endSave`. **`beginSave()`** and **`endSave()`** follow the usual pattern again: each takes `m_db.mutex` and calls the database’s `beginSave()` / `endSave()` (including for nested callers such as `Map::timerUpdate`).

## Goal of the PR

Reduce the time spent with `m_db.mutex` held during saves so that **loads and other users of the map DB wait less**, especially on busy servers or with slow storage.

## How does the PR work?

- **`serializeMapBlock(MapBlock *, compression_level)`** — returns `std::string` (version byte + serialized data), **no mutex**.
- **`saveSerializedMapBlock(MapBlock *, MapDatabase *, std::string_view)`** — calls `db->saveBlock(pos, data)` and clears modified flags on success.
- **`ServerMap::save()`** — collects `(MapBlock*, blob)` for blocks that need saving, then under **one** `MutexAutoLock`: `beginSave()` on DB, loop `saveSerializedMapBlock`, `endSave()`.
- **`beginSave()` / `endSave()`** — each takes `m_db.mutex` and delegates to `m_db.dbase->beginSave()` / `endSave()` (same overall shape as before this work, without extra ServerMap batch state).
- **`saveBlock(MapBlock *)`** — serialize blob **outside** the lock, then lock and write via `saveSerializedMapBlock`.

## Does it resolve any reported issues?

No separate GitHub issue is required; it addresses the old **`FIXME: serialization happens under mutex`** concern in `servermap.cpp` by moving serialization out of that critical section; a separate **zero-copy** FIXME remains on the serialization buffer path. It continues the performance thread from [PR #15151](https://github.com/luanti-org/luanti/pull/15151).

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?

Not explicitly tied to a numbered item there. It is a **server performance/responsiveness** improvement (shorter critical section on the map DB mutex).

## If not a bug fix, why is this PR needed? What use cases does it solve?

Not a correctness bug fix; it is an **optimization**. Use cases: dedicated servers with heavy map churn, large periodic saves, or slow disks where **serialization under the lock** stretched contention with **block loads** and similar work.

## AI / LLM disclosure

Cursor AI was used in editing.

## Files changed

| File | Role |
|------|------|
| `src/servermap.cpp` | Save path, `serializeMapBlock`, `saveSerializedMapBlock`, `beginSave`/`endSave`, `saveBlock` |
| `src/servermap.h` | Includes, static helper declarations |

## Note

Please reject if you don't have time to review or don't want to deal with it. I am using this code locally, so I'm sharing it. I am currently moving away from this method for my personal use while experimenting locally with a 64-mutex stripe arrangement, which will likely become my norm.