### PR TITLE
Add area clamping to the voxel area iterator.

### DIFF
--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -101,12 +101,8 @@ local function clamp_range(query_min, query_max, target_min, target_max)
 		return -1, -2
 	end
 	-- Otherwise, clamp the requested range to the target range.
-	if query_min < target_min then
-		query_min = target_min
-	end
-	if query_max > target_max then
-		query_max = target_max
-	end
+	query_min = math.max(query_min, target_min)
+	query_max = math.min(query_max, target_max)
 	return query_min, query_max
 end
 

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -108,8 +108,8 @@ end
 
 function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
 	minx, maxx = clamp_range(minx, maxx, self.MinEdge.x, self.MaxEdge.x)
-	miny, maxy = clamp_range(miny, maxy, self.MinEdge.x, self.MaxEdge.x)
-	minz, maxz = clamp_range(minz, maxz, self.MinEdge.x, self.MaxEdge.x)
+	miny, maxy = clamp_range(miny, maxy, self.MinEdge.y, self.MaxEdge.y)
+	minz, maxz = clamp_range(minz, maxz, self.MinEdge.z, self.MaxEdge.z)
 
 	-- if the range is invalid or empty return an empty iterator
 	if minx > maxx or miny > maxy or minz > maxz then

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -100,6 +100,7 @@ local function clamp_range(query_min, query_max, target_min, target_max)
 		-- Use fixed values for simplicity.
 		return -1, -2
 	end
+
 	-- Otherwise, clamp the requested range to the target range.
 	query_min = math.max(query_min, target_min)
 	query_max = math.min(query_max, target_max)
@@ -111,10 +112,10 @@ function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
 	miny, maxy = clamp_range(miny, maxy, self.MinEdge.y, self.MaxEdge.y)
 	minz, maxz = clamp_range(minz, maxz, self.MinEdge.z, self.MaxEdge.z)
 
-	-- if the range is invalid or empty return an empty iterator
+	-- If the range is invalid or empty, return an empty iterator.
 	if minx > maxx or miny > maxy or minz > maxz then
 		return function()
-			-- explicit nil for clear iterator protocol
+			-- An explicit nil for clear iterator protocol.
 			return nil
 		end
 	end

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -98,7 +98,7 @@ local function clamp_range(query_min, query_max, target_min, target_max)
 	--     or doesn't intersect the target range.
 	if query_min > query_max or query_max < target_min or query_min > target_max then
 		-- Use fixed values for simplicity.
-		return {-1, -2}
+		return -1, -2
 	end
 	-- Otherwise, clamp the requested range to the target range.
 	if query_min < target_min then
@@ -107,7 +107,7 @@ local function clamp_range(query_min, query_max, target_min, target_max)
 	if query_max > target_max then
 		query_max = target_max
 	end
-	return {query_min, query_max}
+	return query_min, query_max
 end
 
 function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -93,7 +93,36 @@ function VoxelArea:containsi(i)
 	return (i >= 1) and (i <= self:getVolume())
 end
 
+local function clamp_range(query_min, query_max, target_min, target_max)
+	-- Return an invalid range if the requested range is empty,
+	--     or doesn't intersect the target range.
+	if query_min > query_max or query_max < target_min or query_min > target_max then
+		-- Use fixed values for simplicity.
+		return {-1, -2}
+	end
+	-- Otherwise, clamp the requested range to the target range.
+	if query_min < target_min then
+		query_min = target_min
+	end
+	if query_max > target_max then
+		query_max = target_max
+	end
+	return {query_min, query_max}
+end
+
 function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
+	minx, maxx = clamp_range(minx, maxx, self.MinEdge.x, self.MaxEdge.x)
+	miny, maxy = clamp_range(miny, maxy, self.MinEdge.x, self.MaxEdge.x)
+	minz, maxz = clamp_range(minz, maxz, self.MinEdge.x, self.MaxEdge.x)
+
+	-- if the range is invalid or empty return an empty iterator
+	if minx > maxx or miny > maxy or minz > maxz then
+		return function()
+			-- explicit nil for clear iterator protocol
+			return nil
+		end
+	end
+
 	local i = self:index(minx, miny, minz) - 1
 	local xrange = maxx - minx + 1
 	local nextaction = i + 1 + xrange

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5614,6 +5614,8 @@ All numbers used in these methods must be integers.
   indices.
     * from (`minx`,`miny`,`minz`) to (`maxx`,`maxy`,`maxz`) in the order of
       `[z [y [x]]]`.
+    * empty iterator if (`minx`, `miny`, `minz`) to (`maxx`, `maxy`, `maxz`) is outside of the VoxelArea
+      * Since version 5.16.0
 * `iterp(minp, maxp)`: same as above, except takes a vector
 
 ### Y stride and z stride of a flat array

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -202,6 +202,7 @@ dofile(modpath .. "/load_time.lua")
 dofile(modpath .. "/on_shutdown.lua")
 dofile(modpath .. "/color.lua")
 dofile(modpath .. "/vector2.lua")
+dofile(modpath .. "/voxelarea.lua")
 
 --------------
 

--- a/games/devtest/mods/unittests/voxelarea.lua
+++ b/games/devtest/mods/unittests/voxelarea.lua
@@ -1,0 +1,75 @@
+
+local function test_voxelarea_invalid_area_example(player, pos)
+	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
+	local va = VoxelArea(p1, p2)
+	local vmax = va:getVolume() -- this is 4096
+	for i in va:iter(0, 16, 0, 15, 0, 15) do
+		if i < 0 or i > vmax then
+			error(("index %d is invalid"):format(i))
+		end
+	end
+end
+
+unittests.register("test_voxelarea_invalid_area_example", test_voxelarea_invalid_area_example, {})
+
+-- Compare two (functions returning) iterators for equality.
+-- We need to use functions returning iterators because
+--		otherwise changing the iterator implementation
+--		could change which of the 6 parameters are nil,
+--		and how they line up.
+local function compare_iterators(iterable_a, iterable_b)
+	local fun_a, state_a, control_a = iterable_a()
+	local fun_b, state_b, control_b = iterable_b()
+	while true do
+		control_a = fun_a(state_a, control_a)
+		control_b = fun_b(state_b, control_b)
+		if control_a == nil or control_b == nil then
+			-- At least one iterator has ended.
+			-- If they did not both end, then they differ in length.
+			return control_a == control_b
+		elseif control_a ~= control_b then
+			-- The iterator elements differ.
+			return false
+		end
+	end
+end
+
+-- These are equivalent:
+--		`va:iter(0, 10, 0, 15, 20, 15)`
+--		`va:iter(0, 16, 0, 15, 20, 15)`
+local function test_voxelarea_equivalence_example(player, pos)
+	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
+	local va = VoxelArea(p1, p2)
+
+	local comparison_success = compare_iterators(
+			function() va:iter(0, 10, 0, 15, 20, 15) end,
+			function() va:iter(0, 16, 0, 15, 20, 15) end
+		)
+	if not comparison_success then
+		error("Unexpected mismatch between VoxelArea iterators!")
+	end
+
+end
+unittests.register("test_voxelarea_equivalence_example", test_voxelarea_equivalence_example, {})
+
+local function empty_iterator()
+	return function()
+		return nil
+	end
+end
+
+-- `va:iter(0, 10, 0, 15, 12, 15)` produces no results.
+local function test_voxelarea_empty_example(player, pos)
+	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
+	local va = VoxelArea(p1, p2)
+
+	local comparison_success = compare_iterators(
+			function() va:iter(0, 10, 0, 15, 12, 15) end,
+			empty_iterator
+		)
+	if not comparison_success then
+		error("supposedly empty VoxelArea iterator was not empty")
+	end
+end
+
+unittests.register("test_voxelarea_empty_example", test_voxelarea_empty_example, {})

--- a/games/devtest/mods/unittests/voxelarea.lua
+++ b/games/devtest/mods/unittests/voxelarea.lua
@@ -42,8 +42,8 @@ local function test_voxelarea_equivalence_example(player, pos)
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			function() va:iter(0, 10, 0, 15, 20, 15) end,
-			function() va:iter(0, 16, 0, 15, 20, 15) end
+			function() return va:iter(0, 10, 0, 15, 20, 15) end,
+			function() return va:iter(0, 16, 0, 15, 20, 15) end
 		)
 	if not comparison_success then
 		error("Unexpected mismatch between VoxelArea iterators!")
@@ -64,7 +64,7 @@ local function test_voxelarea_empty_example(player, pos)
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			function() va:iter(0, 10, 0, 15, 12, 15) end,
+			function() return va:iter(0, 10, 0, 15, 12, 15) end,
 			empty_iterator
 		)
 	if not comparison_success then

--- a/games/devtest/mods/unittests/voxelarea.lua
+++ b/games/devtest/mods/unittests/voxelarea.lua
@@ -13,11 +13,13 @@ end
 
 unittests.register("test_voxelarea_invalid_area_iteration", test_voxelarea_invalid_area_iteration, {})
 
+-- Pack 3 items into a closure.
+-- Used to pack an iterator for `compare_iterators()`.
 local function pack_triple(a, b, c)
 	return function() return a, b, c end
 end
 
--- Compare two table-packed iterators for equality.
+-- Compare two closure-packed iterators for equality.
 local function compare_iterators(iterable_a, iterable_b)
 	local fun_a, state_a, control_a = iterable_a()
 	local fun_b, state_b, control_b = iterable_b()

--- a/games/devtest/mods/unittests/voxelarea.lua
+++ b/games/devtest/mods/unittests/voxelarea.lua
@@ -1,25 +1,22 @@
 
-local function test_voxelarea_invalid_area_example(player, pos)
+local function test_voxelarea_invalid_area_iteration()
 	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
 	local va = VoxelArea(p1, p2)
-	local vmax = va:getVolume() -- this is 4096
+	-- This is 4096.
+	local vmax = va:getVolume()
 	for i in va:iter(0, 16, 0, 15, 0, 15) do
 		if i < 0 or i > vmax then
-			error(("index %d is invalid"):format(i))
+			error(("VoxelArea index %d is invalid."):format(i))
 		end
 	end
 end
 
-unittests.register("test_voxelarea_invalid_area_example", test_voxelarea_invalid_area_example, {})
+unittests.register("test_voxelarea_invalid_area_iteration", test_voxelarea_invalid_area_iteration, {})
 
--- Compare two (functions returning) iterators for equality.
--- We need to use functions returning iterators because
---		otherwise changing the iterator implementation
---		could change which of the 6 parameters are nil,
---		and how they line up.
+-- Compare two table-packed iterators for equality.
 local function compare_iterators(iterable_a, iterable_b)
-	local fun_a, state_a, control_a = iterable_a()
-	local fun_b, state_b, control_b = iterable_b()
+	local fun_a, state_a, control_a = table.unpack(iterable_a)
+	local fun_b, state_b, control_b = table.unpack(iterable_b)
 	while true do
 		control_a = fun_a(state_a, control_a)
 		control_b = fun_b(state_b, control_b)
@@ -37,39 +34,31 @@ end
 -- These are equivalent:
 --		`va:iter(0, 10, 0, 15, 20, 15)`
 --		`va:iter(0, 16, 0, 15, 20, 15)`
-local function test_voxelarea_equivalence_example(player, pos)
+local function test_voxelarea_clipped_iterator_equivalence()
 	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			function() return va:iter(0, 10, 0, 15, 20, 15) end,
-			function() return va:iter(0, 16, 0, 15, 20, 15) end
+			table.pack(va:iter(0, 10, 0, 15, 20, 15)),
+			table.pack(va:iter(0, 16, 0, 15, 20, 15))
 		)
 	if not comparison_success then
-		error("Unexpected mismatch between VoxelArea iterators!")
-	end
-
-end
-unittests.register("test_voxelarea_equivalence_example", test_voxelarea_equivalence_example, {})
-
-local function empty_iterator()
-	return function()
-		return nil
+		error("Unexpected mismatch between clipped and non-clipped VoxelArea iterators!")
 	end
 end
+unittests.register("test_voxelarea_clipped_iterator_equivalence", test_voxelarea_clipped_iterator_equivalence, {})
 
 -- `va:iter(0, 10, 0, 15, 12, 15)` produces no results.
-local function test_voxelarea_empty_example(player, pos)
+local function test_voxelarea_empty_out_of_bounds_iterator()
 	local p1, p2 = vector.new(0,16,0), vector.new(15,31,15)
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			function() return va:iter(0, 10, 0, 15, 12, 15) end,
-			empty_iterator
+			table.pack(va:iter(0, 10, 0, 15, 12, 15)),
+			table.pack(function() return nil end)
 		)
 	if not comparison_success then
-		error("supposedly empty VoxelArea iterator was not empty")
+		error("Out-of-bounds VoxelArea iterator was not empty.")
 	end
 end
-
-unittests.register("test_voxelarea_empty_example", test_voxelarea_empty_example, {})
+unittests.register("test_voxelarea_empty_out_of_bounds_iterator", test_voxelarea_empty_out_of_bounds_iterator, {})

--- a/games/devtest/mods/unittests/voxelarea.lua
+++ b/games/devtest/mods/unittests/voxelarea.lua
@@ -13,10 +13,14 @@ end
 
 unittests.register("test_voxelarea_invalid_area_iteration", test_voxelarea_invalid_area_iteration, {})
 
+local function pack_triple(a, b, c)
+	return function() return a, b, c end
+end
+
 -- Compare two table-packed iterators for equality.
 local function compare_iterators(iterable_a, iterable_b)
-	local fun_a, state_a, control_a = table.unpack(iterable_a)
-	local fun_b, state_b, control_b = table.unpack(iterable_b)
+	local fun_a, state_a, control_a = iterable_a()
+	local fun_b, state_b, control_b = iterable_b()
 	while true do
 		control_a = fun_a(state_a, control_a)
 		control_b = fun_b(state_b, control_b)
@@ -39,8 +43,8 @@ local function test_voxelarea_clipped_iterator_equivalence()
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			table.pack(va:iter(0, 10, 0, 15, 20, 15)),
-			table.pack(va:iter(0, 16, 0, 15, 20, 15))
+			pack_triple(va:iter(0, 10, 0, 15, 20, 15)),
+			pack_triple(va:iter(0, 16, 0, 15, 20, 15))
 		)
 	if not comparison_success then
 		error("Unexpected mismatch between clipped and non-clipped VoxelArea iterators!")
@@ -54,8 +58,8 @@ local function test_voxelarea_empty_out_of_bounds_iterator()
 	local va = VoxelArea(p1, p2)
 
 	local comparison_success = compare_iterators(
-			table.pack(va:iter(0, 10, 0, 15, 12, 15)),
-			table.pack(function() return nil end)
+			pack_triple(va:iter(0, 10, 0, 15, 12, 15)),
+			pack_triple(function() return nil end)
 		)
 	if not comparison_success then
 		error("Out-of-bounds VoxelArea iterator was not empty.")


### PR DESCRIPTION
The goal of this PR is to address #17065.

It works by adding a private range-clamping function in voxelarea.lua, calling that logic in the VoxelArea iterator function, and returning an empty iterator if the requested box is outside the VoxelArea or empty.

This resolves #17065.

An alternative resolution can be found in my other PR about this issue, [Add bounds and isinteger checks to VoxelArea iteration](https://github.com/luanti-org/luanti/pull/17163).

This PR is Ready for Review:

- [x] Document the API change
- [x] Add tests for out-of-bounds VoxelArea iteration

## How to test

Run the devtest game and its unittest mod; I don't know how yet, but there's a Github Action for it.
Alternatively, use the Lua API to test it as written in the issue.
