### PR TITLE
Fix focus inside scroll container being lost on formspec update

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2993,7 +2993,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 		// Preserve focus
 		gui::IGUIElement *focused_element = Environment->getFocus();
-		if (focused_element && focused_element->getParent() == this) {
+		// Check recursively to cover elements inside e.g. scroll containers
+		if (focused_element && isMyChild(focused_element)) {
 			s32 focused_id = focused_element->getID();
 			if (focused_id > ID_PROCEED_BTN) {
 				for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {


### PR DESCRIPTION
@siliconsniffer :D

before:

https://github.com/user-attachments/assets/4bf80a55-6965-4308-bf44-f1c7a1c57f78

after:

https://github.com/user-attachments/assets/cba08039-74c6-4de2-8c23-b281a32e3f3b



## To do

This PR is a Ready for Review.

## How to test

go to settings, navigate using keyboard / tab, see that the focus is not reset when it shouldn't be