### PR TITLE
httpfetch: Reject newlines in headers

### DIFF
--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -140,6 +140,7 @@ bool httpfetch_async_get(u64 caller, HTTPFetchResult &fetch_result)
 static size_t httpfetch_writefunction(
 		char *ptr, size_t size, size_t nmemb, void *userdata)
 {
+	assert(userdata);
 	auto *dest = reinterpret_cast<std::string*>(userdata);
 	size_t count = size * nmemb;
 	dest->append(ptr, count);
@@ -150,6 +151,18 @@ static size_t httpfetch_discardfunction(
 		char *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	return size * nmemb;
+}
+
+static bool string_safe_for_curl(std::string_view s, const char *kind)
+{
+	// NUL isn't unsafe but will truncate the string, so warn too
+	if (s.find_first_of("\r\n") != std::string::npos || s.find('\0') != std::string::npos) {
+		warningstream << "httpfetch: can't use " << kind << " \"";
+		safe_print_string(warningstream, s);
+		warningstream << "\" because it contains invalid characters" << std::endl;
+		return false;
+	}
+	return true;
 }
 
 class CurlHandlePool
@@ -261,8 +274,10 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS,
 			request.connect_timeout);
 
-	curl_easy_setopt(curl, CURLOPT_USERAGENT,
-		request.useragent.empty() ? nullptr : request.useragent.c_str());
+	if (string_safe_for_curl(request.useragent, "user agent")) {
+		curl_easy_setopt(curl, CURLOPT_USERAGENT,
+			request.useragent.empty() ? nullptr : request.useragent.c_str());
+	}
 
 	// Set up a write callback that writes to the
 	// result struct, unless the data is to be discarded
@@ -336,7 +351,9 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 
 	// Set additional HTTP headers
 	for (const auto &s : request.extra_headers) {
-		http_header = curl_slist_append(http_header, s.c_str());
+		if (string_safe_for_curl(s, "request header")) {
+			http_header = curl_slist_append(http_header, s.c_str());
+		}
 	}
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, http_header);
 


### PR DESCRIPTION
Noticed this while reading https://curl.se/libcurl/security.html.

## To do

This PR is Ready for Review.

## How to test

left as exercise for reader