### PR TITLE
[no sq] Client: Unify and clean up start/exit parameters

### DIFF
--- a/builtin/mainmenu/dlg_register.lua
+++ b/builtin/mainmenu/dlg_register.lua
@@ -55,6 +55,7 @@ local function register_buttonhandler(this, fields)
 			return true
 		end
 
+		gamedata.mode       = "join"
 		gamedata.playername = fields.name
 		gamedata.password   = fields.password
 		gamedata.address    = this.data.address
@@ -67,12 +68,7 @@ local function register_buttonhandler(this, fields)
 		local server = this.data.server
 		if server then
 			serverlistmgr.add_favorite(server)
-			gamedata.servername        = server.name
-			gamedata.serverdescription = server.description
 		else
-			gamedata.servername        = ""
-			gamedata.serverdescription = ""
-
 			serverlistmgr.add_favorite({
 				address = gamedata.address,
 				port = gamedata.port,

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -381,6 +381,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		end
 
 		if core.settings:get_bool("enable_server") then
+			gamedata.mode       = "host"
 			gamedata.playername = fields["te_playername"]
 			gamedata.password   = fields["te_passwd"]
 			gamedata.port       = fields["te_serverport"]
@@ -391,7 +392,7 @@ local function main_button_handler(this, fields, name, tabdata)
 				core.settings:set("bind_address",fields["te_serveraddr"])
 			end
 		else
-			gamedata.singleplayer = true
+			gamedata.mode = "singleplayer"
 		end
 
 		core.start()

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -64,7 +64,6 @@ local function set_selected_server(server)
 	end
 	local address = server.address
 	local port    = server.port
-	gamedata.serverdescription = server.description
 
 	if address and port then
 		core.settings:set("address", address)
@@ -152,10 +151,9 @@ local function get_formspec(tabview, name, tabdata)
 	local selected_server = find_selected_server()
 
 	if selected_server then
-		gamedata.serverdescription = selected_server.description
-		if gamedata.serverdescription then
+		if selected_server.description then
 			retval = retval .. "textarea[0.25,1.85;5.25,2.7;;;" ..
-				core.formspec_escape(gamedata.serverdescription) .. "]"
+				core.formspec_escape(selected_server.description) .. "]"
 		end
 
 		-- URL button
@@ -514,6 +512,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 					return true
 				end
 
+				gamedata.mode       = "join"
 				gamedata.address    = server.address
 				gamedata.port       = server.port
 				gamedata.playername = fields.te_name
@@ -522,9 +521,6 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				if fields.te_pwd then
 					gamedata.password = fields.te_pwd
 				end
-
-				gamedata.servername        = server.name
-				gamedata.serverdescription = server.description
 
 				if gamedata.address and gamedata.port then
 					set_selected_server(server)
@@ -600,6 +596,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	local te_port_number = tonumber(fields.te_port)
 
 	if (fields.btn_mp_login or fields.key_enter) and host_filled then
+		gamedata.mode       = "join"
 		gamedata.playername = fields.te_name
 		gamedata.password   = fields.te_pwd
 		gamedata.address    = fields.te_address
@@ -617,17 +614,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 			serverlistmgr.add_favorite(server)
 
-			gamedata.servername        = server.name
-			gamedata.serverdescription = server.description
-
 			if not is_server_protocol_compat_or_error(
 						server.proto_min, server.proto_max) then
 				return true
 			end
 		else
-			gamedata.servername        = ""
-			gamedata.serverdescription = ""
-
 			serverlistmgr.add_favorite({
 				address = gamedata.address,
 				port = gamedata.port,

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -40,8 +40,10 @@ The "gamedata" table is read when calling `core.start()`. It should contain:
     password       = <password>,
     address        = <IP/address>,
     port           = <port>,
+    do_reconnect   = <bool>,
+    allow_login_or_register = "login"|"register"|"any",
     selected_world = <index>, -- 0 for client mode
-    singleplayer   = <true/false>,
+    mode           = "singleplayer"|"host"|"join",
 }
 ```
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -172,8 +172,7 @@ bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args
 
 	// If an error occurs, this is set to something by menu().
 	// It is then displayed before the menu shows on the next call to menu()
-	std::string error_message;
-	bool reconnect_requested = false;
+	GameErrorData errordata;
 
 	bool first_loop = true;
 
@@ -208,11 +207,10 @@ bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args
 			guiroot = guienv->addStaticText(L"",
 				core::rect<s32>(0, 0, 10000, 10000));
 
-			bool should_run_game = launch_game(error_message, reconnect_requested,
-				start_data, cmd_args);
+			bool should_run_game = launch_game(errordata, start_data, cmd_args);
 
 			// Reset the reconnect_requested flag
-			reconnect_requested = false;
+			errordata.reconnect_requested = false;
 
 			// If skip_main_menu, we only want to startup once
 			if (skip_main_menu && !first_loop)
@@ -234,15 +232,13 @@ bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args
 				input,
 				m_rendering_engine,
 				start_data,
-				error_message,
-				chat_backend,
-				&reconnect_requested
+				errordata,
+				chat_backend
 			);
 #ifdef NDEBUG
 		} catch (std::exception &e) {
-			error_message = "Some exception: ";
-			error_message.append(debug_describe_exc(e));
-			errorstream << error_message << std::endl;
+			errordata.message = "Some exception: " + debug_describe_exc(e);
+			errorstream << errordata.message << std::endl;
 		}
 #endif
 
@@ -263,7 +259,7 @@ bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args
 
 		// If no main menu, show error and exit
 		if (skip_main_menu) {
-			if (!error_message.empty())
+			if (!errordata.message.empty())
 				retval = false;
 			break;
 		}
@@ -426,14 +422,12 @@ void ClientLauncher::config_guienv()
 	}
 }
 
-bool ClientLauncher::launch_game(std::string &error_message,
-		bool reconnect_requested, GameStartData &start_data,
+bool ClientLauncher::launch_game(GameErrorData &errordata, GameStartData &start_data,
 		const Settings &cmd_args)
 {
-	// Prepare and check the start data to launch a game
-	std::string error_message_lua = error_message;
-	error_message.clear();
+	std::string &error_message = errordata.message;
 
+	// Prepare and check the start data to launch a game
 	if (cmd_args.exists("password"))
 		start_data.password = cmd_args.get("password");
 
@@ -455,11 +449,9 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	 */
 	if (!skip_main_menu) {
 		// Initialize menu data
-		MainMenuData menudata;
+		MainMenuData menudata(errordata);
 		(GameClientData &)menudata = start_data;
 		menudata.port = itos(start_data.socket_port);
-		menudata.script_data.errormessage        = std::move(error_message_lua);
-		menudata.script_data.reconnect_requested = reconnect_requested;
 
 		main_menu(&menudata);
 
@@ -467,11 +459,11 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		if (!m_rendering_engine->run() || *porting::signal_handler_killstatus())
 			return false;
 
-		if (!menudata.script_data.errormessage.empty()) {
+		if (!menudata.script_data.message.empty()) {
 			/* The calling function will pass this back into this function upon the
 			 * next iteration (if any) causing it to be displayed by the GUI
 			 */
-			error_message = menudata.script_data.errormessage;
+			error_message = menudata.script_data.message;
 			return false;
 		}
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -95,8 +95,11 @@ ClientLauncher::~ClientLauncher()
 }
 
 
-bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
+bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args)
 {
+	GameStartData start_data;
+	static_cast<GameParams &>(start_data) = game_params;
+
 	init_args(start_data, cmd_args);
 
 	try {
@@ -283,12 +286,14 @@ void ClientLauncher::init_args(GameStartData &start_data, const Settings &cmd_ar
 	start_data.address = g_settings->get("address");
 	if (cmd_args.exists("address")) {
 		// Join a remote server
+		start_data.mode = GameClientData::GM_JOIN;
 		start_data.address = cmd_args.get("address");
 		start_data.world_path.clear();
 		start_data.name = g_settings->get("name");
 	}
 	if (!start_data.world_path.empty()) {
 		// Start a singleplayer instance
+		start_data.mode = GameClientData::GM_SINGLEPLAYER;
 		start_data.address = "";
 	}
 
@@ -297,6 +302,9 @@ void ClientLauncher::init_args(GameStartData &start_data, const Settings &cmd_ar
 
 	// If a world was commanded, select it
 	if (!start_data.world_path.empty()) {
+		if (!start_data.name.empty())
+			start_data.mode = GameClientData::GM_HOST_AND_JOIN;
+
 		auto &spec = start_data.world_spec;
 
 		spec.path = start_data.world_path;
@@ -445,15 +453,11 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	/*
 	 * Show the GUI menu
 	 */
-	std::string server_name, server_description;
 	if (!skip_main_menu) {
 		// Initialize menu data
-		// TODO: Re-use existing structs (GameStartData)
 		MainMenuData menudata;
-		menudata.address                         = start_data.address;
-		menudata.name                            = start_data.name;
-		menudata.password                        = start_data.password;
-		menudata.port                            = itos(start_data.socket_port);
+		(GameClientData &)menudata = start_data;
+		menudata.port = itos(start_data.socket_port);
 		menudata.script_data.errormessage        = std::move(error_message_lua);
 		menudata.script_data.reconnect_requested = reconnect_requested;
 
@@ -484,18 +488,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 			start_data.world_path = start_data.world_spec.path;
 		}
 
-		start_data.name = menudata.name;
-		start_data.password = menudata.password;
-		start_data.address = std::move(menudata.address);
-		start_data.allow_login_or_register = menudata.allow_login_or_register;
-		server_name = menudata.servername;
-		server_description = menudata.serverdescription;
-
-		start_data.local_server = !menudata.simple_singleplayer_mode &&
-			start_data.address.empty();
-	} else {
-		start_data.local_server = !start_data.world_path.empty() &&
-			start_data.address.empty() && !start_data.name.empty();
+		(GameClientData &)start_data = menudata;
 	}
 
 	if (!start_data.isSinglePlayer() && start_data.name.empty()) {
@@ -521,7 +514,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	}
 
 	// For singleplayer and local server
-	if (start_data.address.empty()) {
+	if (start_data.isAnyServer()) {
 		auto &worldspec = start_data.world_spec;
 		if (worldspec.path.empty()) {
 			error_message = gettext("No world selected and no address "

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -509,9 +509,9 @@ bool ClientLauncher::launch_game(GameErrorData &errordata, GameStartData &start_
 	if (start_data.isAnyServer()) {
 		auto &worldspec = start_data.world_spec;
 		if (worldspec.path.empty()) {
-			error_message = gettext("No world selected and no address "
-					"provided. Nothing to do.");
-			errorstream << error_message << std::endl;
+			errordata.setError(
+				gettext("No world selected and no address provided. Nothing to do.")
+			);
 			return false;
 		}
 
@@ -528,13 +528,13 @@ bool ClientLauncher::launch_game(GameErrorData &errordata, GameStartData &start_
 		}
 
 		if (!start_data.game_spec.isValid()) {
+			std::string msg;
 			if (world_exists) {
-				error_message = gettext("Could not find or load game: ")
-					+ worldspec.gameid;
+				msg = gettext("Could not find or load game: ") + worldspec.gameid;
 			} else {
-				error_message = gettext("World does not exist and no game selected to create one.");
+				msg = gettext("World does not exist and no game selected to create one.");
 			}
-			errorstream << error_message << std::endl;
+			errordata.setError(msg);
 			return false;
 		}
 	}

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -10,6 +10,7 @@ class RenderingEngine;
 class Settings;
 class MyEventReceiver;
 class InputHandler;
+struct GameParams;
 struct GameStartData;
 struct MainMenuData;
 
@@ -20,7 +21,7 @@ public:
 
 	~ClientLauncher();
 
-	bool run(GameStartData &start_data, const Settings &cmd_args);
+	bool run(const GameParams &game_params, const Settings &cmd_args);
 
 private:
 	void init_args(GameStartData &start_data, const Settings &cmd_args);

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -32,7 +32,7 @@ private:
 	static void setting_changed_callback(const std::string &name, void *data);
 	void config_guienv();
 
-	bool launch_game(std::string &error_message, bool reconnect_requested,
+	bool launch_game(GameErrorData &errordata,
 		GameStartData &start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -749,8 +749,6 @@ bool Game::initSound()
 bool Game::createServer(const std::string &map_dir,
 		const SubgameSpec &gamespec, u16 port)
 {
-	std::string *error_message = &(errordata->message);
-
 	showOverlayMessage(N_("Creating server..."), 0, 5);
 
 	std::string bind_str;
@@ -774,9 +772,8 @@ bool Game::createServer(const std::string &map_dir,
 			<< " -- Listening on all addresses." << std::endl;
 	}
 	if (bind_addr.isIPv6() && !g_settings->getBool("enable_ipv6")) {
-		*error_message = fmtgettext("Unable to listen on %s because IPv6 is disabled",
-			bind_addr.serializeString().c_str());
-		errorstream << *error_message << std::endl;
+		errordata->setError(fmtgettext("Unable to listen on %s because IPv6 is disabled",
+			bind_addr.serializeString().c_str()));
 		return false;
 	}
 
@@ -848,8 +845,7 @@ bool Game::createClient(const GameStartData &start_data)
 	if (!could_connect) {
 		if (error_message->empty() && !connect_aborted) {
 			// Should not happen if error messages are set properly
-			*error_message = gettext("Connection failed for unknown reason");
-			errorstream << *error_message << std::endl;
+			errordata->setError(gettext("Connection failed for unknown reason"));
 		}
 		return false;
 	}
@@ -857,8 +853,7 @@ bool Game::createClient(const GameStartData &start_data)
 	if (!getServerContent(&connect_aborted)) {
 		if (error_message->empty() && !connect_aborted) {
 			// Should not happen if error messages are set properly
-			*error_message = gettext("Connection failed for unknown reason");
-			errorstream << *error_message << std::endl;
+			errordata->setError(gettext("Connection failed for unknown reason"));
 		}
 		return false;
 	}
@@ -1225,9 +1220,10 @@ bool Game::checkConnection()
 		const std::string reason = wide_to_utf8(
 			unescape_translate(utf8_to_wide(client->accessDeniedReason())));
 
-		errordata->message = fmtgettext("Access denied. Reason: %s", reason.c_str());
-		errordata->reconnect_requested = client->reconnectRequested();
-		errorstream << errordata->message << std::endl;
+		errordata->setError(
+			fmtgettext("Access denied. Reason: %s", reason.c_str()),
+			client->reconnectRequested()
+		);
 		return false;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -424,8 +424,7 @@ bool Game::startup(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
 		const GameStartData &start_data,
-		std::string &error_message,
-		bool *reconnect,
+		GameErrorData &errordata,
 		ChatBackend *chat_backend)
 {
 
@@ -433,8 +432,7 @@ bool Game::startup(volatile std::sig_atomic_t *kill,
 	m_rendering_engine        = rendering_engine;
 	device                    = m_rendering_engine->get_raw_device();
 	this->kill                = kill;
-	this->error_message       = &error_message;
-	reconnect_requested       = reconnect;
+	this->errordata           = &errordata;
 	this->input               = input;
 	this->chat_backend        = chat_backend;
 	simple_singleplayer_mode  = start_data.isSinglePlayer();
@@ -751,6 +749,8 @@ bool Game::initSound()
 bool Game::createServer(const std::string &map_dir,
 		const SubgameSpec &gamespec, u16 port)
 {
+	std::string *error_message = &(errordata->message);
+
 	showOverlayMessage(N_("Creating server..."), 0, 5);
 
 	std::string bind_str;
@@ -781,7 +781,7 @@ bool Game::createServer(const std::string &map_dir,
 	}
 
 	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr,
-			false, nullptr, error_message);
+			false, nullptr, &(errordata->message));
 
 	auto start_thread = runInThread([=] {
 		server->start();
@@ -833,6 +833,8 @@ void Game::copyServerClientCache()
 
 bool Game::createClient(const GameStartData &start_data)
 {
+	std::string *error_message = &(errordata->message);
+
 	showOverlayMessage(N_("Creating client..."), 0, 10);
 
 	draw_control = new MapDrawControl();
@@ -965,6 +967,8 @@ bool Game::initGui()
 bool Game::connectToServer(const GameStartData &start_data,
 		bool *connect_ok, bool *connection_aborted)
 {
+	std::string *error_message = &(errordata->message);
+
 	*connect_ok = false;	// Let's not be overly optimistic
 	*connection_aborted = false;
 	const auto &address_name = start_data.address;
@@ -1135,8 +1139,8 @@ bool Game::getServerContent(bool *aborted)
 			return false;
 
 		if (client->getState() < LC_Init) {
-			*error_message = gettext("Client disconnected");
-			errorstream << *error_message << std::endl;
+			errordata->message = gettext("Client disconnected");
+			errorstream << errordata->message << std::endl;
 			return false;
 		}
 
@@ -1221,9 +1225,9 @@ bool Game::checkConnection()
 		const std::string reason = wide_to_utf8(
 			unescape_translate(utf8_to_wide(client->accessDeniedReason())));
 
-		*error_message = fmtgettext("Access denied. Reason: %s", reason.c_str());
-		*reconnect_requested = client->reconnectRequested();
-		errorstream << *error_message << std::endl;
+		errordata->message = fmtgettext("Access denied. Reason: %s", reason.c_str());
+		errordata->reconnect_requested = client->reconnectRequested();
+		errorstream << errordata->message << std::endl;
 		return false;
 	}
 
@@ -3785,16 +3789,16 @@ void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
 		const GameStartData &start_data,
-		std::string &error_message,
-		ChatBackend &chat_backend,
-		bool *reconnect_requested) // Used for local game
+		GameErrorData &errordata,
+		ChatBackend &chat_backend)
 {
 	Game game;
+	std::string &error_message = errordata.message;
 
 	try {
 
 		if (game.startup(kill, input, rendering_engine, start_data,
-				error_message, reconnect_requested, &chat_backend)) {
+				errordata, &chat_backend)) {
 			game.run();
 		}
 

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -16,6 +16,7 @@
 class InputHandler;
 class ChatBackend;
 class RenderingEngine;
+struct GameErrorData;
 struct GameStartData;
 
 struct Jitter {
@@ -40,6 +41,5 @@ void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
 		const GameStartData &start_data,
-		std::string &error_message,
-		ChatBackend &chat_backend,
-		bool *reconnect_requested);
+		GameErrorData &errordata,
+		ChatBackend &chat_backend);

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -34,6 +34,7 @@ class ProfilerGraph;
 class EventManager;
 class GUIChatConsole;
 class QuicktuneShortcutter;
+struct GameErrorData;
 
 const static float object_hit_delay = 0.2;
 
@@ -99,8 +100,7 @@ public:
 			InputHandler *input,
 			RenderingEngine *rendering_engine,
 			const GameStartData &game_params,
-			std::string &error_message,
-			bool *reconnect,
+			GameErrorData &errordata,
 			ChatBackend *chat_backend);
 
 	void run();
@@ -337,8 +337,7 @@ private:
 	video::IVideoDriver        *driver;
 	scene::ISceneManager       *smgr;
 	volatile std::sig_atomic_t *kill;
-	std::string                *error_message;
-	bool                       *reconnect_requested;
+	GameErrorData              *errordata;
 	PausedNodesList             paused_animated_nodes;
 
 	bool simple_singleplayer_mode;

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -54,3 +54,13 @@ struct GameStartData : GameParams, GameClientData
 	// "world_path" must be kept in sync!
 	WorldSpec world_spec;
 };
+
+/// Data provided to Lua for error reporting by the main menu
+struct GameErrorData
+{
+	GameErrorData() = default;
+
+	// Whether the server has requested a reconnect
+	bool reconnect_requested = false;
+	std::string message;
+};

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -8,6 +8,7 @@
 #include "content/subgames.h"
 
 // Information provided from "main"
+// Start information for server or client
 struct GameParams
 {
 	GameParams() = default;
@@ -24,24 +25,31 @@ enum class ELoginRegister {
 	Register
 };
 
-// Information processed by main menu
-// TODO: unify with MainMenuData
-struct GameStartData : GameParams
+struct GameClientData
 {
-	GameStartData() = default;
-
-	bool isSinglePlayer() const { return address.empty() && !local_server; }
+	bool isSinglePlayer() const { return mode == GM_SINGLEPLAYER; }
+	bool isAnyServer() const
+	{ return mode == GM_HOST_AND_JOIN || mode == GM_SINGLEPLAYER; }
 
 	std::string name;
 	std::string password;
-	// If empty, we're hosting a server.
-	// This may or may not be in "simple singleplayer mode".
-	std::string address;
-	// If true, we're hosting a server and are *not* in "simple singleplayer
-	// mode".
-	bool local_server;
+	std::string address; //< non-empty when joining a server
+
+	enum Mode {
+		GM_SINGLEPLAYER,
+		GM_HOST_AND_JOIN,
+		GM_JOIN,
+		GM_Undefined
+	} mode = GM_Undefined;
 
 	ELoginRegister allow_login_or_register = ELoginRegister::Any;
+};
+
+// Information provided by ClientLauncher
+// Client-only data (joining or hosting server)
+struct GameStartData : GameParams, GameClientData
+{
+	GameStartData() = default;
 
 	// "world_path" must be kept in sync!
 	WorldSpec world_spec;

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -6,6 +6,7 @@
 
 #include "irrlichttypes.h"
 #include "content/subgames.h"
+#include "log.h" // errorstream
 
 // Information provided from "main"
 // Start information for server or client
@@ -59,6 +60,15 @@ struct GameStartData : GameParams, GameClientData
 struct GameErrorData
 {
 	GameErrorData() = default;
+
+	/// Raise and log an error
+	/// @param msg Empty string means no error
+	void setError(const std::string &msg, bool reconnect = false)
+	{
+		message = msg;
+		reconnect_requested = reconnect;
+		errorstream << msg << std::endl;
+	}
 
 	// Whether the server has requested a reconnect
 	bool reconnect_requested = false;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -193,7 +193,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 		auto err = strgettext("Failed to load main menu script!");
 		RenderingEngine::showErrorMessageBox(err);
 		m_kill = 1; // break game-menu loop
-		m_data->script_data.errormessage = err;
+		m_data->script_data.message = err;
 	};
 
 
@@ -209,7 +209,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 
 	try {
 		m_script->setMainMenuData(&m_data->script_data);
-		m_data->script_data.errormessage.clear();
+		m_data->script_data.message.clear();
 
 		if (!loadMainMenuScript()) {
 			report_fatal_error();
@@ -219,7 +219,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 		run();
 	} catch (ModError &e) {
 		errorstream << "Main menu error: " << e.what() << std::endl;
-		m_data->script_data.errormessage = e.what();
+		m_data->script_data.message = e.what();
 	}
 }
 

--- a/src/gui/guiMainMenu.h
+++ b/src/gui/guiMainMenu.h
@@ -7,18 +7,10 @@
 #include "gameparams.h"
 #include <string>
 
-/// Data provided to Lua for error reporting by the main menu
-struct MainMenuDataForScript {
-
-	MainMenuDataForScript() = default;
-
-	// Whether the server has requested a reconnect
-	bool reconnect_requested = false;
-	std::string errormessage;
-};
-
 struct MainMenuData : GameClientData {
-	MainMenuData() = default;
+	MainMenuData(GameErrorData &errordata) :
+		script_data(errordata)
+	{}
 
 	// Client options
 	std::string port; // TODO combine into GameClientData
@@ -30,5 +22,5 @@ struct MainMenuData : GameClientData {
 	int selected_world = 0;
 
 	// Data to be passed to the script
-	MainMenuDataForScript script_data;
+	GameErrorData &script_data;
 };

--- a/src/gui/guiMainMenu.h
+++ b/src/gui/guiMainMenu.h
@@ -7,38 +7,28 @@
 #include "gameparams.h"
 #include <string>
 
+/// Data provided to Lua for error reporting by the main menu
 struct MainMenuDataForScript {
 
 	MainMenuDataForScript() = default;
 
 	// Whether the server has requested a reconnect
 	bool reconnect_requested = false;
-	std::string errormessage = "";
+	std::string errormessage;
 };
 
-// TODO: unify with GameStartData
-struct MainMenuData {
+struct MainMenuData : GameClientData {
+	MainMenuData() = default;
+
 	// Client options
-	std::string servername;
-	std::string serverdescription;
-	// If empty, we're hosting a server.
-	// This may or may not be in "simple singleplayer mode".
-	std::string address;
-	std::string port;
-	std::string name;
-	std::string password;
+	std::string port; // TODO combine into GameClientData
+
 	// Whether to reconnect
 	bool do_reconnect = false;
 
 	// Server options
 	int selected_world = 0;
-	// If true, we're hosting a server and *are* in "simple singleplayer mode".
-	bool simple_singleplayer_mode = false;
 
 	// Data to be passed to the script
 	MainMenuDataForScript script_data;
-
-	ELoginRegister allow_login_or_register = ELoginRegister::Any;
-
-	MainMenuData() = default;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 #endif
 	}
 
-	GameStartData game_params;
+	GameParams game_params;
 #if !CHECK_CLIENT_BUILD()
 	porting::attachOrCreateConsole();
 	game_params.is_dedicated_server = true;

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -5,16 +5,17 @@
 #include "cpp_api/s_mainmenu.h"
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
+#include "gameparams.h"
 
-void ScriptApiMainMenu::setMainMenuData(const MainMenuDataForScript *data)
+void ScriptApiMainMenu::setMainMenuData(const GameErrorData *data)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
 	lua_getglobal(L, "gamedata");
 	int gamedata_idx = lua_gettop(L);
 	lua_pushstring(L, "errormessage");
-	if (!data->errormessage.empty()) {
-		lua_pushstring(L, data->errormessage.c_str());
+	if (!data->message.empty()) {
+		lua_pushstring(L, data->message.c_str());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/script/cpp_api/s_mainmenu.h
+++ b/src/script/cpp_api/s_mainmenu.h
@@ -6,7 +6,8 @@
 
 #include "cpp_api/s_base.h"
 #include "util/string.h"
-#include "gui/guiMainMenu.h"
+
+struct GameErrorData;
 
 class ScriptApiMainMenu : virtual public ScriptApiBase {
 public:
@@ -14,7 +15,7 @@ public:
 	 * Hand over MainMenuDataForScript to lua to inform lua of the content
 	 * @param data the data
 	 */
-	void setMainMenuData(const MainMenuDataForScript *data);
+	void setMainMenuData(const GameErrorData *data);
 
 	/**
 	 * process events received from formspec

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -123,9 +123,21 @@ int ModApiMainMenu::l_start(lua_State *L)
 
 	MainMenuData *data = engine->m_data;
 
-	data->selected_world = getIntegerData(L, "selected_world",valid) -1;
-	data->simple_singleplayer_mode = getBoolData(L,"singleplayer",valid);
 	data->do_reconnect = getBoolData(L, "do_reconnect", valid);
+
+	const std::string mode = getTextData(L, "mode");
+	if (mode == "singleplayer") {
+		data->mode = GameClientData::GM_SINGLEPLAYER;
+	} else if (mode == "host") {
+		data->mode = GameClientData::GM_HOST_AND_JOIN;
+	} else if (mode == "join") {
+		data->mode = GameClientData::GM_JOIN;
+	} else if (!data->do_reconnect) {
+		// If reconnect: Re-use value on C++ side
+		luaL_error(L, "unknown start mode");
+	}
+
+	data->selected_world = getIntegerData(L, "selected_world", valid) - 1;
 	if (!data->do_reconnect) {
 		// Get rid of trailing whitespace in name (may be added by autocompletion
 		// on Android, which would then cause SERVER_ACCESSDENIED_WRONG_CHARS_IN_NAME).
@@ -143,8 +155,6 @@ int ModApiMainMenu::l_start(lua_State *L)
 		else
 			data->allow_login_or_register = ELoginRegister::Any;
 	}
-	data->serverdescription = getTextData(L,"serverdescription");
-	data->servername        = getTextData(L,"servername");
 
 	//close menu next time
 	engine->m_startgame = true;


### PR DESCRIPTION
**1st commit**

* Main menu cleanup: unused `servername` and `serverdescription`
* Replace `local_server` and `simple_singleplayer_mode` with a single `mode` (singleplayer/host/join)

**2nd commit**

* Unify the duo `error_message` & `reconnect_requested` into its own struct
* This effectively deduplicates `MainMenuDataForScript`

Also addresses a long-standing TODO:
https://github.com/luanti-org/luanti/blob/b387c8a84a7aeb41884480a53089995baec9ef71/src/gameparams.h#L27-L33

**3rd commit**

* New helper function to set and log errors

## To do

This PR is Ready for Review.

## How to test

1. Ensure that singleplayer, host by GUI and joining servers still works
```sh
# Singleplayer
./luanti --go --worldname myworld

# Join a server
./luanti --go --address 0.0.0.1 --name Test

# Host non-dedicated server
./luanti --go --name Test --worldname myworld
```
2. Do the same using the main menu
3. Start a dedicated server, join with another instance and run `//lua core.request_shutdown("hello", true, 1)` (worldedit_commands mod). Test the reconnect feature.