### PR TITLE
[no sq] Fix list reading using `lua_next`, which does not guarantee order + small cleanups

### DIFF
--- a/irr/include/IGUIElement.h
+++ b/irr/include/IGUIElement.h
@@ -528,42 +528,39 @@ public:
 
 	//! Finds the first element with the given id.
 	/** \param id: Id to search for.
-	\param searchchildren: Set this to true, if also children of this
+	\param recursive: Set this to true, if also children of this
 	element may contain the element with the searched id and they
 	should be searched too.
 	\return Returns the first element with the given id. If no element
-	with this id was found, 0 is returned. */
-	virtual IGUIElement *getElementFromId(s32 id, bool searchchildren = false) const
+	with this id was found, nullptr is returned. */
+	virtual IGUIElement *getElementFromId(s32 id, bool recursive = false) const
 	{
-		IGUIElement *e = 0;
-
 		for (auto child : Children) {
 			if (child->getID() == id)
 				return child;
 
-			if (searchchildren)
-				e = child->getElementFromId(id, true);
-
-			if (e)
-				return e;
+			if (recursive) {
+				if (auto *e = child->getElementFromId(id, true))
+					return e;
+			}
 		}
 
-		return e;
+		return nullptr;
 	}
 
-	//! returns true if the given element is a child of this one.
-	//! \param child: The child element to check
-	bool isMyChild(IGUIElement *child) const
+	//! returns true if the given element is a descendant of this one.
+	//! @note elements are not descendants of themselves
+	//! \param element: The element to check
+	bool isMyDescendant(const IGUIElement *element) const
 	{
-		if (!child)
+		if (!element)
 			return false;
-		do {
-			if (child->Parent)
-				child = child->Parent;
 
-		} while (child->Parent && child != this);
-
-		return child == this;
+		while ((element = element->Parent)) {
+			if (element == this)
+				return true;
+		}
+		return false;
 	}
 
 	//! searches elements to find the closest next element to tab to

--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -235,10 +235,10 @@ bool CGUIComboBox::OnEvent(const SEvent &event)
 			switch (event.GUIEvent.EventType) {
 			case EGET_ELEMENT_FOCUS_LOST:
 				if (ListBox &&
-						(Environment->hasFocus(ListBox) || ListBox->isMyChild(event.GUIEvent.Caller)) &&
+						(Environment->hasFocus(ListBox) || ListBox->isMyDescendant(event.GUIEvent.Caller)) &&
 						event.GUIEvent.Element != this &&
-						!isMyChild(event.GUIEvent.Element) &&
-						!ListBox->isMyChild(event.GUIEvent.Element)) {
+						!isMyDescendant(event.GUIEvent.Element) &&
+						!ListBox->isMyDescendant(event.GUIEvent.Element)) {
 					openCloseMenu();
 				}
 				break;
@@ -369,7 +369,7 @@ void CGUIComboBox::draw()
 
 	IGUIElement *currentFocus = Environment->getFocus();
 	if (currentFocus != LastFocus) {
-		HasFocus = currentFocus == this || isMyChild(currentFocus);
+		HasFocus = currentFocus == this || isMyDescendant(currentFocus);
 		LastFocus = currentFocus;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1399,7 +1399,7 @@ void Game::processUserInput(f32 dtime)
 	}
 
 	if (!guienv->hasFocus(gui_chat_console.get()) && gui_chat_console->isOpen()
-		&& !gui_chat_console->isMyChild(guienv->getFocus()))
+		&& !gui_chat_console->isMyDescendant(guienv->getFocus()))
 	{
 		gui_chat_console->closeConsoleAtOnce();
 	}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2995,7 +2995,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		// Preserve focus
 		gui::IGUIElement *focused_element = Environment->getFocus();
 		// Check recursively to cover elements inside e.g. scroll containers
-		if (focused_element && isMyChild(focused_element)) {
+		if (focused_element && isMyDescendant(focused_element)) {
 			s32 focused_id = focused_element->getID();
 			if (focused_id > ID_PROCEED_BTN) {
 				for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {
@@ -3315,7 +3315,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// Set initial focus if parser didn't set it
 	gui::IGUIElement *focused_element = Environment->getFocus();
 	if (!focused_element
-			|| !isMyChild(focused_element)
+			|| !isMyDescendant(focused_element)
 			|| focused_element->getType() == gui::EGUIET_TAB_CONTROL)
 		setInitialFocus();
 
@@ -3731,7 +3731,7 @@ void GUIFormSpecMenu::autoScroll()
 
 	// Find the scroll container that contains the focused element
 	for (const auto &cont : m_scroll_containers) {
-		if (!cont.second->isMyChild(focus))
+		if (!cont.second->isMyDescendant(focus))
 			continue;
 
 		gui::IGUIElement *clipper = cont.second->getParent();
@@ -4115,7 +4115,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
-		if (hovered && isMyChild(hovered) &&
+		if (hovered && isMyDescendant(hovered) &&
 				hovered->getType() == gui::EGUIET_TAB_CONTROL) {
 			gui::IGUISkin* skin = Environment->getSkin();
 			sanity_check(skin != NULL);
@@ -4136,7 +4136,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 				|| keySettingHasMatch("keymap_inventory", kp)
 				|| event.KeyInput.Key==KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
-			if (focused && isMyChild(focused) &&
+			if (focused && isMyDescendant(focused) &&
 					(focused->getType() == gui::EGUIET_LIST_BOX ||
 					focused->getType() == gui::EGUIET_CHECK_BOX) &&
 					(focused->getParent()->getType() != gui::EGUIET_COMBO_BOX ||
@@ -4156,7 +4156,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
-		if (hovered && isMyChild(hovered)) {
+		if (hovered && isMyDescendant(hovered)) {
 			hovered->OnEvent(event);
 			return event.MouseInput.Event == EMIE_MOUSE_WHEEL;
 		}

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -60,7 +60,7 @@ void GUIModalMenu::allowFocusRemoval(bool allow)
 
 bool GUIModalMenu::canTakeFocus(gui::IGUIElement *e)
 {
-	return (e && (e == this || isMyChild(e))) || m_allow_focus_removal;
+	return (e && (e == this || isMyDescendant(e))) || m_allow_focus_removal;
 }
 
 void GUIModalMenu::draw()

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -925,21 +925,15 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 
 	lua_getfield(L, index, "connects_to");
 	if (lua_istable(L, -1)) {
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		while (lua_next(L, table) != 0) {
-			// Value at -1
+		LuaHelper::for_ipairs(L, -1, [&]() {
 			f.connects_to.emplace_back(lua_tostring(L, -1));
-			lua_pop(L, 1);
-		}
+		});
 	}
 	lua_pop(L, 1);
 
 	lua_getfield(L, index, "connect_sides");
 	if (lua_istable(L, -1)) {
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		while (lua_next(L, table) != 0) {
+		LuaHelper::for_ipairs(L, -1, [&]() {
 			// Value at -1
 			std::string_view side(lua_tostring(L, -1));
 			// Note faces are flipped to make checking easier
@@ -958,8 +952,7 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 			else
 				warningstream << "Unknown value for \"connect_sides\": "
 					<< side << std::endl;
-			lua_pop(L, 1);
-		}
+		});
 	}
 	lua_pop(L, 1);
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -4,6 +4,7 @@
 #include "common/c_content.h"
 #include "common/c_converter.h"
 #include "common/c_types.h"
+#include "common/helper.h"
 #include "nodedef.h"
 #include "object_properties.h"
 #include "collision.h"
@@ -404,31 +405,29 @@ void read_object_properties(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	lua_getfield(L, -1, "textures");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		prop->textures.clear();
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		while(lua_next(L, table) != 0){
-			// key at index -2 and value at index -1
-			if(lua_isstring(L, -1))
+		LuaHelper::for_ipairs(L, -1, [&]() {
+			int tp = lua_type(L, -1);
+			if (tp == LUA_TSTRING) {
 				prop->textures.emplace_back(lua_tostring(L, -1));
-			else
+			} else {
+				script_log_unique(L, std::string("Textures must be strings, got ") +
+						lua_typename(L, tp), warningstream);
 				prop->textures.emplace_back("");
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-		}
+			};
+		});
 	}
 	lua_pop(L, 1);
 
 	lua_getfield(L, -1, "colors");
 	if (lua_istable(L, -1)) {
-		int table = lua_gettop(L);
 		prop->colors.clear();
-		for (lua_pushnil(L); lua_next(L, table); lua_pop(L, 1)) {
+		LuaHelper::for_ipairs(L, -1, [&]() {
 			video::SColor color(255, 255, 255, 255);
 			read_color(L, -1, &color);
 			prop->colors.push_back(color);
-		}
+		});
 	}
 	lua_pop(L, 1);
 
@@ -749,78 +748,44 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 	/* Meshnode model filename */
 	getstringfield(L, index, "mesh", f.mesh);
 
-	// tiles = {}
-	lua_getfield(L, index, "tiles");
-	if(lua_istable(L, -1)){
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		int i = 0;
-		while(lua_next(L, table) != 0){
-			// Read tiledef from value
-			f.tiledef[i] = read_tiledef(L, -1, f.drawtype, false);
-			// removes value, keeps key for next iteration
+	const auto read_tiles = [&](const char *name, TileDef *tiledefs) {
+		lua_getfield(L, index, name);
+		if (!lua_istable(L, -1)) {
 			lua_pop(L, 1);
-			i++;
-			if(i==6){
+			return;
+		}
+		int i = 0;
+		for (; LuaHelper::geti(L, -1, i); ++i, lua_pop(L, 1)) {
+			if (i >= 6) {
+				script_log_unique(L, std::string("Ignoring extraneous ") + name, warningstream);
 				lua_pop(L, 1);
 				break;
 			}
+			tiledefs[i] = read_tiledef(L, -1, f.drawtype, false);
 		}
 		// Copy last value to all remaining textures
-		if(i >= 1){
-			TileDef lasttile = f.tiledef[i-1];
-			while(i < 6){
-				f.tiledef[i] = lasttile;
-				i++;
+		if (i > 0 && i < 6) {
+			TileDef lasttile = tiledefs[i - 1];
+			for (int j = i; j < 6; ++j) {
+				tiledefs[j] = lasttile;
 			}
 		}
-	}
-	lua_pop(L, 1);
+		lua_pop(L, 1);
+	};
 
-	// overlay_tiles = {}
-	lua_getfield(L, index, "overlay_tiles");
-	if (lua_istable(L, -1)) {
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		int i = 0;
-		while (lua_next(L, table) != 0) {
-			// Read tiledef from value
-			f.tiledef_overlay[i] = read_tiledef(L, -1, f.drawtype, false);
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-			i++;
-			if (i == 6) {
-				lua_pop(L, 1);
-				break;
-			}
-		}
-		// Copy last value to all remaining textures
-		if (i >= 1) {
-			TileDef lasttile = f.tiledef_overlay[i - 1];
-			while (i < 6) {
-				f.tiledef_overlay[i] = lasttile;
-				i++;
-			}
-		}
-	}
-	lua_pop(L, 1);
+	read_tiles("tiles", f.tiledef);
+	read_tiles("overlay_tiles", f.tiledef_overlay);
 
 	// special_tiles = {}
 	lua_getfield(L, index, "special_tiles");
-	if(lua_istable(L, -1)){
-		int table = lua_gettop(L);
-		lua_pushnil(L);
-		int i = 0;
-		while(lua_next(L, table) != 0){
-			// Read tiledef from value
-			f.tiledef_special[i] = read_tiledef(L, -1, f.drawtype, true);
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-			i++;
-			if(i==CF_SPECIAL_COUNT){
+	if (lua_istable(L, -1)) {
+		for (int i = 0; LuaHelper::geti(L, index, i); ++i, lua_pop(L, 1)) {
+			if (i >= CF_SPECIAL_COUNT) {
+				script_log_unique(L, "Ignoring extraneous special_tiles", warningstream);
 				lua_pop(L, 1);
 				break;
 			}
+			f.tiledef_special[i] = read_tiledef(L, -1, f.drawtype, true);
 		}
 	}
 	lua_pop(L, 1);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -56,7 +56,7 @@ struct EnumString es_TouchInteractionMode[] =
 };
 
 /******************************************************************************/
-void read_item_definition(lua_State* L, int index,
+void read_item_definition(lua_State *L, int index,
 		const ItemDefinition &default_def, ItemDefinition &def)
 {
 	if (index < 0)
@@ -327,7 +327,7 @@ void read_object_properties(lua_State *L, int index,
 		ServerActiveObject *sao, ObjectProperties *prop, IItemDefManager *idef,
 		bool fallback)
 {
-	if(index < 0)
+	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
 	if (lua_isnil(L, index))
 		return;
@@ -373,7 +373,7 @@ void read_object_properties(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	lua_getfield(L, -1, "pointable");
-	if(!lua_isnil(L, -1)){
+	if (!lua_isnil(L, -1)) {
 		prop->pointable = read_pointability_type(L, -1);
 	}
 	lua_pop(L, 1);
@@ -442,12 +442,12 @@ void read_object_properties(lua_State *L, int index,
 	}
 
 	lua_getfield(L, -1, "spritediv");
-	if(lua_istable(L, -1))
+	if (lua_istable(L, -1))
 		prop->spritediv = read_v2s16(L, -1);
 	lua_pop(L, 1);
 
 	lua_getfield(L, -1, "initial_sprite_basepos");
-	if(lua_istable(L, -1))
+	if (lua_istable(L, -1))
 		prop->initial_sprite_basepos = read_v2s16(L, -1);
 	lua_pop(L, 1);
 
@@ -1629,13 +1629,13 @@ ToolCapabilities read_tool_capabilities(
 	getintfield(L, table, "punch_attack_uses", toolcap.punch_attack_uses);
 
 	lua_getfield(L, table, "groupcaps");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		int table_groupcaps = lua_gettop(L);
 		lua_pushnil(L);
-		while(lua_next(L, table_groupcaps) != 0){
+		while (lua_next(L, table_groupcaps) != 0) {
 			// key at index -2 and value at index -1
 			std::string groupname = luaL_checkstring(L, -2);
-			if(lua_istable(L, -1)){
+			if (lua_istable(L, -1)) {
 				int table_groupcap = lua_gettop(L);
 				// This will be created
 				ToolGroupCap groupcap;
@@ -1644,7 +1644,7 @@ ToolCapabilities read_tool_capabilities(
 				getintfield(L, table_groupcap, "uses", groupcap.uses);
 				// DEPRECATED: maxwear
 				float maxwear = 0;
-				if (getfloatfield(L, table_groupcap, "maxwear", maxwear)){
+				if (getfloatfield(L, table_groupcap, "maxwear", maxwear)) {
 					if (maxwear != 0)
 						groupcap.uses = 1.0f/maxwear;
 					else
@@ -1655,10 +1655,10 @@ ToolCapabilities read_tool_capabilities(
 				}
 				// Read "times" table
 				lua_getfield(L, table_groupcap, "times");
-				if(lua_istable(L, -1)){
+				if (lua_istable(L, -1)) {
 					int table_times = lua_gettop(L);
 					lua_pushnil(L);
-					while(lua_next(L, table_times) != 0){
+					while (lua_next(L, table_times) != 0) {
 						// key at index -2 and value at index -1
 						int rating = luaL_checkinteger(L, -2);
 						float time = luaL_checknumber(L, -1);
@@ -1678,10 +1678,10 @@ ToolCapabilities read_tool_capabilities(
 	lua_pop(L, 1);
 
 	lua_getfield(L, table, "damage_groups");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		int table_damage_groups = lua_gettop(L);
 		lua_pushnil(L);
-		while(lua_next(L, table_damage_groups) != 0){
+		while (lua_next(L, table_damage_groups) != 0) {
 			// key at index -2 and value at index -1
 			std::string groupname = luaL_checkstring(L, -2);
 			u16 value = luaL_checkinteger(L, -1);
@@ -1718,10 +1718,10 @@ Pointabilities read_pointabilities(lua_State *L, int index)
 
 	luaL_checktype(L, index, LUA_TTABLE);
 	lua_getfield(L, index, "nodes");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		int ti = lua_gettop(L);
 		lua_pushnil(L);
-		while(lua_next(L, ti) != 0) {
+		while (lua_next(L, ti) != 0) {
 			// key at index -2 and value at index -1
 			std::string name = luaL_checkstring(L, -2);
 
@@ -1739,10 +1739,10 @@ Pointabilities read_pointabilities(lua_State *L, int index)
 	lua_pop(L, 1);
 
 	lua_getfield(L, index, "objects");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		int ti = lua_gettop(L);
 		lua_pushnil(L);
-		while(lua_next(L, ti) != 0) {
+		while (lua_next(L, ti) != 0) {
 			// key at index -2 and value at index -1
 			std::string name = luaL_checkstring(L, -2);
 
@@ -1765,7 +1765,7 @@ Pointabilities read_pointabilities(lua_State *L, int index)
 /******************************************************************************/
 void push_pointability_type(lua_State *L, PointabilityType pointable)
 {
-	switch(pointable)
+	switch (pointable)
 	{
 	case PointabilityType::POINTABLE:
 		lua_pushboolean(L, true);
@@ -1991,7 +1991,7 @@ void push_items(lua_State *L, const std::vector<ItemStack> &items)
 /******************************************************************************/
 std::vector<ItemStack> read_items(lua_State *L, int index, IGameDef *gdef)
 {
-	if(index < 0)
+	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
 
 	std::vector<ItemStack> items;

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -12,10 +12,11 @@ extern "C" {
 #include "log.h"
 #include "common/c_converter.h"
 #include "common/c_internal.h"
+#include "common/c_types.h"
+#include "common/helper.h"
 #include "constants.h"
 #include <set>
 #include <cmath>
-#include "common/c_types.h"
 
 static v3d read_v3d(lua_State *L, int index);
 static v3d check_v3d(lua_State *L, int index);
@@ -430,14 +431,12 @@ size_t read_stringlist(lua_State *L, int index, std::vector<std::string> *result
 	size_t num_strings = 0;
 
 	if (lua_istable(L, index)) {
-		lua_pushnil(L);
-		while (lua_next(L, index)) {
+		LuaHelper::for_ipairs(L, index, [&]() {
 			if (lua_isstring(L, -1)) {
 				result->push_back(lua_tostring(L, -1));
 				num_strings++;
 			}
-			lua_pop(L, 1);
-		}
+		});
 	} else if (lua_isstring(L, index)) {
 		result->push_back(lua_tostring(L, index));
 		num_strings++;

--- a/src/script/common/helper.h
+++ b/src/script/common/helper.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string_view>
+#include <type_traits>
 
 extern "C" {
 #include <lua.h>
@@ -12,6 +13,48 @@ extern "C" {
 
 class LuaHelper
 {
+public:
+
+	/**
+	 * @brief Utility for list iteration.
+	 * Usage:
+	 * ```cpp
+	 * for (int i = 0; LuaHelper::geti(L, -1, i); ++i, lua_pop(L, 1)) ...
+	 * ```
+	 * @param table index of the table t on the stack
+	 * @param i integer to index table with
+	 * @return false if `t[i + 1]` is nil, true otherwise;
+	 *         `t[i + 1]` is left on the stack in the latter case.
+	 */
+	static bool geti(lua_State *L, int table, int i)
+	{
+		lua_rawgeti(L, table, i + 1);
+		if (lua_isnil(L, -1)) {
+			lua_pop(L, 1);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @brief Iterate values `t[1]`, `t[2]`, ... of the given table in order.
+	 * @details Iterates up to the first `nil` value, similar to `ipairs` in Lua.
+	 *          Values will be left on the stack for `f()`.
+	 *          `f()` must leave the stack level unchanged.
+	 * @param table Lua stack (pseudo-)index of table
+	 * @param f Function (typically lambda) to be called for each value.
+	 */
+	template <typename F>
+	static void for_ipairs(lua_State *L, int table, const F &f)
+	{
+		if (table < 0)
+			table = lua_gettop(L) + table + 1;
+		static_assert(std::is_same_v<std::invoke_result_t<F>, void>);
+		for (int i = 0; geti(L, table, i); ++i, lua_pop(L, 1))
+			f();
+	}
+
+
 protected:
 	/**
 	 * Read a value using a template type T from Lua state L at index

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -5,6 +5,7 @@
 #include "cpp_api/s_env.h"
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
+#include "common/helper.h"
 #include "log.h"
 #include "mapgen/mapgen.h"
 #include "lua_api/l_env.h"
@@ -176,14 +177,10 @@ bool ScriptApiEnv::read_nodenames(lua_State *L, int idx, std::vector<std::string
 {
 	if (lua_istable(L, idx)) {
 		const int table = idx < 0 ? (lua_gettop(L) + idx + 1) : idx;
-		lua_pushnil(L);
-		while (lua_next(L, table)) {
-			// key at index -2 and value at index -1
+		LuaHelper::for_ipairs(L, table, [&]() {
 			luaL_checktype(L, -1, LUA_TSTRING);
 			to.emplace_back(readParam<std::string>(L, -1));
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-		}
+		});
 	} else if (lua_isstring(L, idx)) {
 		to.emplace_back(readParam<std::string>(L, idx));
 	} else {

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -58,10 +58,10 @@ bool ModApiCraft::readCraftRecipeShaped(lua_State *L, int index,
 bool ModApiCraft::readCraftRecipeShapeless(lua_State *L, int index,
 		std::vector<std::string> &recipe)
 {
-	if(index < 0)
+	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
 
-	if(!lua_istable(L, index))
+	if (!lua_istable(L, index))
 		return false;
 
 	for (int i = 0; LuaHelper::geti(L, index, i); ++i, lua_pop(L, 1)) {

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -30,14 +30,14 @@ bool ModApiCraft::readCraftRecipeShaped(lua_State *L, int index,
 	if (!lua_istable(L, index))
 		return false;
 
-	for (int row = 0; LuaHelper::geti(L, index, row); ++row) {
+	for (int row = 0; LuaHelper::geti(L, index, row); ++row, lua_pop(L, 1)) {
 		if (!lua_istable(L, -1)) {
 			lua_pop(L, 1);
 			return false;
 		}
 		int index2 = lua_gettop(L);
 		int col = 0;
-		for (; LuaHelper::geti(L, index2, col); ++col) {
+		for (; LuaHelper::geti(L, index2, col); ++col, lua_pop(L, 1)) {
 			if (!lua_isstring(L, -1)) {
 				lua_pop(L, 2);
 				return false;

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -8,6 +8,7 @@
 #include "lua_api/l_item.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "common/helper.h"
 #include "server.h"
 #include "craftdef.h"
 
@@ -23,39 +24,32 @@ struct EnumString ModApiCraft::es_CraftMethod[] =
 bool ModApiCraft::readCraftRecipeShaped(lua_State *L, int index,
 		int &width, std::vector<std::string> &recipe)
 {
-	if(index < 0)
+	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
 
-	if(!lua_istable(L, index))
+	if (!lua_istable(L, index))
 		return false;
 
-	lua_pushnil(L);
-	int rowcount = 0;
-	while(lua_next(L, index) != 0){
-		int colcount = 0;
-		// key at index -2 and value at index -1
-		if(!lua_istable(L, -1))
-			return false;
-		int table2 = lua_gettop(L);
-		lua_pushnil(L);
-		while(lua_next(L, table2) != 0){
-			// key at index -2 and value at index -1
-			if(!lua_isstring(L, -1))
-				return false;
-			recipe.emplace_back(readParam<std::string>(L, -1));
-			// removes value, keeps key for next iteration
+	for (int row = 0; LuaHelper::geti(L, index, row); ++row) {
+		if (!lua_istable(L, -1)) {
 			lua_pop(L, 1);
-			colcount++;
+			return false;
 		}
-		if(rowcount == 0){
-			width = colcount;
-		} else {
-			if(colcount != width)
+		int index2 = lua_gettop(L);
+		int col = 0;
+		for (; LuaHelper::geti(L, index2, col); ++col) {
+			if (!lua_isstring(L, -1)) {
+				lua_pop(L, 2);
 				return false;
+			}
+			recipe.emplace_back(readParam<std::string>(L, -1));
 		}
-		// removes value, keeps key for next iteration
-		lua_pop(L, 1);
-		rowcount++;
+		if (row == 0) {
+			width = col;
+		} else if (col != width) {
+			lua_pop(L, 1);
+			return false;
+		}
 	}
 	return width != 0;
 }
@@ -70,14 +64,12 @@ bool ModApiCraft::readCraftRecipeShapeless(lua_State *L, int index,
 	if(!lua_istable(L, index))
 		return false;
 
-	lua_pushnil(L);
-	while(lua_next(L, index) != 0){
-		// key at index -2 and value at index -1
-		if(!lua_isstring(L, -1))
+	for (int i = 0; LuaHelper::geti(L, index, i); ++i, lua_pop(L, 1)) {
+		if (!lua_isstring(L, -1)) {
+			lua_pop(L, 1);
 			return false;
+		}
 		recipe.emplace_back(readParam<std::string>(L, -1));
-		// removes value, keeps key for next iteration
-		lua_pop(L, 1);
 	}
 	return true;
 }

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -78,24 +78,24 @@ bool ModApiCraft::readCraftRecipeShapeless(lua_State *L, int index,
 bool ModApiCraft::readCraftReplacements(lua_State *L, int index,
 		CraftReplacements &replacements)
 {
-	if(index < 0)
+	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
 
-	if(!lua_istable(L, index))
+	if (!lua_istable(L, index))
 		return false;
 
 	lua_pushnil(L);
-	while(lua_next(L, index) != 0){
+	while (lua_next(L, index) != 0) {
 		// key at index -2 and value at index -1
-		if(!lua_istable(L, -1))
+		if (!lua_istable(L, -1))
 			return false;
 		lua_rawgeti(L, -1, 1);
-		if(!lua_isstring(L, -1))
+		if (!lua_isstring(L, -1))
 			return false;
 		std::string replace_from = readParam<std::string>(L, -1);
 		lua_pop(L, 1);
 		lua_rawgeti(L, -1, 2);
-		if(!lua_isstring(L, -1))
+		if (!lua_isstring(L, -1))
 			return false;
 		std::string replace_to = readParam<std::string>(L, -1);
 		lua_pop(L, 1);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -10,6 +10,7 @@
 #include "lua_api/l_noise.h"
 #include "lua_api/l_vmanip.h"
 #include "lua_api/l_object.h"
+#include "common/helper.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "scripting_server.h"
@@ -749,14 +750,10 @@ void ModApiEnvBase::collectNodeIds(lua_State *L, int idx, const NodeDefManager *
 	std::vector<content_t> &filter)
 {
 	if (lua_istable(L, idx)) {
-		lua_pushnil(L);
-		while (lua_next(L, idx) != 0) {
-			// key at index -2 and value at index -1
+		LuaHelper::for_ipairs(L, idx, [&]() {
 			luaL_checktype(L, -1, LUA_TSTRING);
 			ndef->getIds(readParam<std::string>(L, -1), filter);
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-		}
+		});
 	} else if (lua_isstring(L, idx)) {
 		ndef->getIds(readParam<std::string>(L, idx), filter);
 	}

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -67,11 +67,9 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 
 	lua_getfield(L, 1, "extra_headers");
 	if (lua_istable(L, 2)) {
-		lua_pushnil(L);
-		while (lua_next(L, 2) != 0) {
+		LuaHelper::for_ipairs(L, 2, [&]() {
 			req.extra_headers.emplace_back(readParam<std::string>(L, -1));
-			lua_pop(L, 1);
-		}
+		});
 	}
 	lua_pop(L, 1);
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -284,15 +284,16 @@ bool read_schematic_def(lua_State *L, int index,
 
 	lua_getfield(L, index, "yslice_prob");
 	if (lua_istable(L, -1)) {
-		for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
+		LuaHelper::for_ipairs(L, -1, [&]() {
 			u16 ypos;
 			if (!getintfield(L, -1, "ypos", ypos) || (ypos >= size.Y) ||
 				!getintfield(L, -1, "prob", schem->slice_probs[ypos]))
-				continue;
+				return;
 
 			schem->slice_probs[ypos] >>= 1;
-		}
+		});
 	}
+	lua_pop(L, 1);
 
 	return true;
 }
@@ -442,18 +443,18 @@ size_t get_biome_list(lua_State *L, int index,
 	// returns number of failed resolutions
 	size_t fail_count = 0;
 
-	for (lua_pushnil(L); lua_next(L, index); lua_pop(L, 1)) {
+	LuaHelper::for_ipairs(L, index, [&]() {
 		Biome *biome = get_or_load_biome(L, -1, biomemgr);
 		if (!biome) {
 			fail_count++;
 			warningstream << "get_biome_list: failed to get biome '"
 				<< (lua_isstring(L, -1) ? lua_tostring(L, -1) : "")
 				<< "'" << std::endl;
-			continue;
+			return;
 		}
 
 		biome_id_list->insert(biome->index);
-	}
+	});
 
 	return fail_count;
 }
@@ -1028,20 +1029,16 @@ int ModApiMapgen::l_set_gen_notify(lua_State *L)
 	}
 
 	if (lua_istable(L, 2)) {
-		lua_pushnil(L);
-		while (lua_next(L, 2)) {
+		LuaHelper::for_ipairs(L, 2, [&]() {
 			if (lua_isnumber(L, -1))
 				emerge->gen_notify_on_deco_ids.insert((u32)lua_tonumber(L, -1));
-			lua_pop(L, 1);
-		}
+		});
 	}
 
 	if (lua_istable(L, 3)) {
-		lua_pushnil(L);
-		while (lua_next(L, 3)) {
+		LuaHelper::for_ipairs(L, 3, [&]() {
 			emerge->gen_notify_on_custom.insert(readParam<std::string>(L, -1));
-			lua_pop(L, 1);
-		}
+		});
 	}
 
 	// Clear sets if relevant flag disabled

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -7,6 +7,7 @@
 #include "lua_api/l_vmanip.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "common/helper.h"
 #include "cpp_api/s_security.h"
 #include "server.h"
 #include "serverenvironment.h"
@@ -230,9 +231,9 @@ bool read_schematic_def(lua_State *L, int index,
 	std::unordered_map<std::string, content_t> name_id_map;
 
 	u32 i = 0;
-	for (lua_pushnil(L); lua_next(L, -2); i++, lua_pop(L, 1)) {
+	LuaHelper::for_ipairs(L, -1, [&]() {
 		if (i >= numnodes)
-			continue;
+			return;
 
 		//// Read name
 		std::string name;
@@ -266,7 +267,8 @@ bool read_schematic_def(lua_State *L, int index,
 
 		//// Actually set the node in the schematic
 		schem->schemdata[i] = MapNode(name_index, param1, param2);
-	}
+		++i;
+	});
 
 	if (i != numnodes) {
 		errorstream << "read_schematic_def: incorrect number of "
@@ -1689,8 +1691,7 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 
 	std::vector<std::pair<v3s16, u8> > prob_list;
 	if (lua_istable(L, 3)) {
-		lua_pushnil(L);
-		while (lua_next(L, 3)) {
+		LuaHelper::for_ipairs(L, 3, [&]() {
 			if (lua_istable(L, -1)) {
 				lua_getfield(L, -1, "pos");
 				v3s16 pos = check_v3s16(L, -1);
@@ -1699,23 +1700,18 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 				u8 prob = getintfield_default(L, -1, "prob", MTSCHEM_PROB_ALWAYS);
 				prob_list.emplace_back(pos, prob);
 			}
-
-			lua_pop(L, 1);
-		}
+		});
 	}
 
 	std::vector<std::pair<s16, u8> > slice_prob_list;
 	if (lua_istable(L, 5)) {
-		lua_pushnil(L);
-		while (lua_next(L, 5)) {
+		LuaHelper::for_ipairs(L, 5, [&]() {
 			if (lua_istable(L, -1)) {
 				s16 ypos = getintfield_default(L, -1, "ypos", 0);
 				u8 prob  = getintfield_default(L, -1, "prob", MTSCHEM_PROB_ALWAYS);
 				slice_prob_list.emplace_back(ypos, prob);
 			}
-
-			lua_pop(L, 1);
-		}
+		});
 	}
 
 	if (!schem.getSchematicFromMap(&env->getMap(), p1, p2)) {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -82,8 +82,6 @@ ObjDef *get_objdef(lua_State *L, int index, const ObjDefManager *objmgr);
 Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
 Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef);
-size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<biome_t> *biome_id_list);
 
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names);
@@ -411,8 +409,8 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 }
 
 
-size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::unordered_set<biome_t> *biome_id_list)
+static size_t get_biome_list(lua_State *L, int index,
+	BiomeManager *biomemgr, std::unordered_set<biome_t> *biome_ids)
 {
 	if (index < 0)
 		index = lua_gettop(L) + 1 + index;
@@ -436,7 +434,7 @@ size_t get_biome_list(lua_State *L, int index,
 			return 1;
 		}
 
-		biome_id_list->insert(biome->index);
+		biome_ids->insert(biome->index);
 		return 0;
 	}
 
@@ -453,7 +451,7 @@ size_t get_biome_list(lua_State *L, int index,
 			return;
 		}
 
-		biome_id_list->insert(biome->index);
+		biome_ids->insert(biome->index);
 	});
 
 	return fail_count;

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -6,6 +6,7 @@
 #include "lua_api/l_internal.h"
 #include "lua_api/l_inventory.h"
 #include "common/c_content.h"
+#include "common/helper.h"
 #include "serverenvironment.h"
 #include "map.h"
 #include "mapblock.h"
@@ -86,14 +87,10 @@ int NodeMetaRef::l_mark_as_private(lua_State *L)
 
 	bool modified = false;
 	if (lua_istable(L, 2)) {
-		lua_pushnil(L);
-		while (lua_next(L, 2) != 0) {
-			// key at index -2 and value at index -1
+		LuaHelper::for_ipairs(L, 2, [&]() {
 			luaL_checktype(L, -1, LUA_TSTRING);
 			modified |= meta->markPrivate(readParam<std::string>(L, -1), true);
-			// removes value, keeps key for next iteration
-			lua_pop(L, 1);
-		}
+		});
 	} else if (lua_isstring(L, 2)) {
 		modified |= meta->markPrivate(readParam<std::string>(L, 2), true);
 	}

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -11,6 +11,7 @@
 #include "lua_api/l_playermeta.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "common/helper.h"
 #include "cpp_api/s_base.h"
 #include "log.h"
 #include "player.h"
@@ -2087,13 +2088,9 @@ int ObjectRef::l_set_sky(lua_State *L)
 		lua_getfield(L, 2, "textures");
 		sky_params.textures.clear();
 		if (lua_istable(L, -1) && sky_params.type == "skybox") {
-			lua_pushnil(L);
-			while (lua_next(L, -2) != 0) {
-				// Key is at index -2 and value at index -1
+			LuaHelper::for_ipairs(L, -1, [&]() {
 				sky_params.textures.emplace_back(readParam<std::string>(L, -1));
-				// Removes the value, but keeps the key for iteration
-				lua_pop(L, 1);
-			}
+			});
 		}
 		lua_pop(L, 1);
 
@@ -2196,13 +2193,9 @@ int ObjectRef::l_set_sky(lua_State *L)
 
 		sky_params.textures.clear();
 		if (lua_istable(L, 4)) {
-			lua_pushnil(L);
-			while (lua_next(L, 4) != 0) {
-				// Key at index -2, and value at index -1
+			LuaHelper::for_ipairs(L, 4, [&]() {
 				sky_params.textures.emplace_back(readParam<std::string>(L, -1));
-				// Remove the value, keep the key for the next iteration
-				lua_pop(L, 1);
-			}
+			});
 		}
 		if (sky_params.type == "skybox" && sky_params.textures.size() != 6)
 			throw LuaError("Skybox expects 6 textures.");
@@ -2622,6 +2615,37 @@ int ObjectRef::l_get_day_night_ratio(lua_State *L)
 	return 1;
 }
 
+static std::optional<MinimapMode> read_minimap_mode(lua_State *L, int index)
+{
+	if (!lua_istable(L, index))
+		return std::nullopt;
+
+	MinimapMode mode;
+
+	std::string type = getstringfield_default(L, index, "type", "");
+	if (type == "off")
+		mode.type = MINIMAP_TYPE_OFF;
+	else if (type == "surface")
+		mode.type = MINIMAP_TYPE_SURFACE;
+	else if (type == "radar")
+		mode.type = MINIMAP_TYPE_RADAR;
+	else if (type == "texture") {
+		mode.type = MINIMAP_TYPE_TEXTURE;
+		mode.texture = getstringfield_default(L, index, "texture", "");
+		mode.scale = getintfield_default(L, index, "scale", 1);
+	} else {
+		warningstream << "Minimap mode of unknown type \"" << type.c_str()
+			<< "\" ignored.\n" << std::endl;
+		return std::nullopt;
+	}
+
+	mode.label = getstringfield_default(L, index, "label", "");
+	// Size is limited to 512. Performance gets poor if size too large, and
+	// segfaults have been experienced.
+	mode.size = rangelim(getintfield_default(L, index, "size", 0), 1, 512);
+	return mode;
+}
+
 // set_minimap_modes(self, modes, selected_mode)
 int ObjectRef::l_set_minimap_modes(lua_State *L)
 {
@@ -2635,41 +2659,10 @@ int ObjectRef::l_set_minimap_modes(lua_State *L)
 	std::vector<MinimapMode> modes;
 	s16 selected_mode = readParam<s16>(L, 3);
 
-	lua_pushnil(L);
-	while (lua_next(L, 2) != 0) {
-		/* key is at index -2, value is at index -1 */
-		if (lua_istable(L, -1)) {
-			bool ok = true;
-			MinimapMode mode;
-			std::string type = getstringfield_default(L, -1, "type", "");
-			if (type == "off")
-				mode.type = MINIMAP_TYPE_OFF;
-			else if (type == "surface")
-				mode.type = MINIMAP_TYPE_SURFACE;
-			else if (type == "radar")
-				mode.type = MINIMAP_TYPE_RADAR;
-			else if (type == "texture") {
-				mode.type = MINIMAP_TYPE_TEXTURE;
-				mode.texture = getstringfield_default(L, -1, "texture", "");
-				mode.scale = getintfield_default(L, -1, "scale", 1);
-			} else {
-				warningstream << "Minimap mode of unknown type \"" << type.c_str()
-					<< "\" ignored.\n" << std::endl;
-				ok = false;
-			}
-
-			if (ok) {
-				mode.label = getstringfield_default(L, -1, "label", "");
-				// Size is limited to 512. Performance gets poor if size too large, and
-				// segfaults have been experienced.
-				mode.size = rangelim(getintfield_default(L, -1, "size", 0), 1, 512);
-				modes.push_back(mode);
-			}
-		}
-		/* removes 'value'; keeps 'key' for next iteration */
-		lua_pop(L, 1);
-	}
-	lua_pop(L, 1); // Remove key
+	LuaHelper::for_ipairs(L, 2, [&]() {
+		if (auto mode = read_minimap_mode(L, -1))
+			modes.push_back(*mode);
+	});
 
 	getServer(L)->SendMinimapModes(player->getPeerId(), modes, selected_mode);
 	return 0;


### PR DESCRIPTION
Using `ipairs`-like iteration for lists where we should, since `lua_next` **does not guarantee order**, even though it mostly works in practice. See the commit descriptions for some details.

## How to test

Make sure that the touched functions work as expected when used.

I did not do this for all of them. I think based on the code changes it should be possible to confirm that the code still does the same thing as before (or a better thing) by careful reading.