### PR TITLE
Bump all used GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,27 +50,27 @@ jobs:
       # "assemblerelease" is very fast after "bundlerelease".
       run: cd android; ./gradlew assemblerelease
     - name: Save AAB artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Luanti-release.aab
         path: android/app/build/outputs/bundle/release/app-release.aab
     - name: Save armeabi artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Luanti-armeabi-v7a.apk
         path: android/app/build/outputs/apk/release/app-armeabi-v7a-release-unsigned.apk
     - name: Save arm64 artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Luanti-arm64-v8a.apk
         path: android/app/build/outputs/apk/release/app-arm64-v8a-release-unsigned.apk
     - name: Save x86 artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Luanti-x86.apk
         path: android/app/build/outputs/apk/release/app-x86-release-unsigned.apk
     - name: Save x86_64 artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: Luanti-x86_64.apk
         path: android/app/build/outputs/apk/release/app-x86_64-release-unsigned.apk

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
-    - uses: leafo/gh-actions-lua@v12
+    - uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: "5.1.5"
     - uses: leafo/gh-actions-luarocks@v6

--- a/.github/workflows/lua_api_deploy.yml
+++ b/.github/workflows/lua_api_deploy.yml
@@ -36,13 +36,13 @@ jobs:
           ./build.sh
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'public/'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -112,9 +112,11 @@ jobs:
           cd build
           rm -rf macos
           cpack -G ZIP -B macos
+          f=macos/*.zip
+          mv "$f" "${f%.zip}${osver}-${arch}.zip"
 
       - name: Upload
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
-          name: luanti-macos${{matrix.osver}}_${{matrix.arch}}
+          archive: false
           path: ./build/macos/*.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -112,8 +112,8 @@ jobs:
           cd build
           rm -rf macos
           cpack -G ZIP -B macos
-          f=macos/*.zip
-          mv "$f" "${f%.zip}${osver}-${arch}.zip"
+          set -- macos/*.zip
+          mv "$1" "${1%.zip}${osver}-${arch}.zip"
 
       - name: Upload
         uses: actions/upload-artifact@v7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,15 +78,15 @@ jobs:
            cp -v "$dest"/*.exe $GITHUB_WORKSPACE/artifact/
         if: ${{ matrix.config.nsis }}
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
-          name: "mingw${{ matrix.config.bits }}"
+          archive: false
           path: artifact/*.zip
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
-          name: "mingw${{ matrix.config.bits }}-nsis"
+          archive: false
           path: artifact/*.exe
           if-no-files-found: error
         if: ${{ matrix.config.nsis }}
@@ -145,9 +145,10 @@ jobs:
         run: |
           cpack -G ZIP -B "$env:GITHUB_WORKSPACE\Package"
           rm -r $env:GITHUB_WORKSPACE\Package\_CPack_Packages
+          Get-ChildItem "$env:GITHUB_WORKSPACE\Package\*.zip" | Rename-Item -NewName { $_.Name -replace '\.zip$', '-msvc.zip' }
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
-          name: msvc-${{ matrix.config.arch }}
+          archive: false
           path: .\Package\
           if-no-files-found: error


### PR DESCRIPTION
Bump all GitHub Actions used by the project.

It fixes a few NodeJS 20 warnings from `actions/upload-artifact`.

I used the new `archive` parameter from v7 to upload files directly without the mandatory ZIP container previously required.

LLM inline auto-completion have been used a few times.

## To do

This PR is Ready for Review.

- [x] See workflow runs

## How to test

See workflow runs.