### PR TITLE
Raise minimum libcurl version

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -16,9 +16,11 @@
 | LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |
 | GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
 | JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
-| Curl       | 7.56.0+ | Optional   |
-| gettext    | -       | Optional   |
+| Curl       | 7.66.0+ | Optional, but recommended |
+| gettext    | -       | Optional, but recommended |
 | OpenSSL    | 3.0+    | Optional (only libcrypto used) |
+
+<!-- TODO: audio stuff is missing here -->
 
 For Debian/Ubuntu users:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,7 @@ option(ENABLE_CURL "Enable cURL support" TRUE)
 set(USE_CURL FALSE)
 
 if(ENABLE_CURL)
-	find_package(CURL 7.28.0)
+	find_package(CURL 7.66.0)
 	if (CURL_FOUND)
 		message(STATUS "cURL support enabled.")
 		set(USE_CURL TRUE)

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -242,13 +242,11 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 	const char *protocols = "HTTP,HTTPS,FTP,FTPS";
 	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, protocols);
 	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, protocols);
-#elif LIBCURL_VERSION_NUM >= 0x071304
+#else
 	// These settings were introduced in curl 7.19.4, and later deprecated.
 	long protocols =
-		CURLPROTO_HTTP |
-		CURLPROTO_HTTPS |
-		CURLPROTO_FTP |
-		CURLPROTO_FTPS;
+		CURLPROTO_HTTP | CURLPROTO_HTTPS |
+		CURLPROTO_FTP | CURLPROTO_FTPS;
 	curl_easy_setopt(curl, CURLOPT_PROTOCOLS, protocols);
 	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, protocols);
 #endif
@@ -433,13 +431,6 @@ HTTPFetchOngoing::~HTTPFetchOngoing()
 	pool->free(curl);
 }
 
-
-#if LIBCURL_VERSION_NUM >= 0x074200
-#define HAVE_CURL_MULTI_POLL
-#else
-#undef HAVE_CURL_MULTI_POLL
-#endif
-
 class CurlFetchThread : public Thread
 {
 protected:
@@ -592,38 +583,12 @@ protected:
 	{
 		CURLMcode mres;
 
-#ifdef HAVE_CURL_MULTI_POLL
 		mres = curl_multi_poll(m_multi, nullptr, 0, timeout, nullptr);
 
 		if (mres != CURLM_OK) {
 			errorstream << "curl_multi_poll returned error code "
 				<< mres << std::endl;
 		}
-#else
-		// If there's nothing to do curl_multi_wait() will immediately return
-		// so we have to emulate the sleeping.
-
-		fd_set dummy;
-		int max_fd;
-		mres = curl_multi_fdset(m_multi, &dummy, &dummy, &dummy, &max_fd);
-		if (mres != CURLM_OK) {
-			errorstream << "curl_multi_fdset returned error code "
-				<< mres << std::endl;
-			max_fd = -1;
-		}
-
-		if (max_fd == -1) { // curl has nothing to wait for
-			if (timeout > 0)
-				sleep_ms(timeout);
-		} else {
-			mres = curl_multi_wait(m_multi, nullptr, 0, timeout, nullptr);
-
-			if (mres != CURLM_OK) {
-				errorstream << "curl_multi_wait returned error code "
-					<< mres << std::endl;
-			}
-		}
-#endif
 	}
 
 	void *run()

--- a/src/util/colorize.cpp
+++ b/src/util/colorize.cpp
@@ -51,11 +51,7 @@ std::string colorize_url(const std::string &url)
 	auto path = url_get(CURLUPART_PATH);
 	auto query = url_get(CURLUPART_QUERY);
 	auto fragment = url_get(CURLUPART_FRAGMENT);
-#if LIBCURL_VERSION_NUM >= 0x074100
 	auto zoneid = url_get(CURLUPART_ZONEID);
-#else
-	std::string zoneid;
-#endif
 
 	std::ostringstream os;
 

--- a/src/util/colorize.h
+++ b/src/util/colorize.h
@@ -23,11 +23,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define COLOR_CODE(color) "\x1b(c@" color ")"
 
 #if USE_CURL
-#include <curl/curlver.h>
-// curl_url functions since 7.62.0
-#if LIBCURL_VERSION_NUM >= 0x073e00
 #define HAVE_COLORIZE_URL
-#endif
 #endif
 
 #ifdef HAVE_COLORIZE_URL


### PR DESCRIPTION
why? the URL colorization is a security feature and shouldn't randomly be missing

compatibility check: curl >= 7.66.0 (from 2019) is available on:
* Ubuntu 22.04 LTS
* Debian 11
* RHEL 9 derivatives 

## To do

This PR is Ready for Review.

