### PR TITLE
[NO SQUASH] IrrlichtMt: CGUIComboBox improvements

### DIFF
--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -236,11 +236,10 @@ bool CGUIComboBox::OnEvent(const SEvent &event)
 			switch (event.GUIEvent.EventType) {
 			case EGET_ELEMENT_FOCUS_LOST:
 				if (ListBox &&
-						(Environment->hasFocus(ListBox) || ListBox->isMyDescendant(event.GUIEvent.Caller)) &&
+						// Newly focused element
 						event.GUIEvent.Element != this &&
-						!isMyDescendant(event.GUIEvent.Element) &&
-						!ListBox->isMyDescendant(event.GUIEvent.Element)) {
-					openCloseMenu();
+						!isMyDescendant(event.GUIEvent.Element)) {
+					openCloseMenu(); // close
 				}
 				break;
 			case EGET_BUTTON_CLICKED:
@@ -264,28 +263,23 @@ bool CGUIComboBox::OnEvent(const SEvent &event)
 				break;
 			}
 			break;
-		case EET_MOUSE_INPUT_EVENT:
+		case EET_MOUSE_INPUT_EVENT: {
+			core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
 
 			switch (event.MouseInput.Event) {
 			case EMIE_LMOUSE_PRESSED_DOWN: {
-				core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
 
-				// send to list box
-				if (ListBox && ListBox->isPointInside(p) && ListBox->OnEvent(event))
+				if (!ListBox && isPointInside(p)) {
+					// Quick select: mouse down -> drag to position -> mouse up -> (selected)
+					openCloseMenu(); // open
 					return true;
+				}
 
-				return true;
+				break;
 			}
 			case EMIE_LMOUSE_LEFT_UP: {
-				core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
-
-				// send to list box
-				if (!(ListBox &&
-							ListBox->getAbsolutePosition().isPointInside(p) &&
-							ListBox->OnEvent(event))) {
-					openCloseMenu();
-				}
-				return true;
+				// Eaten by CGUIListBox
+				break;
 			}
 			case EMIE_MOUSE_WHEEL: {
 				// Try scrolling parent first
@@ -311,7 +305,13 @@ bool CGUIComboBox::OnEvent(const SEvent &event)
 			default:
 				break;
 			}
+
+			// Prevent interaction with underlying elements.
+			if (isPointInside(p) || (ListBox && ListBox->isPointInside(p)))
+				return true;
+
 			break;
+		}
 		default:
 			break;
 		}

--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -125,7 +125,8 @@ void CGUIComboBox::removeItem(u32 idx)
 //! Returns caption of this element.
 const wchar_t *CGUIComboBox::getText() const
 {
-	return getItem(Selected);
+	const wchar_t *item = getItem(Selected);
+	return item ? item : L"";
 }
 
 //! adds an item and returns the index of it


### PR DESCRIPTION
Does not fix any reported issue.

Commit 1: Ensures that `getText()` always returns a valid pointer
Commit 2: Removal of superfluous/unused input handling code + click->drag->release selection (I can split this into a separate commit if desired)

## To do

This PR is Ready for Review.

## How to test

1. Open a formspec with a dropdown
2. Use the dropdown in whatever ways possible (scroll, click, drag&click)
3. With the test code below:
    1. Have an ItemStack in the first few slots
    2. Open the dropdown
    3. Right-click on the list options
    4. The ItemStack must not be picked up (event captured)

Some devtest test code:
```
/lua core.show_formspec("singleplayer", "test", "size[8,5]list[current_player;main;0,1;8,4;0]dropdown[0.25,0.2;2,0.8;test;Item 1,Item 2;0;]")
```
