### PR TITLE
Add texture modifier rendering itemstacks

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1039,6 +1039,24 @@ embedding a whole image, this may vary by use case.
 
 *See notes: `TEXMOD_UPSCALE`*
 
+#### `[inventorypreview:<base64>[:<W>x<H>]`
+
+Renders the inventory preview of an itemstack using the same rendering
+pipeline as the inventory GUI. The itemstack is provided as a base64-encoded
+serialized itemstack string.
+
+The optional `W` and `H` parameters specify the texture resolution in pixels.
+If omitted, the default resolution is 64x64. Values are clamped to 16-512.
+
+This texture modifier is useful for showing accurate 2D previews of
+complex nodes (stairs, slabs, nodeboxes, meshes) on entities.
+Use `core.get_item_inventory_texture` to generate a valid string.
+
+    [inventorypreview:ZGVmYXVsdDpwaWNrX3N0b25l:64x64
+    [inventorypreview:ZGVmYXVsdDpwaWNrX3N0b25l:128x128
+
+*See notes: `TEXMOD_UPSCALE`*
+
 Hardware coloring
 -----------------
 
@@ -7285,6 +7303,15 @@ Item handling
 
 * `core.inventorycube(img1, img2, img3)`
     * Returns a string for making an image of a cube (useful as an item image)
+* `core.get_item_inventory_texture(itemstring[, size])`
+    * Returns a texture string `[inventorypreview:...` that renders the
+      inventory preview of `itemstring`, using the same pipeline as the
+      inventory GUI.
+    * `itemstring`: the item name or full itemstring (e.g. `"default:stone"`)
+    * `size`: optional resolution in pixels (default: 64, clamped to 16-512)
+    * Returns `nil` if the item is unknown.
+    * Useful for showing accurate 2D previews of complex nodes (stairs,
+      slabs, nodeboxes, meshes) on entities.
 * `core.get_pointed_thing_position(pointed_thing, above)`
     * Returns the position of a `pointed_thing` or `nil` if the `pointed_thing`
       does not refer to a node or entity.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -22,7 +22,9 @@
 #include "game.h"
 #include "gettext.h"
 #include "gettime.h"
+#include "gui/drawItemStack.h"
 #include "guiscalingfilter.h"
+#include "inventory.h"
 #include "item_visuals_manager.h"
 #include "itemdef.h"
 #include "mapblock.h"
@@ -35,6 +37,7 @@
 #include "shader.h"
 #include "translation.h"
 #include "util/auth.h"
+#include "util/base64.h"
 #include "util/pointedthing.h"
 #include "util/screenshot.h"
 #include "util/serialize.h"
@@ -48,6 +51,59 @@
 #include "modchannels.h"
 #include "script/common/c_types.h" // LuaError
 #include "script/scripting_client.h"
+
+static video::IImage *generateInventoryPreviewImage(Client *client,
+		std::string_view texture_name)
+{
+	static const std::string_view prefix = "[inventorypreview:";
+	if (texture_name.compare(0, prefix.size(), prefix) != 0)
+		return nullptr;
+
+	std::string_view encoded = texture_name.substr(prefix.size());
+	if (size_t modifier_pos = encoded.find('^'); modifier_pos != std::string_view::npos)
+		encoded = encoded.substr(0, modifier_pos);
+
+	std::string itemstring = base64_decode(encoded);
+	if (itemstring.empty())
+		return nullptr;
+
+	ItemStack item;
+	item.deSerialize(itemstring, client->getItemDefManager());
+	if (item.empty())
+		return nullptr;
+
+	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
+	if (!driver || !driver->queryFeature(video::EVDF_RENDER_TO_TARGET))
+		return nullptr;
+
+	static u32 preview_counter = 0;
+	const core::dimension2du size(64, 64);
+	std::string rt_name = "__inventory_preview_" + itos(++preview_counter);
+	video::ITexture *render_target = driver->addRenderTargetTexture(
+			size, rt_name.c_str(), video::ECF_A8R8G8B8);
+	if (!render_target)
+		return nullptr;
+
+	core::rect<s32> old_viewport = driver->getViewPort();
+	driver->setRenderTarget(render_target, true, true, video::SColor(0, 0, 0, 0));
+
+	core::rect<s32> rect(0, 0, size.Width, size.Height);
+	drawItemStack(driver, nullptr, item, rect, nullptr, client, IT_ROT_NONE);
+
+	driver->setRenderTarget(nullptr, false, false);
+	driver->setViewPort(old_viewport);
+
+	void *data = render_target->lock(video::ETLM_READ_ONLY);
+	video::IImage *image = nullptr;
+	if (data) {
+		image = driver->createImageFromData(render_target->getColorFormat(),
+			render_target->getSize(), data, false);
+		render_target->unlock();
+	}
+	driver->removeTexture(render_target);
+
+	return image;
+}
 
 // SSCSM
 #include "client/mod_vfs.h"
@@ -161,6 +217,10 @@ Client::Client(
 	m_state(LC_Created),
 	m_modchannel_mgr(new ModChannelMgr())
 {
+	m_tsrc->setInventoryPreviewGenerator([this] (std::string_view texture_name) {
+		return generateInventoryPreviewImage(this, texture_name);
+	});
+
 	// Add local player
 	m_env.setLocalPlayer(new LocalPlayer(this, playername));
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -59,11 +59,24 @@ static video::IImage *generateInventoryPreviewImage(Client *client,
 	if (texture_name.compare(0, prefix.size(), prefix) != 0)
 		return nullptr;
 
-	std::string_view encoded = texture_name.substr(prefix.size());
-	if (size_t modifier_pos = encoded.find('^'); modifier_pos != std::string_view::npos)
-		encoded = encoded.substr(0, modifier_pos);
+	std::string_view rest = texture_name.substr(prefix.size());
+	if (size_t modifier_pos = rest.find('^'); modifier_pos != std::string_view::npos)
+		rest = rest.substr(0, modifier_pos);
 
-	std::string itemstring = base64_decode(encoded);
+	// Parse optional :WxH resolution suffix (must be after base64 data)
+	u32 width = 64, height = 64;
+	if (size_t colon_pos = rest.rfind(':'); colon_pos != std::string_view::npos) {
+		std::string_view size_str = rest.substr(colon_pos + 1);
+		if (size_t x_pos = size_str.find('x'); x_pos != std::string_view::npos) {
+			width = atoi(std::string(size_str.substr(0, x_pos)).c_str());
+			height = atoi(std::string(size_str.substr(x_pos + 1)).c_str());
+			width = std::clamp(width, 16u, 512u);
+			height = std::clamp(height, 16u, 512u);
+		}
+		rest = rest.substr(0, colon_pos);
+	}
+
+	std::string itemstring = base64_decode(rest);
 	if (itemstring.empty())
 		return nullptr;
 
@@ -77,7 +90,7 @@ static video::IImage *generateInventoryPreviewImage(Client *client,
 		return nullptr;
 
 	static u32 preview_counter = 0;
-	const core::dimension2du size(64, 64);
+	const core::dimension2du size(width, height);
 	std::string rt_name = "__inventory_preview_" + itos(++preview_counter);
 	video::ITexture *render_target = driver->addRenderTargetTexture(
 			size, rt_name.c_str(), video::ECF_A8R8G8B8);

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -109,6 +109,7 @@ public:
 	// Insert a source image into the cache without touching the filesystem.
 	// Shall be called from the main thread.
 	void insertSourceImage(const std::string &name, video::IImage *img);
+	void setInventoryPreviewGenerator(IWritableTextureSource::InventoryPreviewGenerator generator);
 
 	// Rebuild images and textures from the current set of source images
 	// Shall be called from the main thread.
@@ -132,6 +133,7 @@ private:
 	// Generates and caches source images
 	// This should be only accessed from the main thread
 	ImageSource m_imagesource;
+	IWritableTextureSource::InventoryPreviewGenerator m_inventory_preview_generator;
 
 	// Is the image cache enabled?
 	bool m_image_cache_enabled = false;
@@ -235,6 +237,17 @@ video::IImage *TextureSource::getOrGenerateImage(const std::string &name,
 		source_image_names.merge(copy);
 		it->second.image->grab();
 		return it->second.image;
+	}
+
+	static constexpr std::string_view inventory_preview_prefix = "[inventorypreview:";
+	if (m_inventory_preview_generator &&
+			name.compare(0, inventory_preview_prefix.size(), inventory_preview_prefix) == 0) {
+		auto *img = m_inventory_preview_generator(name);
+		if (img && m_image_cache_enabled) {
+			img->grab();
+			m_image_cache[name] = {img, {}};
+		}
+		return img;
 	}
 
 	std::set<std::string> tmp;
@@ -554,6 +567,11 @@ void TextureSource::insertSourceImage(const std::string &name, video::IImage *im
 	if (affected > 0)
 		verbosestream << "TextureSource: inserting \"" << name << "\" caused rebuild of "
 				<< affected << " textures." << std::endl;
+}
+
+void TextureSource::setInventoryPreviewGenerator(IWritableTextureSource::InventoryPreviewGenerator generator)
+{
+	m_inventory_preview_generator = std::move(generator);
 }
 
 void TextureSource::rebuildImagesAndTextures()

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -7,7 +7,9 @@
 #include "irrlichttypes.h"
 #include <SColor.h>
 #include <dimension2d.h>
+#include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace video
@@ -122,6 +124,8 @@ public:
 	IWritableTextureSource() = default;
 	virtual ~IWritableTextureSource() = default;
 
+	using InventoryPreviewGenerator = std::function<video::IImage *(std::string_view)>;
+
 	/// @brief Fulfil texture requests from other threads
 	virtual void processQueue()=0;
 
@@ -130,6 +134,12 @@ public:
 	 * Takes ownership of @p img
 	 */
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;
+
+	/**
+	 * Sets a callback for generating [inventorypreview:*] virtual textures.
+	 * The returned image must be newly allocated and will be dropped by the caller.
+	 */
+	virtual void setInventoryPreviewGenerator(InventoryPreviewGenerator generator)=0;
 
 	/**
 	 * Rebuilds all textures (in case-source images have changed)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -11,6 +11,8 @@
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_security.h"
 #include "filesys.h"
+#include "inventory.h"
+#include "itemdef.h"
 #include "log.h"
 #include "lua_api/l_internal.h"
 #include "network/connection.h"
@@ -18,6 +20,7 @@
 #include "scripting_server.h"
 #include "server.h"
 #include "serverenvironment.h"
+#include "util/base64.h"
 
 #include <algorithm>
 
@@ -680,6 +683,27 @@ int ModApiServer::l_serialize_roundtrip(lua_State *L)
 	return 1;
 }
 
+// get_item_inventory_texture(name)
+int ModApiServer::l_get_item_inventory_texture(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const char *name = luaL_checkstring(L, 1);
+	Server *server = getServer(L);
+	IItemDefManager *idef = server->getItemDefManager();
+	ItemStack item(name, 1, 0, idef);
+	const ItemDefinition &def = item.getDefinition(idef);
+
+	if (def.name == "unknown" && item.name != "unknown") { // unknown item
+		lua_pushnil(L);
+		return 1;
+	}
+
+	std::string texture = "[inventorypreview:" + base64_encode(item.getItemString());
+	lua_pushstring(L, texture.c_str());
+	return 1;
+}
+
 void ModApiServer::Initialize(lua_State *L, int top)
 {
 	API_FCT(request_shutdown);
@@ -721,6 +745,8 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(serialize_roundtrip);
 
 	API_FCT(register_mapgen_script);
+
+	API_FCT(get_item_inventory_texture);
 }
 
 void ModApiServer::InitializeAsync(lua_State *L, int top)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -683,12 +683,17 @@ int ModApiServer::l_serialize_roundtrip(lua_State *L)
 	return 1;
 }
 
-// get_item_inventory_texture(name)
+// get_item_inventory_texture(name[, size])
 int ModApiServer::l_get_item_inventory_texture(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
 	const char *name = luaL_checkstring(L, 1);
+	int size = 64;
+	if (lua_gettop(L) >= 2 && !lua_isnil(L, 2))
+		size = luaL_checkinteger(L, 2);
+	size = std::clamp(size, 16, 512);
+
 	Server *server = getServer(L);
 	IItemDefManager *idef = server->getItemDefManager();
 	ItemStack item(name, 1, 0, idef);
@@ -699,7 +704,8 @@ int ModApiServer::l_get_item_inventory_texture(lua_State *L)
 		return 1;
 	}
 
-	std::string texture = "[inventorypreview:" + base64_encode(item.getItemString());
+	std::string texture = "[inventorypreview:" + base64_encode(item.getItemString())
+		+ ":" + itos(size) + "x" + itos(size);
 	lua_pushstring(L, texture.c_str());
 	return 1;
 }

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -109,6 +109,9 @@ private:
 	// serialize_roundtrip(obj)
 	static int l_serialize_roundtrip(lua_State *L);
 
+	// get_item_inventory_texture(name)
+	static int l_get_item_inventory_texture(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);


### PR DESCRIPTION
- Goal of the PR
  Add a server-side Lua API to generate accurate inventory preview textures
  for any item, so mods like ``drawers`` can display correct 2D icons of
  complex nodes (stairs, slabs, nodeboxes, meshes) on world entities.

- How does the PR work?
  New Lua function ``core.get_item_inventory_texture(itemname)`` returns a
  virtual texture string ``[inventorypreview:<base64 itemstring>]``. On the
  client, the texture source recognises this prefix, decodes the itemstring,
  and renders the item through the same ``drawItemStack`` pipeline used by
  the inventory GUI, producing an accurate 2D snapshot.

- Does it resolve any reported issue?
  Yes, fixes https://github.com/minetest-mods/drawers/issues/60

- Does this relate to a goal in the roadmap?
  Not directly, but it improves the modding API and enables better visual
  fidelity for entity-based storage mods.

- If not a bug fix, why is this PR needed? What usecases does it solve?
  Without this API, mods can only approximate inventory icons using
  ``[inventorycube]``, which produces incorrect results for stairs, slabs,
  walls, and other non-fullblock nodes. This prevents drawer/barrel/crate
  mods from showing recognisable item previews on their entities.

- If you have used an LLM/AI to help with code or assets, you must disclose this.
  Yes -- this PR was created with assistance from opencode + GPT 5.5 xhigh

## To do

This PR is Ready for Review.

## How to test

.. code-block:: lua

  local texture = core.get_item_inventory_texture("mcl_stairs:stair_oak")
  local obj = minetest.add_entity(pos, "drawers:drawer")
  obj:set_properties({
      visual = "upright_sprite",
      textures = { texture },
  })
