### PR TITLE
GUIScrollBar: Use GUIButton instead of CGUIButton

### DIFF
--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -5,10 +5,23 @@ For conditions of distribution and use, see copyright notice in irrlicht.h
 */
 
 #include "guiScrollBar.h"
+#include "guiButton.h"
 
 GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 		core::rect<s32> rectangle, bool horizontal, ISimpleTextureSource *tsrc) :
 		CGUIScrollBar(environment, parent, id, rectangle, horizontal)
 {
-	(void)tsrc; // Yet unused.
+	// We use GUIButton instead of CGUIButton
+	if (UpButton)
+		UpButton->drop();
+	UpButton = new GUIButton(Environment, this, -1, {}, tsrc, NoClip);
+	UpButton->setSubElement(true);
+	UpButton->setTabStop(false);
+	if (DownButton)
+		DownButton->drop();
+	DownButton = new GUIButton(Environment, this, -1, {}, tsrc, NoClip);
+	DownButton->setSubElement(true);
+	DownButton->setTabStop(false);
+
+	refreshControls();
 }

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -12,13 +12,17 @@ GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s3
 		CGUIScrollBar(environment, parent, id, rectangle, horizontal)
 {
 	// We use GUIButton instead of CGUIButton
-	if (UpButton)
+	if (UpButton) {
+		UpButton->remove();
 		UpButton->drop();
+	}
 	UpButton = new GUIButton(Environment, this, -1, {}, tsrc, NoClip);
 	UpButton->setSubElement(true);
 	UpButton->setTabStop(false);
-	if (DownButton)
+	if (DownButton) {
+		DownButton->remove();
 		DownButton->drop();
+	}
 	DownButton = new GUIButton(Environment, this, -1, {}, tsrc, NoClip);
 	DownButton->setSubElement(true);
 	DownButton->setTabStop(false);


### PR DESCRIPTION
Partly fixes #17139

At first, I wanted to make the button construction a virtual function of `CGUIScrollBar`, but it gets called in the constructor so this doesn't work.

## To do

Ready for Review.

## How to test

See issue