### PR TITLE
MTP Server: Acquire info mutex to set peer ID

### DIFF
--- a/src/network/mtp/impl.cpp
+++ b/src/network/mtp/impl.cpp
@@ -1632,7 +1632,10 @@ void Connection::DisconnectPeer(session_t peer_id)
 
 void Connection::SetPeerID(session_t id)
 {
-	m_peer_id = id;
+	{
+		MutexAutoLock _(m_info_mutex);
+		m_peer_id = id;
+	}
 	// fix peer id in existing queued reliable packets
 	if (id != PEER_ID_INEXISTENT)
 		putCommand(ConnectionCommand::peer_id_set(id));


### PR DESCRIPTION
TSan reports a data race on `Connection::m_peer_id` because `Connection::SetPeerID` does not synchronize with `Connection::getDesc`. This data race could also be resolved using atomics, but the mutex appears to have been the intended approach.

`m_info_mutex` was only acquired in a single place (`Connection::getDesc`) prior to this change (for reading, not writing; ergo, it was doing nothing), so it should be easy to verify by code inspection that this change does not introduce a deadlock.

## To do

Ready for Review.

## How to test

TSan should no longer report a data race when running the unittests. Of course, this does not guarantee there is no data race.