### PR TITLE
Fix segfault on exit when dragging a scrollbar

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -78,11 +78,13 @@ ClientLauncher::~ClientLauncher()
 	delete g_gamecallback;
 	g_gamecallback = nullptr;
 
-	guiroot = nullptr;
-	guienv = nullptr;
 	assert(g_menumgr.menuCount() == 0);
 
 	delete m_rendering_engine;
+
+	// CGUIEnvironment causes calls to `deletingMenu`, which needs `guienv != nullptr`.
+	guiroot = nullptr;
+	guienv = nullptr;
 
 	// delete event receiver only after all Irrlicht stuff is gone
 	delete receiver;


### PR DESCRIPTION
`guienv` was `nullptr` in `deletingMenu` (called within `CGUIEnvironment` dtor). This solution is not perfect because there's a few code lines executed between the deallocation and these few lines.

## To do

This PR is Ready for Review.

## How to test

1. Drag a scrollbar in the main menu or in-game
2. Hit Alt+F4
3. `master`: segfault
4. PR: There must not be any segfault