### PR TITLE
Sound: Print lingering sounds when AL is out of ids

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -399,6 +399,10 @@ Call these functions only at load time!
       Negative step will lower the sound volume, positive step will increase
       the sound volume.
     * `gain` the target gain for the fade.
+* `core.debug_print_playing_sounds()`
+    * Logs a list of all currently playing sounds to warningstream.
+    * Only for debugging, don't depend on the output format or existence of this
+      function.
 
 ### Timing
 * `core.after(time, func, ...)`

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -403,6 +403,7 @@ Call these functions only at load time!
     * Logs a list of all currently playing sounds to warningstream.
     * Only for debugging, don't depend on the output format or existence of this
       function.
+    * Requires `debug` privilege.
 
 ### Timing
 * `core.after(time, func, ...)`

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -128,6 +128,11 @@ public:
 			const v3f &vel) = 0;
 
 	/**
+	 * Prints all currently playing sounds, for debugging.
+	 */
+	virtual void printPlayingSounds() = 0;
+
+	/**
 	 * Get and reset the list of sounds that were stopped.
 	 */
 	std::vector<sound_handle_t> pollRemovedSounds()
@@ -173,6 +178,8 @@ public:
 	void stopSound(sound_handle_t sound) override {}
 	void fadeSound(sound_handle_t sound, f32 step, f32 target_gain) override {}
 	void updateSoundPosVel(sound_handle_t sound, const v3f &pos, const v3f &vel) override {}
+
+	void printPlayingSounds() override {}
 };
 
 /**

--- a/src/client/sound/playing_sound.cpp
+++ b/src/client/sound/playing_sound.cpp
@@ -10,6 +10,7 @@
 
 #include "al_extensions.h"
 #include "sound_constants.h"
+#include "porting.h"
 #include <cassert>
 #include <cmath>
 
@@ -19,8 +20,12 @@ PlayingSound::PlayingSound(ALuint source_id, std::shared_ptr<ISoundDataOpen> dat
 		bool loop, f32 volume, f32 pitch, f32 start_time,
 		const std::optional<std::pair<v3f, v3f>> &pos_vel_opt,
 		const ALExtensions &exts [[maybe_unused]])
-	: m_source_id(source_id), m_data(std::move(data)), m_looping(loop),
-	m_is_positional(pos_vel_opt.has_value())
+	:
+	m_source_id(source_id),
+	m_data(std::move(data)),
+	m_looping(loop),
+	m_is_positional(pos_vel_opt.has_value()),
+	m_creation_time_s(porting::getTimeS())
 {
 	// Calculate actual start_time (see lua_api.txt for specs)
 	f32 len_seconds = m_data->m_decode_info.length_seconds;
@@ -260,6 +265,14 @@ void PlayingSound::setPitch(f32 pitch)
 	alSourcef(m_source_id, AL_PITCH, pitch);
 	if (isStreaming())
 		stepStream(true);
+}
+
+std::string PlayingSound::getLoggingName() const
+{
+	if (!m_data)
+		return "<no_data>";
+
+	return m_data->m_decode_info.name_for_logging;
 }
 
 } // namespace sound

--- a/src/client/sound/playing_sound.h
+++ b/src/client/sound/playing_sound.h
@@ -32,6 +32,7 @@ class PlayingSound final
 	bool m_is_positional;
 	bool m_stopped_means_dead = true;
 	std::optional<FadeState> m_fade_state = std::nullopt;
+	u64 m_creation_time_s; // timestamp from porting::getTimeS()
 
 public:
 	PlayingSound(ALuint source_id, std::shared_ptr<ISoundDataOpen> data, bool loop,
@@ -92,6 +93,10 @@ public:
 		if (getState() == AL_PAUSED)
 			play();
 	}
+
+	std::string getLoggingName() const;
+
+	u64 getCreationTimeS() const { return m_creation_time_s; }
 };
 
 } // namespace sound

--- a/src/client/sound/proxy_sound_manager.cpp
+++ b/src/client/sound/proxy_sound_manager.cpp
@@ -149,4 +149,9 @@ void ProxySoundManager::updateSoundPosVel(sound_handle_t sound, const v3f &pos_,
 	send(sound_manager_messages_to_mgr::UpdateSoundPosVel{sound, pos_, vel_});
 }
 
+void ProxySoundManager::printPlayingSounds()
+{
+	send(sound_manager_messages_to_mgr::PrintPlayingSounds{});
+}
+
 } // namespace sound

--- a/src/client/sound/proxy_sound_manager.h
+++ b/src/client/sound/proxy_sound_manager.h
@@ -55,6 +55,8 @@ public:
 	void stopSound(sound_handle_t sound) override;
 	void fadeSound(sound_handle_t soundid, f32 step, f32 target_gain) override;
 	void updateSoundPosVel(sound_handle_t sound, const v3f &pos_, const v3f &vel_) override;
+
+	void printPlayingSounds() override;
 };
 
 } // namespace sound

--- a/src/client/sound/sound_constants.h
+++ b/src/client/sound/sound_constants.h
@@ -95,8 +95,8 @@ constexpr f32 MIN_STREAM_BUFFER_LENGTH = 1.0f;
 constexpr f32 STREAM_BIGSTEP_TIME = 0.3f;
 // step duration for the OpenALSoundManager thread, in seconds
 constexpr f32 SOUNDTHREAD_DTIME = 0.016f;
-// time (in seconds) till lingering sounds may be printed again (for logging)
-constexpr u64 LINGERIN_SOUND_PRINT_INTERVAL = 10;
+// time (in seconds) till playing sounds may be printed again, if rate-limited
+constexpr u64 PLAYING_SOUNDS_PRINT_INTERVAL = 10;
 
 static_assert(SOUND_DURATION_MAX_SINGLE >= MIN_STREAM_BUFFER_LENGTH * 2.0f,
 		"There's no benefit in streaming if we can't queue more than 2 buffers.");

--- a/src/client/sound/sound_constants.h
+++ b/src/client/sound/sound_constants.h
@@ -79,6 +79,8 @@
  *
  */
 
+#include "irrTypes.h"
+
 namespace sound {
 
 // constants
@@ -93,6 +95,8 @@ constexpr f32 MIN_STREAM_BUFFER_LENGTH = 1.0f;
 constexpr f32 STREAM_BIGSTEP_TIME = 0.3f;
 // step duration for the OpenALSoundManager thread, in seconds
 constexpr f32 SOUNDTHREAD_DTIME = 0.016f;
+// time (in seconds) till lingering sounds may be printed again (for logging)
+constexpr u64 LINGERIN_SOUND_PRINT_INTERVAL = 10;
 
 static_assert(SOUND_DURATION_MAX_SINGLE >= MIN_STREAM_BUFFER_LENGTH * 2.0f,
 		"There's no benefit in streaming if we can't queue more than 2 buffers.");

--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -160,8 +160,11 @@ std::shared_ptr<PlayingSound> OpenALSoundManager::createPlayingSound(
 
 	ALuint source_id;
 	alGenSources(1, &source_id);
-	if (warn_if_al_error("createPlayingSound (alGenSources)") != AL_NO_ERROR) {
-		// happens ie. if there are too many sources (out of memory)
+	if (auto err = warn_if_al_error("createPlayingSound (alGenSources)"); err != AL_NO_ERROR) {
+		if (err == AL_OUT_OF_MEMORY) {
+			// this usually means there are too many sources
+			printLingeringPlayingSounds();
+		}
 		return nullptr;
 	}
 
@@ -251,13 +254,70 @@ int OpenALSoundManager::removeDeadSounds()
 	return num_deleted_sounds;
 }
 
+void OpenALSoundManager::printLingeringPlayingSounds()
+{
+	// Do at most every LINGERIN_SOUND_PRINT_INTERVAL seconds
+	u64 tnow_sec = porting::getTimeS();
+	if (m_next_lingering_sounds_print > tnow_sec)
+		return;
+	m_next_lingering_sounds_print = tnow_sec + LINGERIN_SOUND_PRINT_INTERVAL;
+
+	// Count sounds per name
+	struct Agg {
+		uint32_t count = 0;
+		u64 age_oldest; // in seconds
+	};
+	std::unordered_map<std::string, Agg> aggregate;
+
+	for (const auto &[_handle, snd] : m_sounds_playing) {
+		assert(snd);
+		auto &agg = aggregate[snd->getLoggingName()];
+
+		u64 age = tnow_sec - std::min(snd->getCreationTimeS(), tnow_sec);
+		if (agg.count == 0 || agg.age_oldest < age)
+			agg.age_oldest = age;
+
+		agg.count += 1;
+	}
+
+	// Sort
+	struct Row {
+		std::string name;
+		Agg agg;
+	};
+
+	std::vector<Row> rows;
+	rows.reserve(aggregate.size());
+
+	for (auto &[name, agg] : aggregate) {
+		rows.push_back({name, agg});
+	}
+
+	std::sort(rows.begin(), rows.end(),
+		[](const Row &l, const Row &r) {
+			if (l.agg.age_oldest != r.agg.age_oldest)
+				return l.agg.age_oldest > r.agg.age_oldest;
+			return l.agg.count > r.agg.count;
+		});
+
+	// print
+	warningstream << "OpenALSoundManager: "
+			<< "There are "<< m_sounds_playing.size() << " playing sounds:\n"
+			<< "count | age (oldest) | name\n"
+			<< "------|--------------|---------\n";
+	for (const auto &r : rows) {
+		warningstream << r.agg.count << " | " << r.agg.age_oldest << " s | " << r.name << "\n";
+	}
+}
+
 OpenALSoundManager::OpenALSoundManager(SoundManagerSingleton *smg,
 		std::unique_ptr<SoundFallbackPathProvider> fallback_path_provider) :
 	Thread("OpenALSoundManager"),
 	m_fallback_path_provider(std::move(fallback_path_provider)),
 	m_device(smg->m_device.get()),
 	m_context(smg->m_context.get()),
-	m_exts(m_device)
+	m_exts(m_device),
+	m_next_lingering_sounds_print(porting::getTimeS())
 {
 	SANITY_CHECK(!!m_fallback_path_provider);
 

--- a/src/client/sound/sound_manager.cpp
+++ b/src/client/sound/sound_manager.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<PlayingSound> OpenALSoundManager::createPlayingSound(
 	if (auto err = warn_if_al_error("createPlayingSound (alGenSources)"); err != AL_NO_ERROR) {
 		if (err == AL_OUT_OF_MEMORY) {
 			// this usually means there are too many sources
-			printLingeringPlayingSounds();
+			printPlayingSounds(true);
 		}
 		return nullptr;
 	}
@@ -254,13 +254,15 @@ int OpenALSoundManager::removeDeadSounds()
 	return num_deleted_sounds;
 }
 
-void OpenALSoundManager::printLingeringPlayingSounds()
+void OpenALSoundManager::printPlayingSounds(bool rate_limit)
 {
-	// Do at most every LINGERIN_SOUND_PRINT_INTERVAL seconds
+	// Do at most every PLAYING_SOUNDS_PRINT_INTERVAL seconds
 	u64 tnow_sec = porting::getTimeS();
-	if (m_next_lingering_sounds_print > tnow_sec)
-		return;
-	m_next_lingering_sounds_print = tnow_sec + LINGERIN_SOUND_PRINT_INTERVAL;
+	if (rate_limit) {
+		if (m_next_lingering_sounds_print > tnow_sec)
+			return;
+		m_next_lingering_sounds_print = tnow_sec + PLAYING_SOUNDS_PRINT_INTERVAL;
+	}
 
 	// Count sounds per name
 	struct Agg {
@@ -537,6 +539,9 @@ void *OpenALSoundManager::run()
 			mgr.fadeSound(msg.soundid, msg.step, msg.target_gain); return Result::Ok; }
 		Result operator()(UpdateSoundPosVel &&msg) {
 			mgr.updateSoundPosVel(msg.sound, msg.pos_, msg.vel_); return Result::Ok; }
+
+		Result operator()(PrintPlayingSounds &&msg) {
+			mgr.printPlayingSounds(false); return Result::Ok; }
 
 		Result operator()(PleaseStop &&msg) {
 			return Result::StopRequested; }

--- a/src/client/sound/sound_manager.h
+++ b/src/client/sound/sound_manager.h
@@ -64,8 +64,9 @@ private:
 	// if true, all sounds will be directly paused after creation
 	bool m_is_paused = false;
 
-	// used for printing warnings only once
+	// stuff for only-once / rate-limited warnings
 	std::unordered_set<std::string> m_warned_positional_stereo_sounds;
+	u64 m_next_lingering_sounds_print; // timestamp from porting::getTimeS()
 
 public:
 	// used for communication with ProxySoundManager
@@ -114,6 +115,12 @@ private:
 	 * @return Number of removed sounds.
 	 */
 	int removeDeadSounds();
+
+	/**
+	 * Logs names of playing sounds into warningstream.
+	 * Used for diagnosis, i.e. if no new sound sources can be allocated.
+	 */
+	void printLingeringPlayingSounds();
 
 public:
 	OpenALSoundManager(SoundManagerSingleton *smg,

--- a/src/client/sound/sound_manager.h
+++ b/src/client/sound/sound_manager.h
@@ -116,12 +116,6 @@ private:
 	 */
 	int removeDeadSounds();
 
-	/**
-	 * Logs names of playing sounds into warningstream.
-	 * Used for diagnosis, i.e. if no new sound sources can be allocated.
-	 */
-	void printLingeringPlayingSounds();
-
 public:
 	OpenALSoundManager(SoundManagerSingleton *smg,
 			std::unique_ptr<SoundFallbackPathProvider> fallback_path_provider);
@@ -152,6 +146,8 @@ private:
 	void stopSound(sound_handle_t sound);
 	void fadeSound(sound_handle_t soundid, f32 step, f32 target_gain);
 	void updateSoundPosVel(sound_handle_t sound, const v3f &pos_, const v3f &vel_);
+
+	void printPlayingSounds(bool rate_limit);
 
 protected:
 	/* Thread stuff */

--- a/src/client/sound/sound_manager_messages.h
+++ b/src/client/sound/sound_manager_messages.h
@@ -27,6 +27,8 @@ namespace sound_manager_messages_to_mgr {
 	struct FadeSound { sound_handle_t soundid; f32 step; f32 target_gain; };
 	struct UpdateSoundPosVel { sound_handle_t sound; v3f pos_; v3f vel_; };
 
+	struct PrintPlayingSounds{};
+
 	struct PleaseStop {};
 }
 
@@ -48,6 +50,8 @@ using SoundManagerMsgToMgr = std::variant<
 		sound_manager_messages_to_mgr::StopSound,
 		sound_manager_messages_to_mgr::FadeSound,
 		sound_manager_messages_to_mgr::UpdateSoundPosVel,
+
+		sound_manager_messages_to_mgr::PrintPlayingSounds,
 
 		sound_manager_messages_to_mgr::PleaseStop
 	>;

--- a/src/script/lua_api/l_client_sound.cpp
+++ b/src/script/lua_api/l_client_sound.cpp
@@ -55,8 +55,15 @@ int ModApiClientSound::l_sound_play(lua_State *L)
 // debug_print_playing_sounds()
 int ModApiClientSound::l_debug_print_playing_sounds(lua_State *L)
 {
-	ISoundManager *sound_manager = getClient(L)->getSoundManager();
+	Client *client = getClient(L);
 
+	if (!client->checkPrivilege("debug")) {
+		warningstream << "core.debug_print_playing_sounds(): Missing priv: debug"
+				<< std::endl;
+		return 0;
+	}
+
+	ISoundManager *sound_manager = client->getSoundManager();
 	sound_manager->printPlayingSounds();
 
 	return 0;

--- a/src/script/lua_api/l_client_sound.cpp
+++ b/src/script/lua_api/l_client_sound.cpp
@@ -52,9 +52,20 @@ int ModApiClientSound::l_sound_play(lua_State *L)
 	return 1;
 }
 
+// debug_print_playing_sounds()
+int ModApiClientSound::l_debug_print_playing_sounds(lua_State *L)
+{
+	ISoundManager *sound_manager = getClient(L)->getSoundManager();
+
+	sound_manager->printPlayingSounds();
+
+	return 0;
+}
+
 void ModApiClientSound::Initialize(lua_State *L, int top)
 {
 	API_FCT(sound_play);
+	API_FCT(debug_print_playing_sounds);
 }
 
 /* ClientSoundHandle */

--- a/src/script/lua_api/l_client_sound.h
+++ b/src/script/lua_api/l_client_sound.h
@@ -17,6 +17,9 @@ private:
 	// sound_play(spec, parameters)
 	static int l_sound_play(lua_State *L);
 
+	// debug_print_playing_sounds()
+	static int l_debug_print_playing_sounds(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 };


### PR DESCRIPTION
Better diagnosis about what causes `createPlayingSound (alGenSources): out of memory` warnings.
Limited to once per 10 seconds, to avoid log spam.

Should fix #17172, by giving mod authors the tools to fix their leaks.

For future readers: If the warnings says there's only a low number of sounds (by default < 256), or if you can't explain where the lingering sounds come from (i.e. you've made sure in your mod that all sounds should be stopped, but the client still has them), please open an engine.


## To do

This PR is a Ready for Review.

## How to test

* Set the number of sound sources low. Either:
  * `alsoft-config` -> "Resources" tab -> "Number of Sound Sources"
  * In `~/.config/alsoft.conf` (path may differ):
    ```
    [General]
    sources=8
    ```
* In devtest, use the jukebox to play many looping sounds and release them.
* Play more sounds.
* Look at the warnings.

Alternative:
* `.lua core.debug_print_playing_sounds()`

Example output:
```
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: [OpenAL Error] createPlayingSound (alGenSources): out of memory
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: OpenALSoundManager: There are 16 playing sounds:
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: count | age (oldest) | name
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: ------|--------------|---------
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: 15 | 24 s | item_drop_pickup_1.ogg
2026-05-14 17:48:26: WARNING[OpenALSoundManager]: 1 | 17 s | <redacted>/technic_track5.ogg
2026-05-14 17:48:30: WARNING[OpenALSoundManager]: [OpenAL Error] createPlayingSound (alGenSources): out of memory
```
