### PR TITLE
Fix string metatable in CPCSM and SSCSM

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -100,6 +100,21 @@ static int l_nop(lua_State *L)
 	return 0;
 }
 
+/*
+ * In addition to copying the whitelisted tables, we also need to
+ * replace the string metatable. Otherwise old_globals.string would
+ * be accessible via getmetatable("").__index from inside the sandbox.
+ */
+static inline void replace_string_metatable(lua_State *L)
+{
+	lua_pushliteral(L, "");
+	lua_newtable(L);
+	lua_getglobal(L, "string");
+	lua_setfield(L, -2, "__index");
+	lua_setmetatable(L, -2);
+	lua_pop(L, 1); // Pop empty string
+}
+
 
 void ScriptApiSecurity::initializeSecurity()
 {
@@ -315,18 +330,7 @@ void ScriptApiSecurity::initializeSecurity()
 
 	lua_pop(L, 1); // Pop globals_backup
 
-
-	/*
-	 * In addition to copying the tables in whitelist_tables, we also need to
-	 * replace the string metatable. Otherwise old_globals.string would
-	 * be accessible via getmetatable("").__index from inside the sandbox.
-	 */
-	lua_pushliteral(L, "");
-	lua_newtable(L);
-	lua_getglobal(L, "string");
-	lua_setfield(L, -2, "__index");
-	lua_setmetatable(L, -2);
-	lua_pop(L, 1); // Pop empty string
+	replace_string_metatable(L);
 
 	FATAL_ERROR_IF(sanity_check_top != lua_gettop(L), "unbalanced stack");
 }
@@ -457,6 +461,8 @@ void ScriptApiSecurity::initializeSecurityClient()
 
 	// Set the environment to the one we created earlier
 	setLuaEnv(L, thread);
+
+	replace_string_metatable(L);
 }
 
 void ScriptApiSecurity::initializeSecuritySSCSM()

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -595,6 +595,8 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 
 	// Set the environment to the one we created earlier
 	setLuaEnv(L, thread);
+
+	replace_string_metatable(L);
 }
 
 #endif


### PR DESCRIPTION
Solves #17105

## How to test

See that the metatable `__index` of string objects in clientmods is equal to the `string` table.
``` lua
print(getmetatable("").__index)
print(string)
```
In client mod environment.
