### PR TITLE
Add bounds and isinteger checks to VoxelArea iteration

### DIFF
--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -94,7 +94,7 @@ function VoxelArea:containsi(i)
 end
 
 local function assert_integral(num, var, which)
-	if math.floor(num) != num then
+	if math.floor(num) ~= num then
 		error((which .. var .. " %f is not an integer"):format(num))
 	end
 end

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -108,7 +108,10 @@ local function check_range(query_min, query_max, target_min, target_max, var)
 				.. var .. "' range is reversed or empty.")
 	elseif query_min > target_max or query_max < target_min then
 		error("Requested VoxelArea iteration axis '"
-				.. var .. "' range is outside the VoxelArea.")
+				.. var .. "' range is fully outside the VoxelArea.")
+	elseif query_min < target_min or query_max > target_max then
+		error("Requested Voxelarea iteration axis '"
+				.. var .. "' range is partly outside the VoxelArea.")
 	end
 end
 

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -113,9 +113,9 @@ local function check_range(query_min, query_max, target_min, target_max, var)
 end
 
 function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
-	check_range(minx, maxx, self.MinEdge.x, self.MaxEdge.x)
-	check_range(miny, maxy, self.MinEdge.y, self.MaxEdge.y)
-	check_range(minz, maxz, self.MinEdge.z, self.MaxEdge.z)
+	check_range(minx, maxx, self.MinEdge.x, self.MaxEdge.x, "x")
+	check_range(miny, maxy, self.MinEdge.y, self.MaxEdge.y, "y")
+	check_range(minz, maxz, self.MinEdge.z, self.MaxEdge.z, "z")
 
 	local i = self:index(minx, miny, minz) - 1
 	local xrange = maxx - minx + 1

--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -93,7 +93,30 @@ function VoxelArea:containsi(i)
 	return (i >= 1) and (i <= self:getVolume())
 end
 
+local function assert_integral(num, var, which)
+	if math.floor(num) != num then
+		error((which .. var .. " %f is not an integer"):format(num))
+	end
+end
+
+local function check_range(query_min, query_max, target_min, target_max, var)
+	assert_integral(query_min, var, "min")
+	assert_integral(query_max, var, "max")
+
+	if query_min > query_max then
+		error("Requested VoxelArea iteration axis '"
+				.. var .. "' range is reversed or empty.")
+	elseif query_min > target_max or query_max < target_min then
+		error("Requested VoxelArea iteration axis '"
+				.. var .. "' range is outside the VoxelArea.")
+	end
+end
+
 function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
+	check_range(minx, maxx, self.MinEdge.x, self.MaxEdge.x)
+	check_range(miny, maxy, self.MinEdge.y, self.MaxEdge.y)
+	check_range(minz, maxz, self.MinEdge.z, self.MaxEdge.z)
+
 	local i = self:index(minx, miny, minz) - 1
 	local xrange = maxx - minx + 1
 	local nextaction = i + 1 + xrange

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5614,6 +5614,8 @@ All numbers used in these methods must be integers.
   indices.
     * from (`minx`,`miny`,`minz`) to (`maxx`,`maxy`,`maxz`) in the order of
       `[z [y [x]]]`.
+    * errors if the arguments are not integers
+    * errors if (`minx`, `miny`, `minz`) to (`maxx`, `maxy`, `maxz`) is not completely inside the VoxelArea.
 * `iterp(minp, maxp)`: same as above, except takes a vector
 
 ### Y stride and z stride of a flat array


### PR DESCRIPTION
The goal of this PR is to address #17065, in the way suggested in [this comment](https://github.com/luanti-org/luanti/issues/17065#issuecomment-4410432143).

This PR works by adding integer argument and is-in-bounds checks to VoxelArea:iter that run before the iterator setup.

This PR will resolve #17065.

An alternative resolution is my other PR, [Add area clamping to the voxel area iterator](https://github.com/luanti-org/luanti/pull/17159) that returns an empty iterator when the requested area is fully out of bounds, and iterates the in-bounds section of the request otherwise.

## To do

This PR is a Work in Progress.

- [x] Document the (sort-of new) requirements in the Lua API documentation
- [ ] Write tests for the new iteration checks

## How to test

Right now, run the devtest game's unittests mod; the raycast test might catch regressions.
