### PR TITLE
[NO SQUASH] Craft: Return correct 'type's to Lua

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -57,6 +57,7 @@ core.features = {
 	set_camera_resettable = true,
 	hud_hideable_field = true,
 	compress_raw_deflate = true,
+	get_all_craft_recipes_fuel = true,
 }
 
 function core.has_feature(arg)

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -31,3 +31,4 @@ This list is largely advisory and items may be reevaluated once the time comes.
 * rework `on_drop` to give Lua full flexibility
    * should take `itemstack, dropper, count` and return the new itemstack
    * https://github.com/luanti-org/luanti/pull/17024 for context
+* use consistent fields for `get_all_craft_recipes` and `get_craft_result`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6212,6 +6212,9 @@ Utilities
       hud_hideable_field = true,
       -- "raw_deflate" method for compress/decompress (5.17.0)
       compress_raw_deflate = true,
+      -- Whether `core.get_all_craft_recipes` returns the correct `method` for fuels
+      -- and `width = 0` for non-shaped recipes. (5.17.0)
+      get_all_craft_recipes_fuel = true,
   }
   ```
 
@@ -7425,7 +7428,7 @@ Item handling
       or `nil` if no recipe was found.
     * recipe entry table:
         * `method`: 'normal' or 'cooking' or 'fuel'
-        * `width`: 0-3, 0 means shapeless recipe
+        * `width`: 0-3, 0 means shapeless recipe. Only valid for `method = "normal"`.
         * `items`: indexed [1-9] table with recipe items
         * `output`: string with item name and quantity
     * Example result for `"default:gold_ingot"` with two recipes:

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6213,7 +6213,7 @@ Utilities
       -- "raw_deflate" method for compress/decompress (5.17.0)
       compress_raw_deflate = true,
       -- Whether `core.get_all_craft_recipes` returns the correct `method` for fuels
-      -- and `width = 0` for non-shaped recipes. (5.17.0)
+      -- `width = 0` for non-shaped recipes and provides the optional `time` field (5.17.0)
       get_all_craft_recipes_fuel = true,
   }
   ```
@@ -7415,22 +7415,23 @@ Item handling
       placed in `decremented_input.items`. Replacements can be placed in
       `decremented_input` if the stack of the replaced item has a count of 1.
     * `decremented_input` = like `input`
-* `core.get_craft_recipe(output)`: returns input
-    * returns last registered recipe for output item (node)
-    * `output` is a node or item type such as `"default:torch"`
-    * `input.method` = `"normal"` or `"cooking"` or `"fuel"`
-    * `input.width` = for example `3`
-    * `input.items` = for example
-      `{stack1, stack2, stack3, stack4, stack 5, stack 6, stack 7, stack 8, stack 9}`
-        * `input.items` = `nil` if no recipe found
-* `core.get_all_craft_recipes(query item)`: returns a table or `nil`
-    * returns indexed table with all registered recipes for query item (node)
-      or `nil` if no recipe was found.
-    * recipe entry table:
+* `core.get_craft_recipe(output)`: returns a table
+    * Returns the last registered recipe for the `output` item name
+    * Return value:
+        * No recipe found: `{ items = nil, width = 0 }`
+        * Recipe found: see `core.get_all_craft_recipes` table values.
+* `core.get_all_craft_recipes(output)`: returns a table or `nil`
+    * Returns an indexed table of all registered recipes which have the result `output`.
+    * Returns `nil` if no recipe was found.
+    * `output`: an item name, such as `"default:torch"`.
+    * Returned table values:
         * `method`: 'normal' or 'cooking' or 'fuel'
-        * `width`: 0-3, 0 means shapeless recipe. Only valid for `method = "normal"`.
-        * `items`: indexed [1-9] table with recipe items
+        * `width`: in range [0, N] (2 or 3 is used often). 0 means shapeless recipe.
+          Only valid for `method = "normal"`.
+        * `items`: list of recipe item names.
+          Empty ingredients (itemstring `""`) are represented as `nil`.
         * `output`: string with item name and quantity
+        * `time` (for 'cooking' or 'fuel'): is `cooktime` or `burntime` (since 5.17.0)
     * Example result for `"default:gold_ingot"` with two recipes:
       ```lua
       {

--- a/games/devtest/mods/unittests/crafting.lua
+++ b/games/devtest/mods/unittests/crafting.lua
@@ -110,3 +110,46 @@ local function test_get_craft_result()
 	assert(output.item:is_empty())
 end
 unittests.register("test_get_craft_result", test_get_craft_result)
+
+
+local function test_get_all_craft_recipes()
+	-- cooking
+	local output
+
+	output = "unittests:steel_ingot"
+	do
+		local recipes = core.get_all_craft_recipes(output)
+
+		core.log("info", "[unittests] cooking recipes="..dump(recipes))
+		local found
+		for _, recipe in ipairs(recipes) do
+			if recipe.type == "cooking" and recipe.items[1] == "unittests:iron_lump" then
+				assert(found == nil, "found too many")
+				found = recipe
+			end
+		end
+		assert(found)
+		assert(ItemStack(found.output) == ItemStack(output)) -- handle aliases
+		assert(found.time == 10) -- cooktime
+	end
+
+	-- fuel
+	output = ""
+	do
+		local recipes = core.get_all_craft_recipes(output)
+		core.log("info", "[unittests] fuel recipes="..dump(recipes))
+		local found
+		for _, recipe in ipairs(recipes) do
+			if recipe.type == "fuel" and recipe.items[1] == "unittests:coal_lump" then
+				assert(found == nil, "found too many")
+				found = recipe
+			end
+		end
+		assert(found)
+		assert(ItemStack(found.output) == ItemStack(output)) -- handle aliases
+		assert(found.time == 40) -- burntime
+	end
+
+end
+unittests.register("test_get_all_craft_recipes", test_get_all_craft_recipes)
+

--- a/games/devtest/mods/unittests/crafting_prepare.lua
+++ b/games/devtest/mods/unittests/crafting_prepare.lua
@@ -51,6 +51,7 @@ core.register_craft({
 	type = "cooking",
 	output = "unittests:steel_ingot_alias",
 	recipe = "unittests:iron_lump_alias",
+	cooktime = 10,
 })
 
 core.register_craft({

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -799,7 +799,7 @@ CraftInput CraftDefinitionToolRepair::getInput(const CraftOutput &output, IGameD
 {
 	std::vector<ItemStack> stack;
 	stack.emplace_back();
-	return CraftInput(CRAFT_METHOD_COOKING, additional_wear, stack);
+	return CraftInput(CRAFT_METHOD_NORMAL, 0, stack);
 }
 
 void CraftDefinitionToolRepair::decrementInput(CraftInput &input, std::vector<ItemStack> &output_replacements,
@@ -872,7 +872,7 @@ CraftInput CraftDefinitionCooking::getInput(const CraftOutput &output, IGameDef 
 {
 	std::vector<std::string> rec;
 	rec.push_back(recipe);
-	return CraftInput(CRAFT_METHOD_COOKING,cooktime,craftGetItems(rec,gamedef));
+	return CraftInput(CRAFT_METHOD_COOKING, 0, craftGetItems(rec, gamedef));
 }
 
 void CraftDefinitionCooking::decrementInput(CraftInput &input, std::vector<ItemStack> &output_replacements,
@@ -975,7 +975,7 @@ CraftInput CraftDefinitionFuel::getInput(const CraftOutput &output, IGameDef *ga
 {
 	std::vector<std::string> rec;
 	rec.push_back(recipe);
-	return CraftInput(CRAFT_METHOD_COOKING,(int)burntime,craftGetItems(rec,gamedef));
+	return CraftInput(CRAFT_METHOD_FUEL, 0, craftGetItems(rec,gamedef));
 }
 
 void CraftDefinitionFuel::decrementInput(CraftInput &input, std::vector<ItemStack> &output_replacements,

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -55,7 +55,7 @@ const int craft_hash_type_max = (int) CRAFT_HASH_TYPE_UNHASHED;
 struct CraftInput
 {
 	CraftMethod method = CRAFT_METHOD_NORMAL;
-	unsigned int width = 0;
+	unsigned int width = 0; //< used only for shaped recipes
 	std::vector<ItemStack> items;
 
 	CraftInput() = default;

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -12,7 +12,7 @@
 #include "server.h"
 #include "craftdef.h"
 
-struct EnumString ModApiCraft::es_CraftMethod[] =
+EnumString ModApiCraft::es_CraftMethod[] =
 {
 	{CRAFT_METHOD_NORMAL, "normal"},
 	{CRAFT_METHOD_COOKING, "cooking"},
@@ -405,27 +405,19 @@ static void push_craft_recipe(lua_State *L, IGameDef *gdef,
 		lua_rawseti(L, -2, j);
 	}
 	lua_setfield(L, -2, "items");
+
+	// Field kept for other craft recipes for backwards compatibility
 	setintfield(L, -1, "width", input.width);
 
-	std::string method_s;
-	switch (input.method) {
-	case CRAFT_METHOD_NORMAL:
-		method_s = "normal";
-		break;
-	case CRAFT_METHOD_COOKING:
-		method_s = "cooking";
-		break;
-	case CRAFT_METHOD_FUEL:
-		method_s = "fuel";
-		break;
-	default:
+	const char *method_s = enum_to_string(ModApiCraft::es_CraftMethod, input.method);
+	if (!method_s)
 		method_s = "unknown";
-	}
-	lua_pushstring(L, method_s.c_str());
+
+	lua_pushstring(L, method_s);
 	lua_setfield(L, -2, "method");
 
 	// Deprecated, only for compatibility's sake
-	lua_pushstring(L, method_s.c_str());
+	lua_pushstring(L, method_s);
 	lua_setfield(L, -2, "type");
 
 	lua_pushstring(L, output.item.c_str());

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -338,6 +338,72 @@ int ModApiCraft::l_clear_craft(lua_State *L)
 	return 1;
 }
 
+/// Pushes to table @ Lua top: method, (type), width, items
+static void push_craft_result_input(lua_State *L,
+		IGameDef *gdef,
+		const CraftInput &input,
+		bool push_itemstacks,
+		bool undocumented_0_4_14_compat)
+{
+	const char *method_s = enum_to_string(ModApiCraft::es_CraftMethod, input.method);
+	if (!method_s)
+		method_s = "unknown";
+
+	lua_pushstring(L, method_s);
+	lua_setfield(L, -2, "method");
+
+	if (undocumented_0_4_14_compat) {
+		// Before 0.4.14 (commit 5c0e659), only "type" (undocumented) was provided.
+		lua_pushstring(L, method_s);
+		lua_setfield(L, -2, "type");
+	}
+
+	// Field kept for other craft recipes for backwards compatibility
+	setintfield(L, -1, "width", input.width);
+
+	if (push_itemstacks) {
+		push_items(L, input.items);
+	} else {
+		lua_newtable(L); // items
+		auto iter = input.items.begin();
+		for (u16 j = 1; iter != input.items.end(); ++iter, j++) {
+			// Inconsistency: empty ingredients are represented as `nil`.
+			if (iter->empty())
+				continue;
+			lua_pushstring(L, iter->name.c_str());
+			lua_rawseti(L, -2, j);
+		}
+	}
+	lua_setfield(L, -2, "items");
+}
+
+/// Pushes to table @ Lua top: item
+static void push_craft_result_output(lua_State *L,
+		IGameDef *gdef,
+		bool is_craft_valid,
+		const char *output_field,
+		const CraftOutput &output,
+		bool push_itemstacks)
+{
+	if (is_craft_valid) {
+		if (push_itemstacks) {
+			ItemStack item;
+			item.deSerialize(output.item, gdef->idef());
+			LuaItemStack::create(L, item);
+		} else {
+			lua_pushstring(L, output.item.c_str());
+		}
+		lua_setfield(L, -2, output_field);
+	} else {
+		FATAL_ERROR_IF(!push_itemstacks, "only used for get_craft_result");
+		LuaItemStack::create(L, ItemStack());
+		lua_setfield(L, -2, output_field);
+	}
+
+	// "time" is handled separately
+}
+
+
 // get_craft_result(input)
 int ModApiCraft::l_get_craft_result(lua_State *L)
 {
@@ -362,29 +428,25 @@ int ModApiCraft::l_get_craft_result(lua_State *L)
 	CraftOutput output;
 	std::vector<ItemStack> output_replacements;
 	bool got = cdef->getCraftResult(input, output, output_replacements, true, gdef);
-	lua_newtable(L); // output table
-	if (got) {
-		ItemStack item;
-		item.deSerialize(output.item, gdef->idef());
-		LuaItemStack::create(L, item);
-		lua_setfield(L, -2, "item");
-		setintfield(L, -1, "time", output.time);
-		push_items(L, output_replacements);
-		lua_setfield(L, -2, "replacements");
-	} else {
-		LuaItemStack::create(L, ItemStack());
-		lua_setfield(L, -2, "item");
-		setintfield(L, -1, "time", 0);
-		lua_newtable(L);
+
+	lua_newtable(L); // return#2 output table
+	{
+		push_craft_result_output(L, gdef, got, "item", output, true);
+
+		setintfield(L, -1, "time", got ? output.time : 0);
+
+		if (got)
+			push_items(L, output_replacements);
+		else
+			lua_newtable(L);
 		lua_setfield(L, -2, "replacements");
 	}
-	lua_newtable(L); // decremented input table
-	lua_pushstring(L, method_s.c_str());
-	lua_setfield(L, -2, "method");
-	lua_pushinteger(L, width);
-	lua_setfield(L, -2, "width");
-	push_items(L, input.items);
-	lua_setfield(L, -2, "items");
+
+	lua_newtable(L); // return#1 decremented input table
+	{
+		push_craft_result_input(L, gdef, input, true, false);
+	}
+
 	return 2;
 }
 
@@ -396,50 +458,19 @@ static void push_craft_recipe(lua_State *L, IGameDef *gdef,
 	CraftInput input = recipe->getInput(tmpout, gdef);
 	CraftOutput output = recipe->getOutput(input, gdef);
 
-	lua_newtable(L); // items
-	auto iter = input.items.begin();
-	for (u16 j = 1; iter != input.items.end(); ++iter, j++) {
-		if (iter->empty())
-			continue;
-		lua_pushstring(L, iter->name.c_str());
-		lua_rawseti(L, -2, j);
-	}
-	lua_setfield(L, -2, "items");
+	push_craft_result_output(L, gdef, true, "output", output, false);
+	push_craft_result_input(L, gdef, input, false, true);
 
-	// Field kept for other craft recipes for backwards compatibility
-	setintfield(L, -1, "width", input.width);
-
-	const char *method_s = enum_to_string(ModApiCraft::es_CraftMethod, input.method);
-	if (!method_s)
-		method_s = "unknown";
-
-	lua_pushstring(L, method_s);
-	lua_setfield(L, -2, "method");
-
-	// Deprecated, only for compatibility's sake
-	lua_pushstring(L, method_s);
-	lua_setfield(L, -2, "type");
-
-	lua_pushstring(L, output.item.c_str());
-	lua_setfield(L, -2, "output");
-}
-
-static void push_craft_recipes(lua_State *L, IGameDef *gdef,
-		const std::vector<CraftDefinition*> &recipes,
-		const CraftOutput &output)
-{
-	if (recipes.empty()) {
-		lua_pushnil(L);
-		return;
-	}
-
-	lua_createtable(L, recipes.size(), 0);
-
-	auto it = recipes.begin();
-	for (unsigned i = 0; it != recipes.end(); ++it) {
-		lua_newtable(L);
-		push_craft_recipe(L, gdef, *it, output);
-		lua_rawseti(L, -2, ++i);
+	// NOTE: The returned table can get very large, hence avoid unused fields
+	// unless needed for the sake of compatibility
+	switch (input.method) {
+		case CRAFT_METHOD_COOKING:
+		case CRAFT_METHOD_FUEL:
+			setintfield(L, -1, "time", output.time);
+			break;
+		case CRAFT_METHOD_NORMAL:
+			// no such field
+			break;
 	}
 }
 
@@ -476,7 +507,19 @@ int ModApiCraft::l_get_all_craft_recipes(lua_State *L)
 	CraftOutput output(item, 0);
 	auto recipes = gdef->cdef()->getCraftRecipes(output, gdef);
 
-	push_craft_recipes(L, gdef, recipes, output);
+	if (recipes.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_createtable(L, recipes.size(), 0);
+
+	auto it = recipes.begin();
+	for (unsigned i = 0; it != recipes.end(); ++it) {
+		lua_newtable(L);
+		push_craft_recipe(L, gdef, *it, output);
+		lua_rawseti(L, -2, ++i);
+	}
 	return 1;
 }
 

--- a/src/script/lua_api/l_craft.h
+++ b/src/script/lua_api/l_craft.h
@@ -26,9 +26,9 @@ private:
 	static bool readCraftRecipeShaped(lua_State *L, int index,
 			int &width, std::vector<std::string> &recipe);
 
+public:
 	static struct EnumString es_CraftMethod[];
 
-public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);
 };


### PR DESCRIPTION
```Lua
print(dump(core.get_all_craft_recipes("")))
```
Should return all "fuel" types. However, all fuels are listed as "cooking", which is not quite correct.

Fixes #5745

Documented the inconsistencies outlined in #7429 in `breakages.md`. Fixing that may break mods that relied on undocumented code.

## To do

This PR is a Work in Progress

- [x] Add feature flag
- [x] Hope that it does not break mods
- [x] Maybe unify `push_craft_recipe` partially with `l_get_craft_result` to have burntime, cooktime and replacements provided. --> Partially done.

## How to test

With Minetest Game, compare the output of this script of master and PR:

```Lua
local function print_recipes_for(output_itemname, print_limit)

	local recipes = core.get_all_craft_recipes(output_itemname)
	local counts = {
		fuel = 0,
		normal = 0, -- shaped or shapeless
		cooking = 0
	}

	-- Bugfix check
	for _, craftdef in ipairs(recipes) do
		local count = counts[craftdef.method]
		counts[craftdef.method] = count + 1

		if true then
			if count < print_limit then
				print(dump(craftdef))
			end
			if count == print_limit then
				print("<limit for '" .. craftdef.method .. "' reached, stop>")
			end
		end
	end

	print("Stats: (output=" .. output_itemname .. ")")
	for k, v in pairs(counts) do
		print("", k, v)
	end
end

print_recipes_for("", 2)
print_recipes_for("default:wood", 2)
print_recipes_for("default:steel_ingot", 2)


print("Toolrepair:")
local TOOL = ItemStack("default:pick_steel")
TOOL:set_wear(0xFFFF - 2000)

local output, decremented = core.get_craft_result({
	items = {TOOL, TOOL},
	method = "normal",
})
print(dump(output), dump(decremented))

core.register_chatcommand("g", {
	func = function(name, param)
		local player = core.get_player_by_name(name)
		local inv = player:get_inventory()
		inv:add_item("main", TOOL)
		inv:add_item("main", TOOL)
	end
})

```
