### PR TITLE
fix: restore correct shading for inventory node items

### DIFF
--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -244,12 +244,12 @@ void setMeshColorByNormal(scene::IMesh *mesh, const v3f &normal,
 }
 
 template <float v3f::*U, float v3f::*V>
-static void rotateMesh(scene::IMesh *mesh, float degrees)
+static void rotateMesh(scene::IMesh *mesh, float degrees, bool rotate_normals = true)
 {
 	degrees *= M_PI / 180.0f;
 	float c = std::cos(degrees);
 	float s = std::sin(degrees);
-	auto rotator = [c, s] (video::S3DVertex *vertex) {
+	auto rotator = [c, s, rotate_normals] (video::S3DVertex *vertex) {
 		auto rotate_vec = [c, s] (v3f &vec) {
 			float u = vec.*U;
 			float v = vec.*V;
@@ -257,7 +257,8 @@ static void rotateMesh(scene::IMesh *mesh, float degrees)
 			vec.*V = s * u + c * v;
 		};
 		rotate_vec(vertex->Pos);
-		rotate_vec(vertex->Normal);
+		if (rotate_normals)
+			rotate_vec(vertex->Normal);
 	};
 	applyToMesh(mesh, rotator);
 }

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -83,10 +83,13 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, u8 facedir);
 
 /*
 	Rotate the mesh around the axis and given angle in degrees.
+	If rotate_normals is true (default), normals are rotated along with positions.
+	Set rotate_normals to false for inventory item rendering where shading
+	expects axis-aligned normals.
 */
-void rotateMeshXYby (scene::IMesh *mesh, f64 degrees);
-void rotateMeshXZby (scene::IMesh *mesh, f64 degrees);
-void rotateMeshYZby (scene::IMesh *mesh, f64 degrees);
+void rotateMeshXYby (scene::IMesh *mesh, f64 degrees, bool rotate_normals = true);
+void rotateMeshXZby (scene::IMesh *mesh, f64 degrees, bool rotate_normals = true);
+void rotateMeshYZby (scene::IMesh *mesh, f64 degrees, bool rotate_normals = true);
 
 /*
  *  Clone the mesh buffer.

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -726,8 +726,9 @@ void createItemMesh(Client *client, const ItemDefinition &def,
 			});
 		}
 
-		rotateMeshXZby(mesh, -45);
-		rotateMeshYZby(mesh, -30);
+		// Don't rotate normals - shading expects axis-aligned normals
+		rotateMeshXZby(mesh, -45, false);
+		rotateMeshYZby(mesh, -30, false);
 	}
 
 	// might need to be re-colorized, this is done only when needed


### PR DESCRIPTION
Rendering regression of shading for inventory nodes

In Luanti 5.11.0, commit 3c5e0d10f changed rotateMesh() to rotate both positions and normals. This broke inventory item shading because applyFacesShading() expects axis-aligned normals.

This fix adds a rotate_normals parameter (defaulting to true for backward compatibility) to rotateMeshXYby/XZby/YZby. For inventory item rendering, we now pass rotate_normals=false to preserve axis-aligned normals so that applyFacesShading() calculates correct shade factors for each face.

Fixes #17110