### PR TITLE
Do not send translation files without a language extension

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2755,10 +2755,11 @@ void Server::sendMediaAnnouncement(session_t peer_id, const std::string &lang_co
 	auto include = [&] (const std::string &name, const MediaInfo &info) -> bool {
 		if (info.no_announce)
 			return false;
-		// Only send translations matching the client's language
-		auto this_lang_code = Translations::getFileLanguage(name);
-		if (!this_lang_code.empty() && this_lang_code != lang_code)
-			return false;
+		if (Translations::isTranslationFileType(name)) {
+			// Only send translations matching the client's language
+			auto this_lang_code = Translations::getFileLanguage(name);
+			return !this_lang_code.empty() && this_lang_code == lang_code;
+		}
 		return true;
 	};
 

--- a/src/test/test_translations.cpp
+++ b/src/test/test_translations.cpp
@@ -24,6 +24,25 @@ static std::string read_translation_file(const std::string &filename)
 
 TEST_CASE("test translations")
 {
+	SECTION("File type detection")
+	{
+		CHECK(Translations::getFileBaseName(TEST_PO_NAME) == "translation_po.de");
+		CHECK(Translations::getFileBaseName("de.po") == "de");
+		CHECK(Translations::getFileBaseName("blank.png") == "");
+
+		CHECK(Translations::getFileLanguage(TEST_PO_NAME) == "de");
+		CHECK(Translations::getFileLanguage("de.po") == "");
+		CHECK(Translations::getFileLanguage("blank.png") == "");
+
+		CHECK(Translations::isTranslationFileType(TEST_PO_NAME));
+		CHECK(Translations::isTranslationFileType("de.po"));
+		CHECK(!Translations::isTranslationFileType("blank.png"));
+
+		CHECK(Translations::isTranslationFile(TEST_PO_NAME));
+		CHECK(!Translations::isTranslationFile("de.po"));
+		CHECK(!Translations::isTranslationFile("blank.png"));
+	}
+
 	SECTION("Plural-Forms function for translations")
 	{
 #define REQUIRE_FORM_SIZE(x) {REQUIRE(form); REQUIRE(form.size() == (x));}

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -17,12 +17,17 @@ Translations *g_client_translations = &client_translations;
 Translations *g_client_translations = nullptr;
 #endif
 
-const std::string_view Translations::getFileLanguage(std::string_view filename)
+const std::string_view Translations::getFileBaseName(std::string_view filename)
 {
 	const char *translate_ext[] = {
 		".tr", ".po", ".mo", NULL
 	};
-	auto basename = removeStringEnd(filename, translate_ext);
+	return removeStringEnd(filename, translate_ext);
+}
+
+const std::string_view Translations::getFileLanguage(std::string_view filename)
+{
+	auto basename = getFileBaseName(filename);
 	auto pos = basename.rfind('.');
 	if (pos == basename.npos)
 		return "";

--- a/src/translation.h
+++ b/src/translation.h
@@ -26,7 +26,12 @@ public:
 	const std::wstring &getPluralTranslation(const std::wstring &textdomain,
 			const std::wstring &s, unsigned long int number) const;
 
+	static const std::string_view getFileBaseName(std::string_view filename);
 	static const std::string_view getFileLanguage(std::string_view filename);
+	static inline bool isTranslationFileType(std::string_view filename)
+	{
+		return !getFileBaseName(filename).empty();
+	}
 	static inline bool isTranslationFile(std::string_view filename)
 	{
 		return !getFileLanguage(filename).empty();

--- a/src/translation.h
+++ b/src/translation.h
@@ -28,10 +28,12 @@ public:
 
 	static const std::string_view getFileBaseName(std::string_view filename);
 	static const std::string_view getFileLanguage(std::string_view filename);
+	// Checks just the file extension
 	static inline bool isTranslationFileType(std::string_view filename)
 	{
 		return !getFileBaseName(filename).empty();
 	}
+	// Checks that the filename includes a language tag
 	static inline bool isTranslationFile(std::string_view filename)
 	{
 		return !getFileLanguage(filename).empty();


### PR DESCRIPTION
Fixes #17026.

This PR is Ready for Review.

## How to test

With Mineclonia:

* Observe that translations still work when using a non-English locale.
* Observe that "Don't know how to load file" errors do not appear.