### PR TITLE
Fix font memory leak

### DIFF
--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -416,7 +416,7 @@ bool CGUITTFont::load(SGUITTFace *face, const u32 size, const bool antialias,
 	update_load_flags();
 
 	// Store our face.
-	face->grab();
+	m_face.grab(face);
 	tt_face = face->face;
 
 	// Store font metrics.

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -256,6 +256,7 @@ namespace gui
 			core::vector2di getKerning(const char32_t thisLetter, const char32_t previousLetter) const;
 
 			video::IVideoDriver* Driver = nullptr;
+			irr_ptr<SGUITTFace> m_face;
 			FT_Face tt_face;
 			FT_Size_Metrics font_metrics;
 			FT_Int32 load_flags;


### PR DESCRIPTION
Fixes #13832

## To do

Ready for Review.

## How to test

Compile with `CMAKE_CXX_FLAGS=-fsanitize=address`
Start Luanti and exit.
