### PR TITLE
Formspec: Do not close on focus change

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -68,6 +68,8 @@ void GUIModalMenu::draw()
 	if (!IsVisible)
 		return;
 
+	m_is_window_focused = RenderingEngine::get_raw_device()->isWindowFocused();
+
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 	v2u32 screensize = driver->getScreenSize();
 	if (screensize != m_screensize_old) {
@@ -121,6 +123,9 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 	gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(current.pos);
 	if (isChild(hovered, this))
+		return false;
+
+	if (!m_is_window_focused)
 		return false;
 
 	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -84,6 +84,7 @@ protected:
 
 private:
 	IMenuManager *m_menumgr;
+	bool m_is_window_focused = false;
 	/* If true, remap a click outside the formspec to ESC. This is so that, for
 	 * example, touchscreen users can close formspecs.
 	 * The default for this setting is true. Currently, it's set to false for


### PR DESCRIPTION
Fixes most of https://github.com/luanti-org/luanti/issues/15955#issuecomment-2763519626

## To do

This PR is Ready for Review.

## How to test

1. Open a formspec
2. Focus another window
3. Focus Luanti but click outside the formspec (by accident or routine)
4. master: The formspec closes. PR: The formspec closes only after a second click.
