### PR TITLE
Remove useless `scale` from text HUD element documentation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1998,9 +1998,6 @@ Displays an image on the HUD.
 
 Displays text on the HUD.
 
-* `scale`: Defines the bounding rectangle of the text, syntax is
-  `{ x = <number>, y = <number> }`.
-  A value such as `{ x = 100, y = 100 }` should work.
 * `text`: The text to be displayed in the HUD element.
   Supports `core.translate` (always)
   and `core.colorize` (since protocol version 44)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2014,6 +2014,9 @@ Displays text on the HUD.
       a rounded down integer value.
 * `style`: determines font style
   Bitfield with 1 = bold, 2 = italic, 4 = monospace
+* `scale`: Do not use.
+  Note: Previous versions of the documentation claimed this field sets
+  a "bounding rectangle" for the text, but it never worked.
 
 ### `statbar`
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -408,8 +408,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::dimension2d<u32> textsize = textfont->getDimension(text.c_str());
 
 				v2s32 offset(0, (e->align.Y - 1.0) * (textsize.Height / 2));
-				core::rect<s32> size(0, 0, e->scale.X * m_scale_factor,
-						text_height * e->scale.Y * m_scale_factor);
+				core::rect<s32> size(0, 0, m_scale_factor, text_height * m_scale_factor);
 				v2s32 offs(e->offset.X * m_scale_factor,
 						e->offset.Y * m_scale_factor);
 


### PR DESCRIPTION
Fixes #17029.

The `scale` field is removed from the documentation for text HUD elements because this field appears to do absolutely nothing after various tests.

Even after considering @SmallJoker’s comments in #17029, I still have not managed to find any HUD definition where `scale` changes anything. So I assume it really does nothing, as I suspected.

If the intention of `scale` was to clip text out of a bounding box, it is not working as promised, so the documentation should not claim it anymore.

This documentation can always be added back later if some *functional* bounding box feature is added.

**NEW CHANGE**: Additionally, an useless `size` variable in `hud.cpp` was removed.

## To do

This PR is ready for review.

## How to test

Read the changed files.

Test if HUD text still works.
