### PR TITLE
Add `hideable` HUD element field

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -55,7 +55,7 @@ core.features = {
 	item_inventory_image_animation = true,
 	get_modnames_load_order = true,
 	set_camera_resettable = true,
-	hud_unhideable_field = true,
+	hud_hideable_field = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -55,6 +55,7 @@ core.features = {
 	item_inventory_image_animation = true,
 	get_modnames_load_order = true,
 	set_camera_resettable = true,
+	hud_unhideable_field = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1977,7 +1977,7 @@ Default 0. By convention, the following values are recommended:
 If your HUD element doesn't fit into any category, pick an integer
 between the suggested values.
 
-If the `unhideable` field is set, players can not hide the element.
+If the `hideable` field is set to `false`, players can not hide the element.
 It can be used to for example obstruct the view of players.
 Does not take effect for clients older than version 5.17
 
@@ -6150,8 +6150,8 @@ Utilities
       get_modnames_load_order = true,
       -- `ObjectRef:set_camera()` accepts `nil` to indicate reset (5.16.0)
       set_camera_resettable = true,
-      -- The HUD element field `unhideable` exists (5.17.0)
-      hud_unhideable_field = true,
+      -- The HUD element field `hideable` exists (5.17.0)
+      hud_hideable_field = true,
   }
   ```
 
@@ -11921,7 +11921,7 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
 
     style = 0, -- integer [u32]
 
-    unhideable = false, -- bool
+    hideable = true, -- bool
 }
 ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1977,6 +1977,10 @@ Default 0. By convention, the following values are recommended:
 If your HUD element doesn't fit into any category, pick an integer
 between the suggested values.
 
+If the `unhideable` field is set, players can not hide the element.
+It can be used to for example obstruct the view of players.
+Does not take effect for clients older than version 5.17
+
 Below are the specific uses for fields in each type; fields not listed for that
 type are ignored.
 
@@ -6146,6 +6150,8 @@ Utilities
       get_modnames_load_order = true,
       -- `ObjectRef:set_camera()` accepts `nil` to indicate reset (5.16.0)
       set_camera_resettable = true,
+      -- The HUD element field `unhideable` exists (5.17.0)
+      hud_unhideable_field = true,
   }
   ```
 
@@ -11914,6 +11920,8 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
     -- Z index: lower z-index HUDs are displayed behind higher z-index HUDs
 
     style = 0, -- integer [u32]
+
+    unhideable = false, -- bool
 }
 ```
 

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -423,20 +423,13 @@ core.register_chatcommand("hudtoggleunhideable", {
 			return false, "No player."
 		end
 
-		if player_hud_all_unhideable[name] then
-			for id, _ in pairs(player:hud_get_all()) do
-				player:hud_change(id, "unhideable", false)
-			end
-			player_hud_all_unhideable[name] = false
-			return true, "All HUD elements are hideable now."
-		else
-			for id, _ in pairs(player:hud_get_all()) do
-				player:hud_change(id, "unhideable", true)
-			end
-			player_hud_all_unhideable[name] = true
-			return true, "All HUD elements are unhideable now."
+		-- Toggle un/hideable
+		local to_set = not player_hud_all_unhideable[name]
+		for id, _ in pairs(player:hud_get_all()) do
+			player:hud_change(id, "unhideable", to_set)
 		end
-	end
+		player_hud_all_unhideable[name] = to_set
+		return true, "All HUD elements are " ... (to_set and "unhideable" or "hideable") .. " now."
 })
 
 

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -377,6 +377,70 @@ core.register_chatcommand("hudinventories", {
 	end
 })
 
+-- Unhideable elements
+
+local hud_unhideable_def = {
+	type = "image",
+	position = {x=0.5, y=0.5},
+	scale = {x = 100, y = 100},
+	text = "smoke_puff.png",
+	unhideable = true,
+}
+
+local player_hud_unhideable_element = {}
+core.register_chatcommand("hudunhideable", {
+	description = "Adds an unhideable HUD image element",
+	params = "[ add | remove ]",
+	func = function(name, params)
+		local player = core.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+
+		if params == "remove" then
+			if player_hud_unhideable_element[name] then
+				player:hud_remove(player_hud_unhideable_element[name])
+			end
+			return true, "HUD unhideable image removed."
+		end
+
+		-- params == "add" or default
+		if not player_hud_unhideable_element[name] then
+			player_hud_unhideable_element[name] = player:hud_add(hud_unhideable_def)
+			assert(player:hud_get(player_hud_unhideable_element[name]).unhideable)
+			return true, "HUD unhideable image added."
+		end
+		return true, "HUD unhideable image already present."
+	end
+})
+
+local player_hud_all_unhideable = {}
+core.register_chatcommand("hudtoggleunhideable", {
+	description = "Makes all HUD elements unhideable",
+	func = function(name, params)
+		local player = core.get_player_by_name(name)
+		if not player then
+			return false, "No player."
+		end
+
+		if player_hud_all_unhideable[name] then
+			for id, _ in pairs(player:hud_get_all()) do
+				player:hud_change(id, "unhideable", false)
+			end
+			player_hud_all_unhideable[name] = false
+			return true, "All HUD elements are hideable now."
+		else
+			for id, _ in pairs(player:hud_get_all()) do
+				player:hud_change(id, "unhideable", true)
+			end
+			player_hud_all_unhideable[name] = true
+			return true, "All HUD elements are unhideable now."
+		end
+	end
+})
+
+
+
 
 core.register_on_leaveplayer(function(player)
 	local playername = player:get_player_name()
@@ -384,6 +448,8 @@ core.register_on_leaveplayer(function(player)
 	player_waypoints[playername] = nil
 	player_hud_hotbars[playername] = nil
 	player_hud_inventories[playername] = nil
+	player_hud_unhideable_element[playername] = nil
+	player_hud_all_unhideable[playername] = nil
 end)
 
 core.register_chatcommand("hudprint", {

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -417,7 +417,7 @@ core.register_chatcommand("hudunhideable", {
 local player_hud_all_unhideable = {}
 core.register_chatcommand("hudtoggleunhideable", {
 	description = "Makes all HUD elements unhideable",
-	func = function(name, params)
+	func = function(name)
 		local player = core.get_player_by_name(name)
 		if not player then
 			return false, "No player."
@@ -429,7 +429,8 @@ core.register_chatcommand("hudtoggleunhideable", {
 			player:hud_change(id, "unhideable", to_set)
 		end
 		player_hud_all_unhideable[name] = to_set
-		return true, "All HUD elements are " ... (to_set and "unhideable" or "hideable") .. " now."
+		return true, "All HUD elements are " .. (to_set and "unhideable" or "hideable") .. " now."
+	end
 })
 
 

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -400,6 +400,7 @@ core.register_chatcommand("hudunhideable", {
 		if params == "remove" then
 			if player_hud_unhideable_element[name] then
 				player:hud_remove(player_hud_unhideable_element[name])
+				player_hud_unhideable_element[name] = nil
 			end
 			return true, "HUD unhideable image removed."
 		end

--- a/games/devtest/mods/testhud/init.lua
+++ b/games/devtest/mods/testhud/init.lua
@@ -384,7 +384,7 @@ local hud_unhideable_def = {
 	position = {x=0.5, y=0.5},
 	scale = {x = 100, y = 100},
 	text = "smoke_puff.png",
-	unhideable = true,
+	hideable = false,
 }
 
 local player_hud_unhideable_element = {}
@@ -407,16 +407,16 @@ core.register_chatcommand("hudunhideable", {
 		-- params == "add" or default
 		if not player_hud_unhideable_element[name] then
 			player_hud_unhideable_element[name] = player:hud_add(hud_unhideable_def)
-			assert(player:hud_get(player_hud_unhideable_element[name]).unhideable)
+			assert(player:hud_get(player_hud_unhideable_element[name]).hideable == false)
 			return true, "HUD unhideable image added."
 		end
 		return true, "HUD unhideable image already present."
 	end
 })
 
-local player_hud_all_unhideable = {}
-core.register_chatcommand("hudtoggleunhideable", {
-	description = "Makes all HUD elements unhideable",
+local player_hud_all_hideable = {}
+core.register_chatcommand("hudtogglehideable", {
+	description = "Makes all HUD elements (un)hideable",
 	func = function(name)
 		local player = core.get_player_by_name(name)
 		if not player then
@@ -424,12 +424,12 @@ core.register_chatcommand("hudtoggleunhideable", {
 		end
 
 		-- Toggle un/hideable
-		local to_set = not player_hud_all_unhideable[name]
+		local to_set = not player_hud_all_hideable[name]
 		for id, _ in pairs(player:hud_get_all()) do
-			player:hud_change(id, "unhideable", to_set)
+			player:hud_change(id, "hideable", to_set)
 		end
-		player_hud_all_unhideable[name] = to_set
-		return true, "All HUD elements are " .. (to_set and "unhideable" or "hideable") .. " now."
+		player_hud_all_hideable[name] = to_set
+		return true, "All HUD elements are " .. (to_set and "hideable" or "unhideable") .. " now."
 	end
 })
 
@@ -443,7 +443,7 @@ core.register_on_leaveplayer(function(player)
 	player_hud_hotbars[playername] = nil
 	player_hud_inventories[playername] = nil
 	player_hud_unhideable_element[playername] = nil
-	player_hud_all_unhideable[playername] = nil
+	player_hud_all_hideable[playername] = nil
 end)
 
 core.register_chatcommand("hudprint", {

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -52,7 +52,7 @@ struct ClientEventHudAdd
 	v3f world_pos;
 	v2f size;
 	s16 z_index;
-	bool unhideable;
+	bool hideable;
 };
 
 struct ClientEventHudChange

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -43,7 +43,7 @@ enum ClientEventType : u8
 struct ClientEventHudAdd
 {
 	u32 server_id;
-	u8 type, flags;
+	u8 type;
 	v2f pos, scale;
 	std::string name;
 	std::string text, text2;
@@ -52,6 +52,7 @@ struct ClientEventHudAdd
 	v3f world_pos;
 	v2f size;
 	s16 z_index;
+	bool unhideable;
 };
 
 struct ClientEventHudChange

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -43,7 +43,7 @@ enum ClientEventType : u8
 struct ClientEventHudAdd
 {
 	u32 server_id;
-	u8 type;
+	u8 type, flags;
 	v2f pos, scale;
 	std::string name;
 	std::string text, text2;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2304,7 +2304,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->z_index   = event->hudadd->z_index;
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
-	e->flags     = event->hudadd->flags;
+	e->unhideable = event->hudadd->unhideable;
 	m_hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd;
@@ -2373,7 +2373,7 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 		CASE_SET(HUD_STAT_STYLE, style, data);
 
-		CASE_SET(HUD_STAT_UNHIDEABLE, flags, data);
+		CASE_SET(HUD_STAT_UNHIDEABLE, unhideable, data);
 
 		case HudElementStat_END:
 			break;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2304,7 +2304,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->z_index   = event->hudadd->z_index;
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
-	e->unhideable = event->hudadd->unhideable;
+	e->hideable  = event->hudadd->hideable;
 	m_hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd;
@@ -2373,7 +2373,7 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 		CASE_SET(HUD_STAT_STYLE, style, data);
 
-		CASE_SET(HUD_STAT_UNHIDEABLE, unhideable, data);
+		CASE_SET(HUD_STAT_HIDEABLE, hideable, data);
 
 		case HudElementStat_END:
 			break;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2304,6 +2304,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->z_index   = event->hudadd->z_index;
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
+	e->flags     = event->hudadd->flags;
 	m_hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd;
@@ -2371,6 +2372,8 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 		CASE_SET(HUD_STAT_TEXT2, text2, sdata);
 
 		CASE_SET(HUD_STAT_STYLE, style, data);
+
+		CASE_SET(HUD_STAT_UNHIDEABLE, flags, data);
 
 		case HudElementStat_END:
 			break;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -370,7 +370,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 	});
 
 	for (HudElement *e : elems) {
-		if (only_unhidable && !e->is_unhideable())
+		if (only_unhidable && !e->unhideable)
 			continue;
 
 		v2s32 pos(floor(e->pos.X * (float) m_screensize.X + 0.5),

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -335,7 +335,7 @@ bool Hud::calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *p
 	return true;
 }
 
-void Hud::drawLuaElements(const v3s16 &camera_offset)
+void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 {
 	const u32 text_height = g_fontengine->getTextHeight();
 	gui::IGUIFont *const font = g_fontengine->getFont();
@@ -370,6 +370,8 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 	});
 
 	for (HudElement *e : elems) {
+		if (only_unhidable && !e->is_unhideable())
+			continue;
 
 		v2s32 pos(floor(e->pos.X * (float) m_screensize.X + 0.5),
 				floor(e->pos.Y * (float) m_screensize.Y + 0.5));

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -370,7 +370,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 	});
 
 	for (HudElement *e : elems) {
-		if (only_unhidable && !e->unhideable)
+		if (only_unhidable && e->hideable)
 			continue;
 
 		v2s32 pos(floor(e->pos.X * (float) m_screensize.X + 0.5),

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -96,7 +96,7 @@ public:
 
 	bool hasElementOfType(HudElementType type);
 
-	void drawLuaElements(const v3s16 &camera_offset);
+	void drawLuaElements(const v3s16 &camera_offset, bool only_unhidable);
 
 private:
 	bool calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos);

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -47,10 +47,14 @@ void DrawHUD::run(PipelineContext &context)
 
 		if (context.draw_crosshair)
 			context.hud->drawCrosshair();
+	}
 
-		context.hud->drawLuaElements(context.client->getCamera()->getOffset());
+	context.hud->drawLuaElements(context.client->getCamera()->getOffset(), !context.show_hud);
+
+	if (context.show_hud) {
 		context.client->getCamera()->drawNametags();
 	}
+
 	context.device->getGUIEnvironment()->drawAll();
 }
 

--- a/src/hud_element.cpp
+++ b/src/hud_element.cpp
@@ -36,6 +36,7 @@ const struct EnumString es_HudElementStat[] =
 	{HUD_STAT_Z_INDEX, "z_index"},
 	{HUD_STAT_TEXT2,   "text2"},
 	{HUD_STAT_STYLE,   "style"},
+	{HUD_STAT_UNHIDEABLE, "unhideable"},
 	{0, NULL},
 };
 

--- a/src/hud_element.cpp
+++ b/src/hud_element.cpp
@@ -36,7 +36,7 @@ const struct EnumString es_HudElementStat[] =
 	{HUD_STAT_Z_INDEX, "z_index"},
 	{HUD_STAT_TEXT2,   "text2"},
 	{HUD_STAT_STYLE,   "style"},
-	{HUD_STAT_UNHIDEABLE, "unhideable"},
+	{HUD_STAT_HIDEABLE, "hideable"},
 	{0, NULL},
 };
 

--- a/src/hud_element.h
+++ b/src/hud_element.h
@@ -98,14 +98,7 @@ struct HudElement {
 	s16 z_index = 0;
 	std::string text2;
 	u32 style;
-	u8 flags = 0; // Only used for unhideable, can be used for other bool fields in the future
-
-	bool is_unhideable() { return flags & 1; }
-	void set_unhideable(bool unhideable)
-	{
-		flags = unhideable ? (flags | 1) : (flags & ~1);
-	}
-
+	bool unhideable = false;
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/hud_element.h
+++ b/src/hud_element.h
@@ -71,6 +71,7 @@ enum HudElementStat : u8 {
 	HUD_STAT_Z_INDEX,
 	HUD_STAT_TEXT2,
 	HUD_STAT_STYLE,
+	HUD_STAT_UNHIDEABLE,
 	HudElementStat_END // Dummy for validity check
 };
 
@@ -97,6 +98,14 @@ struct HudElement {
 	s16 z_index = 0;
 	std::string text2;
 	u32 style;
+	u8 flags = 0; // Only used for unhideable, can be used for other bool fields in the future
+
+	bool is_unhideable() { return flags & 1; }
+	void set_unhideable(bool unhideable)
+	{
+		flags = unhideable ? (flags | 1) : (flags & ~1);
+	}
+
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/hud_element.h
+++ b/src/hud_element.h
@@ -71,7 +71,7 @@ enum HudElementStat : u8 {
 	HUD_STAT_Z_INDEX,
 	HUD_STAT_TEXT2,
 	HUD_STAT_STYLE,
-	HUD_STAT_UNHIDEABLE,
+	HUD_STAT_HIDEABLE,
 	HudElementStat_END // Dummy for validity check
 };
 
@@ -98,7 +98,7 @@ struct HudElement {
 	s16 z_index = 0;
 	std::string text2;
 	u32 style;
-	bool unhideable = false;
+	bool hideable = true;
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1180,6 +1180,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	s16 z_index = 0;
 	std::string text2;
 	u32 style = 0;
+	u8 flags = 0;
 
 	*pkt >> server_id >> type >> pos >> name >> scale >> text >> number >> item
 		>> dir >> align >> offset;
@@ -1208,6 +1209,12 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 			break;
 		// >= 5.5.0-dev
 		*pkt >> style;
+
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.17.0-dev
+		*pkt >> flags;
+
 	} while (0);
 
 	ClientEvent *event = new ClientEvent();
@@ -1229,6 +1236,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd->z_index   = z_index;
 	event->hudadd->text2     = text2;
 	event->hudadd->style     = style;
+	event->hudadd->flags     = flags;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1236,7 +1236,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd->z_index   = z_index;
 	event->hudadd->text2     = text2;
 	event->hudadd->style     = style;
-	event->hudadd->flags     = flags;
+	event->hudadd->unhideable = flags % 2;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1180,7 +1180,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	s16 z_index = 0;
 	std::string text2;
 	u32 style = 0;
-	u8 flags = 0;
+	u8 flags = 1;
 
 	*pkt >> server_id >> type >> pos >> name >> scale >> text >> number >> item
 		>> dir >> align >> offset;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1236,7 +1236,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd->z_index   = z_index;
 	event->hudadd->text2     = text2;
 	event->hudadd->style     = style;
-	event->hudadd->unhideable = flags % 2;
+	event->hudadd->hideable  = flags % 2;
 	m_client_event_queue.push(event);
 }
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2546,7 +2546,7 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 			*value = &elem->style;
 			break;
 		case HUD_STAT_HIDEABLE:
-			elem->hideable = lua_toboolean(L, 4);
+			elem->hideable = lua_isnoneornil(L, 4) ? true : lua_toboolean(L, 4);
 			*value = &elem->hideable;
 			break;
 		case HudElementStat_END:

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2406,7 +2406,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 
 	elem->style = getintfield_default(L, 2, "style", 0);
 
-	elem->set_unhideable(getboolfield_default(L, 2, "unhideable", false));
+	elem->unhideable = getboolfield_default(L, 2, "unhideable", false);
 
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2f()))
@@ -2474,7 +2474,7 @@ void push_hud_element(lua_State *L, HudElement *elem)
 	lua_pushinteger(L, elem->style);
 	lua_setfield(L, -2, "style");
 
-	lua_pushboolean(L, elem->is_unhideable());
+	lua_pushboolean(L, elem->unhideable);
 	lua_setfield(L, -2, "unhideable");
 }
 
@@ -2546,8 +2546,8 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 			*value = &elem->style;
 			break;
 		case HUD_STAT_UNHIDEABLE:
-			elem->set_unhideable(lua_toboolean(L, 4));
-			*value = &elem->flags;
+			elem->unhideable = lua_toboolean(L, 4);
+			*value = &elem->unhideable;
 			break;
 		case HudElementStat_END:
 			return false;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2406,6 +2406,8 @@ void read_hud_element(lua_State *L, HudElement *elem)
 
 	elem->style = getintfield_default(L, 2, "style", 0);
 
+	elem->set_unhideable(getboolfield_default(L, 2, "unhideable", false));
+
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2f()))
 		log_deprecated(L,"Deprecated usage of statbar without size!");
@@ -2471,6 +2473,9 @@ void push_hud_element(lua_State *L, HudElement *elem)
 
 	lua_pushinteger(L, elem->style);
 	lua_setfield(L, -2, "style");
+
+	lua_pushboolean(L, elem->is_unhideable());
+	lua_setfield(L, -2, "unhideable");
 }
 
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value)
@@ -2539,6 +2544,10 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 		case HUD_STAT_STYLE:
 			elem->style = luaL_checknumber(L, 4);
 			*value = &elem->style;
+			break;
+		case HUD_STAT_UNHIDEABLE:
+			elem->set_unhideable(lua_toboolean(L, 4));
+			*value = &elem->flags;
 			break;
 		case HudElementStat_END:
 			return false;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2406,7 +2406,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 
 	elem->style = getintfield_default(L, 2, "style", 0);
 
-	elem->unhideable = getboolfield_default(L, 2, "unhideable", false);
+	elem->hideable = getboolfield_default(L, 2, "hideable", true);
 
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2f()))
@@ -2474,8 +2474,8 @@ void push_hud_element(lua_State *L, HudElement *elem)
 	lua_pushinteger(L, elem->style);
 	lua_setfield(L, -2, "style");
 
-	lua_pushboolean(L, elem->unhideable);
-	lua_setfield(L, -2, "unhideable");
+	lua_pushboolean(L, elem->hideable);
+	lua_setfield(L, -2, "hideable");
 }
 
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value)
@@ -2545,9 +2545,9 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 			elem->style = luaL_checknumber(L, 4);
 			*value = &elem->style;
 			break;
-		case HUD_STAT_UNHIDEABLE:
-			elem->unhideable = lua_toboolean(L, 4);
-			*value = &elem->unhideable;
+		case HUD_STAT_HIDEABLE:
+			elem->hideable = lua_toboolean(L, 4);
+			*value = &elem->hideable;
 			break;
 		case HudElementStat_END:
 			return false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1884,7 +1884,11 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 	else
 		pkt << v2s32::from(form->size);
 
-	pkt << form->z_index << form->text2 << form->style << form->flags;
+	/// Bit 0: unhideable
+	/// Bits 1 ... 8: unused (set to 0)
+	u8 flags = form->unhideable ? 1 : 0;
+
+	pkt << form->z_index << form->text2 << form->style << flags;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1884,7 +1884,7 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 	else
 		pkt << v2s32::from(form->size);
 
-	pkt << form->z_index << form->text2 << form->style;
+	pkt << form->z_index << form->text2 << form->style << form->flags;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1928,6 +1928,9 @@ void Server::SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void 
 				pkt << v2s32::from(*v);
 			break;
 		}
+		case HUD_STAT_UNHIDEABLE:
+			pkt << u32{*(bool *) value};
+			break;
 		default: // all other types
 			pkt << *(u32 *) value;
 			break;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1884,9 +1884,9 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 	else
 		pkt << v2s32::from(form->size);
 
-	/// Bit 0: unhideable
+	/// Bit 0: hideable
 	/// Bits 1 ... 8: unused (set to 0)
-	u8 flags = form->unhideable ? 1 : 0;
+	u8 flags = form->hideable ? 1 : 0;
 
 	pkt << form->z_index << form->text2 << form->style << flags;
 
@@ -1928,7 +1928,7 @@ void Server::SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void 
 				pkt << v2s32::from(*v);
 			break;
 		}
-		case HUD_STAT_UNHIDEABLE:
+		case HUD_STAT_HIDEABLE:
 			pkt << u32{*(bool *) value};
 			break;
 		default: // all other types


### PR DESCRIPTION
Closes #11075

Adds an `hideable` field to HUD elements. If it's set to false, players can't hide the element anymore.

## To do

Ready for Review.

## How to test

- Start devtest
-  Execute `/hudunhideable` and hide the HUD (Press F1)
-  Use `/hudtogglehideable` to make all elements unhideable.
- Read the `lua_api.md` changes
