### PR TITLE
[Adoption] Mainmenu: Add button to copy error message

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -47,7 +47,8 @@ function ui.get_message_formspec(title, message, btn_id)
 		"set_focus[", btn_id, ";true]",
 		"box[0.5,1.2;13,5;#000]",
 		("textarea[0.5,1.2;13,5;;%s;%s]"):format(title, message),
-		"button[5,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
+		"button[2,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
+		"button[8,6.6;4,1;btn_error_copy;" .. fgettext("Copy to clipboard") .. "]"
 	})
 end
 
@@ -180,6 +181,9 @@ core.button_handler = function(fields)
 		gamedata.errormessage = nil
 		gamedata.reconnect_requested = false
 		ui.update()
+		return
+	elseif fields["btn_error_copy"] then
+		core.copy_to_clipboard(gamedata.errormessage)
 		return
 	end
 

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -186,7 +186,7 @@ core.button_handler = function(fields)
 		core.copy_to_clipboard(gamedata.errormessage)
 		gamedata.errormessage = nil
 		gamedata.reconnect_requested = false
-        ui.update()
+		ui.update()
 		return
 	end
 

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -184,9 +184,6 @@ core.button_handler = function(fields)
 		return
 	elseif fields["btn_error_copy"] then
 		core.copy_to_clipboard(gamedata.errormessage)
-		gamedata.errormessage = nil
-		gamedata.reconnect_requested = false
-		ui.update()
 		return
 	end
 

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -184,6 +184,9 @@ core.button_handler = function(fields)
 		return
 	elseif fields["btn_error_copy"] then
 		core.copy_to_clipboard(gamedata.errormessage)
+		gamedata.errormessage = nil
+		gamedata.reconnect_requested = false
+        ui.update()
 		return
 	end
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -443,6 +443,15 @@ Helpers
   [RFC 3986, section 2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 
 
+Clipboard
+-----
+
+* `core.copy_to_clipboard(text)`
+  * Copies text to the clipboard.
+* `core.get_text_from_clipboard()`
+  * Returns text from clipboard.
+
+
 Async
 -----
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -448,8 +448,6 @@ Clipboard
 
 * `core.copy_to_clipboard(text)`
   * Copies text to the clipboard.
-* `core.get_text_from_clipboard()`
-  * Returns text from clipboard.
 
 
 Async

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1120,9 +1120,9 @@ int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 	env->getOSOperator()->copyToClipboard(text);
 
 	if (engine->m_status_text) {
-        engine->m_status_text->setMainMenuStyle();
-        engine->m_status_text->showStatusText(utf8_to_wide("Copied to clipboard!"));
-    }
+		engine->m_status_text->setMainMenuStyle();
+		engine->m_status_text->showStatusText(utf8_to_wide("Copied to clipboard!"));
+	}
 
 	return 0;
 }

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1121,7 +1121,7 @@ int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 
 	if (engine->m_status_text) {
 		engine->m_status_text->setMainMenuStyle();
-		engine->m_status_text->showStatusText(utf8_to_wide("Copied to clipboard!"));
+		engine->m_status_text->showStatusText(wstrgettext("Copied to clipboard!"));
 	}
 
 	return 0;

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1111,22 +1111,22 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 {
-    GUIEngine* engine = getGuiEngine(L);
-    sanity_check(engine != NULL);
+	GUIEngine* engine = getGuiEngine(L);
+	sanity_check(engine != NULL);
 
-    const char *text = luaL_checkstring(L, 1);
+	const char *text = luaL_checkstring(L, 1);
 
 	auto *env = engine->m_rendering_engine->get_gui_env();
-    env->getOSOperator()->copyToClipboard(text);
+	env->getOSOperator()->copyToClipboard(text);
 
-    return 0;
+	return 0;
 }
 
 /******************************************************************************/
 int ModApiMainMenu::l_get_text_from_clipboard(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
-    sanity_check(engine != NULL);
+	sanity_check(engine != NULL);
 
 	auto *env = engine->m_rendering_engine->get_gui_env();
 	auto text = env->getOSOperator()->getTextFromClipboard();

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1109,6 +1109,33 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
+{
+    GUIEngine* engine = getGuiEngine(L);
+    sanity_check(engine != NULL);
+
+    const char *text = luaL_checkstring(L, 1);
+
+	auto *env = engine->m_rendering_engine->get_gui_env();
+    env->getOSOperator()->copyToClipboard(text);
+
+    return 0;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_get_text_from_clipboard(lua_State *L)
+{
+	GUIEngine* engine = getGuiEngine(L);
+    sanity_check(engine != NULL);
+
+	auto *env = engine->m_rendering_engine->get_gui_env();
+	auto text = env->getOSOperator()->getTextFromClipboard();
+
+	lua_pushstring(L, text ? text : "");
+	return 1;
+}
+
+/******************************************************************************/
 void ModApiMainMenu::Initialize(lua_State *L, int top)
 {
 	API_FCT(update_formspec);
@@ -1163,6 +1190,8 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(open_dir);
 	API_FCT(share_file);
 	API_FCT(do_async_callback);
+	API_FCT(copy_to_clipboard);
+	API_FCT(get_text_from_clipboard);
 
 	lua_pushboolean(L, g_first_run);
 	lua_setfield(L, top, "is_first_run");

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1128,19 +1128,6 @@ int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_get_text_from_clipboard(lua_State *L)
-{
-	GUIEngine* engine = getGuiEngine(L);
-	sanity_check(engine != NULL);
-
-	auto *env = engine->m_rendering_engine->get_gui_env();
-	auto text = env->getOSOperator()->getTextFromClipboard();
-
-	lua_pushstring(L, text ? text : "");
-	return 1;
-}
-
-/******************************************************************************/
 void ModApiMainMenu::Initialize(lua_State *L, int top)
 {
 	API_FCT(update_formspec);
@@ -1196,7 +1183,6 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(share_file);
 	API_FCT(do_async_callback);
 	API_FCT(copy_to_clipboard);
-	API_FCT(get_text_from_clipboard);
 
 	lua_pushboolean(L, g_first_run);
 	lua_setfield(L, top, "is_first_run");

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1119,6 +1119,11 @@ int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 	auto *env = engine->m_rendering_engine->get_gui_env();
 	env->getOSOperator()->copyToClipboard(text);
 
+	if (engine->m_status_text) {
+        engine->m_status_text->setMainMenuStyle();
+        engine->m_status_text->showStatusText(utf8_to_wide("Copied to clipboard!"));
+    }
+
 	return 0;
 }
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1111,8 +1111,8 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_copy_to_clipboard(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
-	sanity_check(engine != NULL);
+	GUIEngine *engine = getGuiEngine(L);
+	sanity_check(engine != nullptr);
 
 	const char *text = luaL_checkstring(L, 1);
 

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -151,6 +151,11 @@ private:
 	// async
 	static int l_do_async_callback(lua_State *L);
 
+	// clipboard
+	static int l_copy_to_clipboard(lua_State *L);
+
+	static int l_get_text_from_clipboard(lua_State *L);
+
 public:
 
 	/**

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -154,8 +154,6 @@ private:
 	// clipboard
 	static int l_copy_to_clipboard(lua_State *L);
 
-	static int l_get_text_from_clipboard(lua_State *L);
-
 public:
 
 	/**


### PR DESCRIPTION
Adoption of #17018 

Adds a button to the `ui.get_message_formspec()` to copy the error(s) to the system clipboard.
Kinda aligns with the roadmap [`doc/direction.md#23-ui-improvements`](https://github.com/luanti-org/luanti/blob/master/doc/direction.md#23-ui-improvements)

No AI was used.

## To do

This PR is Ready for Review.

## How to test

See testing instructions in aforementioned PR.

<img width="603" height="354" alt="Screenshot From 2026-05-06 13-20-03" src="https://github.com/user-attachments/assets/13dc148b-6d9b-4abe-bf3b-18ad087ba347" />

