### PR TITLE
Fix mapblock mesh memory leak

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -678,17 +678,13 @@ void Client::step(float dtime)
 					if (minimap_mapblocks.empty())
 						do_mapper_update = false;
 
-					if (r.mesh->isEmpty()) {
-						delete r.mesh;
-					} else {
+					if (!r.mesh->isEmpty()) {
 						// Replace with the new mesh
-						block->mesh = r.mesh;
+						block->mesh = r.mesh.release();
 						if (r.urgent)
 							force_update_shadows = true;
 					}
 				}
-			} else {
-				delete r.mesh;
 			}
 
 			if (m_minimap && do_mapper_update) {

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -263,13 +263,13 @@ void MeshUpdateWorkerThread::doUpdate()
 
 		MeshUpdateResult r;
 		r.p = q->p;
-		r.mesh = mesh_new;
+		r.mesh = std::unique_ptr<MapBlockMesh>(mesh_new);
 		r.solid_sides = get_solid_sides(q->data);
 		r.ack_list = std::move(q->ack_list);
 		r.urgent = q->urgent;
 		r.map_blocks = std::move(q->map_blocks);
 
-		m_manager->putResult(r);
+		m_manager->putResult(std::move(r));
 		m_queue_in->done(q->p);
 		delete q;
 		sp.stop();
@@ -327,12 +327,12 @@ void MeshUpdateManager::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
 	deferUpdate();
 }
 
-void MeshUpdateManager::putResult(const MeshUpdateResult &result)
+void MeshUpdateManager::putResult(MeshUpdateResult &&result)
 {
 	if (result.urgent)
-		m_queue_out_urgent.push_back(result);
+		m_queue_out_urgent.push_back(std::move(result));
 	else
-		m_queue_out.push_back(result);
+		m_queue_out.push_back(std::move(result));
 }
 
 bool MeshUpdateManager::getNextResult(MeshUpdateResult &r)
@@ -358,7 +358,6 @@ void MeshUpdateManager::clearAllQueues(bool finish)
 		for (auto *block : r.map_blocks)
 			if (block)
 				block->refDrop();
-		delete r.mesh;
 	};
 	// Same problem as in MeshUpdateQueue::clear() here: we can't just blindly
 	// throw away results that the server expects to receive an ack for.

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -361,8 +361,8 @@ void MeshUpdateManager::clearAllQueues(bool finish)
 	};
 	// Same problem as in MeshUpdateQueue::clear() here: we can't just blindly
 	// throw away results that the server expects to receive an ack for.
-	const auto &do_it = [&] (ResultQueue &queue) {
-		auto helper = m_queue_out_urgent.iterLocked();
+	const auto &do_it = [&finish, &drop_result] (ResultQueue &queue) {
+		auto helper = queue.iterLocked();
 		for (auto it = helper.begin(); it != helper.end(); ) {
 			if (it->ack_list.empty() || finish) {
 				drop_result(*it);

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -113,7 +113,7 @@ private:
 struct MeshUpdateResult
 {
 	v3s16 p = v3s16(-1338, -1338, -1338);
-	MapBlockMesh *mesh = nullptr;
+	std::unique_ptr<MapBlockMesh> mesh;
 	u8 solid_sides;
 	std::vector<v3s16> ack_list;
 	bool urgent = false;
@@ -151,7 +151,7 @@ public:
 	void updateBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent,
 			bool update_neighbors = false);
 
-	void putResult(const MeshUpdateResult &r);
+	void putResult(MeshUpdateResult &&r);
 
 	/// @note caller needs to refDrop() the affected map_blocks
 	bool getNextResult(MeshUpdateResult &r);


### PR DESCRIPTION
Seems to be a regression of https://github.com/luanti-org/luanti/commit/07d8e00cf4c1660c5e7d0194ecaef521614c6844 @sfan5 
~I'm not sure where the missing delete is but apparently a unique_ptr solves it.~
The problem is wrong lambda capture.

## To do

Ready for Review.

## How to test
Compile with address sanitizers
Start Luanti enter a game world and exit.

