### PR TITLE
Formspec: drop held item even when a child element has focus

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4071,9 +4071,16 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode)
 
 bool GUIFormSpecMenu::remapClickOutside(const SEvent &event)
 {
-	// Don't remap a click outside the formspec to ESC when holding an item.
-	if (m_selected_item)
+	if (m_selected_item) {
+		// Click outside the formspec while holding an item: deliver the event
+		// directly to OnEvent so the drop handler runs even when a focused
+		// child element (e.g. a button) would otherwise consume LMOUSE events.
+		if (event.EventType == EET_MOUSE_INPUT_EVENT &&
+				!getAbsoluteClippingRect().isPointInside(
+						v2s32(event.MouseInput.X, event.MouseInput.Y)))
+			return OnEvent(event);
 		return false;
+	}
 	return GUIModalMenu::remapClickOutside(event);
 }
 


### PR DESCRIPTION
PR #17064 (issue #16952) made remapClickOutside() back off when an item is held so the normal event dispatch could route the click to the drop handler. That works when nothing inside the formspec has keyboard focus, but if a child element (e.g. a button) is focused, it consumes the LMOUSE event before the drop handler in OnEvent() runs, so left-clicking outside the formspec while holding an item still does nothing.

When the click falls outside the formspec rect, deliver the event directly to OnEvent() so the drop path runs regardless of which child element currently has focus.

Tested by @OgelGames - https://github.com/luanti-org/luanti/issues/16952#issuecomment-4376822005

_(AI disclosure: Claude Code was used)_