### PR TITLE
[no squash] Fix two formspec memory leaks

### DIFF
--- a/src/gui/guiButtonItemImage.cpp
+++ b/src/gui/guiButtonItemImage.cpp
@@ -18,10 +18,10 @@ GUIButtonItemImage::GUIButtonItemImage(gui::IGUIEnvironment *environment,
 		bool noclip)
 		: GUIButton (environment, parent, id, rectangle, tsrc, noclip)
 {
-	m_image = new GUIItemImage(environment, this, id,
+	m_image.reset(new GUIItemImage(environment, this, id,
 			core::rect<s32>(0,0,rectangle.getWidth(),rectangle.getHeight()),
-			item, getActiveFont(), client);
-	sendToBack(m_image);
+			item, getActiveFont(), client));
+	sendToBack(m_image.get());
 
 	m_client = client;
 }

--- a/src/gui/guiButtonItemImage.h
+++ b/src/gui/guiButtonItemImage.h
@@ -25,5 +25,5 @@ public:
 
 private:
 	Client *m_client;
-	GUIItemImage *m_image;
+	irr_ptr<GUIItemImage> m_image;
 };

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2830,6 +2830,7 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 			data->current_parent, rect, spec.fid);
 
 	auto meshnode = e->setMesh(mesh);
+	mesh->drop();
 
 	for (u32 i = 0; i < meshnode->getMaterialCount(); ++i) {
 		const auto texture_idx = mesh->getTextureSlot(i);

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -19,7 +19,9 @@ public:
 
 	~GUIScene();
 
+	/// @param mesh does not get consumed, mesh->drop() must still be called afterward
 	scene::AnimatedMeshSceneNode *setMesh(scene::IAnimatedMesh *mesh = nullptr);
+
 	void setTexture(u32 idx, video::ITexture *texture);
 	void setBackgroundColor(const video::SColor &color) noexcept { m_bgcolor = color; };
 	void setFrameLoop(f32 begin, f32 end);


### PR DESCRIPTION
The first commit fixes a memory leak of button item images.
The second commit of meshes in formspecs.

## To do

Ready for Review.

## How to test

Compile with `CMAKE_CXX_FLAGS=-fsanitize=address`
Execute `/test_formspec`
Click on `Model` tab
Exit Luanti
