### PR TITLE
Store focused list

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3005,10 +3005,22 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 					}
 				}
 			}
+
+			if (auto *list = dynamic_cast<GUIInventoryList *>(focused_element)) {
+				m_focused_inventory_list = FocusedInventoryList {
+					list->getInventoryloc(),
+					list->getListname(),
+				};
+			} else {
+				m_focused_inventory_list = std::nullopt;
+			}
+		} else {
+			m_focused_inventory_list = std::nullopt;
 		}
 	} else {
 		// Don't keep old focus value
 		m_focused_element = std::nullopt;
+		m_focused_inventory_list = std::nullopt;
 	}
 
 	removeAll();
@@ -3314,6 +3326,16 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	// Set initial focus if parser didn't set it
 	gui::IGUIElement *focused_element = Environment->getFocus();
+	if ((!focused_element || !isMyChild(focused_element)) && m_focused_inventory_list) {
+		for (GUIInventoryList *list : m_inventorylists) {
+			if (list->getInventoryloc() == m_focused_inventory_list->inventoryloc &&
+					list->getListname() == m_focused_inventory_list->listname) {
+				Environment->setFocus(list);
+				focused_element = list;
+				break;
+			}
+		}
+	}
 	if (!focused_element
 			|| !isMyChild(focused_element)
 			|| focused_element->getType() == gui::EGUIET_TAB_CONTROL)

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -382,11 +382,17 @@ protected:
 	video::SColor m_default_tooltip_color;
 
 private:
+	struct FocusedInventoryList {
+		InventoryLocation inventoryloc;
+		std::string listname;
+	};
+
 	IFormSource               *m_form_src;
 	TextDest                  *m_text_dst;
 	std::string                m_last_formname;
 	u16                        m_formspec_version = 1;
 	std::optional<std::string> m_focused_element = std::nullopt;
+	std::optional<FocusedInventoryList> m_focused_inventory_list = std::nullopt;
 	JoystickController        *m_joystick;
 	bool                       m_show_debug = false;
 	bool                       m_show_focus = false;


### PR DESCRIPTION
PR made to fix issue #17102 . I drilled it down to loss of focus on formspec update. If the formspec contains some sort of a button, it will default to focusing it, resulting in "eating" next click to regain focus.
I don't have much experience with c++ development, so I tried to make as few changes as possible. Introduced struct could be expanded to cover existing focus retention, but it would need a bigger refactor I'm not comfortable to make.
I am one of the "other people" mentioned in the issue. I tested changes both on the devtest example (provided below) and our original branch we observed this problem. These changes fixed issue. Originally we faced this issue while updating a placeholder image for an item, when a hidden distribution list decides where the item should be transferred (armor to the armor list, offhand to the offhand list and so on) in `register_on_player_inventory_action` callback.
As I mentioned, I'm not a C++ dev (didn't touch c++ since uni) so someone should look closely for any unforeseen implications.
gpt-5.4 was used with writing code.

This PR is a Ready for Review.

## How to test
Add this lua code to the game (as a separate mod or injected into existing one), obtain an item, shift-click item in player inventory.
Before applying this patch, every other click does not result in an action. After applying this patch, the problem is gone.
<!-- Example code or instructions -->
```lua
local ff = "size[8,7.5]"

local formspec1 = table.concat{
		"formspec_version[6]",
    ff,
    "image[1.57,0.343;3.62,4.85;chest_chest.png;2]",
    "button[0.5,0.5;1,1;chest_of_everything_bag;test_imgbtn1]",
    -- "image_button[6.5,0.5;1,1;chest_of_everything_bag.png;test_imgbtn2;]",
    "list[current_player;offhand;2.375,1.125;1,1]",
    "list[current_player;main;5.375,4.125;1,1]",
    "listring[current_player;main]",
    "listring[current_player;distr]",
    "listring[current_player;offhand]",
}

local formspec2 = table.concat{
		"formspec_version[6]",
    ff,
    "image[1.57,0.343;3.62,4.85;chest_detached_chest.png;2]",
    "button[0.5,0.5;1,1;chest_of_everything_bag;test_imgbtn1]",
    -- "image_button[6.5,0.5;1,1;chest_of_everything_bag.png;test_imgbtn2;]",
    "list[current_player;offhand;2.375,1.125;1,1]",
    "list[current_player;main;5.375,4.125;1,1]",
    "listring[current_player;main]",
    "listring[current_player;distr]",
    "listring[current_player;offhand]",
}

core.register_on_joinplayer(function(player)
    player:set_inventory_formspec(formspec1)
    local inv = player:get_inventory()
    inv:set_size("main", 1)
    inv:set_size("offhand", 1)
    inv:set_size("distr", 1)
end)

local flag = false
core.register_on_player_inventory_action(function(player, action, inventory, inventory_info)
    if inventory_info.to_list == "distr" then
        local stack = inventory:get_stack(inventory_info.to_list, inventory_info.to_index)
        inventory:set_stack("offhand", 1, stack)
        inventory:set_stack("distr", 1, nil)
    end
    local formspec = flag and formspec1 or formspec2
    flag = not flag
    player:set_inventory_formspec(formspec)
end)
``` 