### PR TITLE
Migrate Docker CI to `docker/github-builder`

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,9 +1,7 @@
 ---
 name: docker_image
 
-# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-# https://docs.docker.com/build/ci/github-actions/multi-platform
-# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# https://docs.docker.com/build/ci/github-actions/github-builder
 
 on:
   push:
@@ -34,160 +32,45 @@ on:
         type: boolean
         default: true
 
-env:
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  # sadly there is no way to lowercase the string, so in some occurences we have to do it in a dedicated step
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build:
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+    uses: docker/github-builder/.github/workflows/build.yml@v1
 
     permissions:
       contents: read
       packages: write
 
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+    with:
+      output: image
+      push: ${{ github.event_name != 'pull_request' }}
+      platforms: linux/amd64,linux/arm64
+      # Keep cache disabled by default, but allow enabling it from manual dispatch.
+      cache: ${{ github.event_name == 'workflow_dispatch' && inputs.use_cache || false }}
+      # We don't sign the image because ghcr.io doesn't support OCI Referrers API yet, and the fallback relies on pushing new tags on each build
+      # https://github.com/docker/github-builder/issues/109#issuecomment-3885082486
+      # https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#backwards-compatibility
+      sign: false
+      sbom: true
+      meta-images: ghcr.io/${{ github.repository }}
+      meta-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=semver,pattern={{major}}
+      labels: |
+        org.opencontainers.image.title=Luanti
+        org.opencontainers.image.vendor=Luanti
+        org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
+        org.opencontainers.image.licenses=LGPL-2.1-only
+      annotations: |
+        org.opencontainers.image.title=Luanti
+        org.opencontainers.image.vendor=Luanti
+        org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
+        org.opencontainers.image.licenses=LGPL-2.1-only
 
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v4.0.0
-
-      # Extract metadata (tags, labels, annotations) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6.0.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=Luanti
-            org.opencontainers.image.vendor=Luanti
-            org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
-            org.opencontainers.image.licenses=LGPL-2.1-only
-          annotations: |
-            org.opencontainers.image.title=Luanti
-            org.opencontainers.image.vendor=Luanti
-            org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
-            org.opencontainers.image.licenses=LGPL-2.1-only
-      
-      # Login against the Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Get image name
-        run:
-          echo "IMAGE_NAME_LOWERCASE"="${IMAGE_NAME,,}" >> $GITHUB_ENV
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v7.1.0
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWERCASE }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          no-cache: true
-          # TODO: why is cache not reliable?
-          # no-cache: ${{ (github.event_name == 'workflow_dispatch' && !inputs.use_cache) || startsWith(github.ref, 'refs/tags/') }}
-      
-      - name: Export digest
-        if: github.event_name != 'pull_request'
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v7
-        if: github.event_name != 'pull_request'
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  push:
-    runs-on: ubuntu-24.04
-    needs: build
-    if: github.event_name != 'pull_request'
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v8
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Get image name
-        run:
-          echo "IMAGE_NAME_LOWERCASE"="${IMAGE_NAME,,}" >> $GITHUB_ENV
-      
-      # Login against the Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v4.0.0
-
-      # Extract metadata (tags, labels, annotations) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6.0.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=Luanti
-            org.opencontainers.image.vendor=Luanti
-            org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
-            org.opencontainers.image.licenses=LGPL-2.1-only
-          annotations: |
-            org.opencontainers.image.title=Luanti
-            org.opencontainers.image.vendor=Luanti
-            org.opencontainers.image.description=Luanti (formerly Minetest) is an open source voxel game-creation platform with easy modding and game creation
-            org.opencontainers.image.licenses=LGPL-2.1-only
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWERCASE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWERCASE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -45,7 +45,11 @@ jobs:
       push: ${{ github.event_name != 'pull_request' }}
       platforms: linux/amd64,linux/arm64
       # Enable cache by default, except for tag builds and when manually disabled.
-      cache: ${{ !startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || inputs.use_cache) }}
+      # cache: ${{ !startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || inputs.use_cache) }}
+      #
+      # For some reason cache doesn't work properly in this specific repository (?)
+      # TODO: figure out why
+      cache: false
       # We don't sign the image because ghcr.io doesn't support OCI Referrers API yet, and the fallback relies on pushing new tags on each build
       # https://github.com/docker/github-builder/issues/109#issuecomment-3885082486
       # https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#backwards-compatibility

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -44,8 +44,8 @@ jobs:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
       platforms: linux/amd64,linux/arm64
-      # Keep cache disabled by default, but allow enabling it from manual dispatch.
-      cache: ${{ github.event_name == 'workflow_dispatch' && inputs.use_cache || false }}
+      # Enable cache by default, except for tag builds and when manually disabled.
+      cache: ${{ !startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || inputs.use_cache) }}
       # We don't sign the image because ghcr.io doesn't support OCI Referrers API yet, and the fallback relies on pushing new tags on each build
       # https://github.com/docker/github-builder/issues/109#issuecomment-3885082486
       # https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#backwards-compatibility

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -44,6 +44,10 @@ jobs:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
       platforms: linux/amd64,linux/arm64
+      # Needed for using .git folder in Dockerfile 
+      # https://docs.docker.com/build/concepts/context/#keep-git-directory
+      build-args: |
+        BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
       # Enable cache by default, except for tag builds and when manually disabled.
       # cache: ${{ !startsWith(github.ref, 'refs/tags/') && (github.event_name != 'workflow_dispatch' || inputs.use_cache) }}
       #


### PR DESCRIPTION
Following https://github.com/luanti-org/luanti/pull/17090, migrate Docker workflow to `docker/github-builder`

Reduces the complexity of the Docker workflow by using the official Docker reusable workflow which is now the [recommended way](https://docs.docker.com/build/ci/github-actions/github-builder) of building images on GitHub, with automatic dispatching on available runners.

I waited for a release of the workflow to lowercase the image name properly (the ugly hack we used previously to handle forks is no longer needed):
https://github.com/docker/github-builder/releases/tag/v1.6.0 

GPT-5.3-Codex have been used to help with the migration.

## To do

This PR is a Ready for Review.

- [x] See if workflow work properly

## How to test

See workflow runs