### PR TITLE
Fix `model[]` formspec element not animating (regression)

### DIFF
--- a/client/shaders/Irrlicht/OneTextureBlend.fsh
+++ b/client/shaders/Irrlicht/OneTextureBlend.fsh
@@ -1,5 +1,3 @@
-#version 100
-
 precision mediump float;
 
 /* Uniforms */

--- a/client/shaders/Irrlicht/Solid.fsh
+++ b/client/shaders/Irrlicht/Solid.fsh
@@ -1,5 +1,3 @@
-#version 100
-
 precision mediump float;
 
 /* Uniforms */

--- a/client/shaders/Irrlicht/Solid.vsh
+++ b/client/shaders/Irrlicht/Solid.vsh
@@ -1,11 +1,14 @@
-#version 100
-
 /* Attributes */
 
 attribute vec3 inVertexPosition;
 attribute vec3 inVertexNormal;
 attribute vec4 inVertexColor_raw;
 attribute vec2 inTexCoord0;
+
+#ifdef USE_SKINNING
+attribute mediump vec4 inVertexWeights;
+attribute mediump uvec4 inVertexJointIDs;
+#endif
 
 /* Uniforms */
 
@@ -15,6 +18,12 @@ uniform mat4 uTMatrix0;
 
 uniform float uThickness;
 
+#ifdef USE_SKINNING
+layout (std140) uniform uJointMatrices {
+	mat4 joints[MAX_JOINTS];
+};
+#endif
+
 /* Varyings */
 
 varying vec2 vTextureCoord0;
@@ -23,7 +32,28 @@ varying float vFogCoord;
 
 void main()
 {
-	gl_Position = uWVPMatrix * vec4(inVertexPosition, 1.0);
+#ifdef USE_SKINNING
+	uvec4 jids = inVertexJointIDs;
+	vec3 skinPos = inVertexPosition;
+	vec3 skinNormal = inVertexNormal;
+	// Alternatively: Introduce neutral bone at index 0 with identity matrix?
+	if (inVertexWeights != vec4(0.0)) {
+		// Note that this deals correctly with a disabled vertex attribute.
+		mat4 mSkin =
+				inVertexWeights.x * joints[jids.x] +
+				inVertexWeights.y * joints[jids.y] +
+				inVertexWeights.z * joints[jids.z] +
+				inVertexWeights.w * joints[jids.w];
+		skinPos = (mSkin * vec4(inVertexPosition, 1.0)).xyz;
+		skinNormal = (mSkin * vec4(inVertexNormal, 0.0)).xyz;
+	}
+#else
+	vec3 skinPos = inVertexPosition;
+	vec3 skinNormal = inVertexNormal;
+#endif
+
+	// TODO why is the normal unused?
+	gl_Position = uWVPMatrix * vec4(skinPos, 1.0);
 	gl_PointSize = uThickness;
 
 	vec4 TextureCoord0 = vec4(inTexCoord0.x, inTexCoord0.y, 1.0, 1.0);
@@ -31,7 +61,7 @@ void main()
 
 	vVertexColor = inVertexColor_raw.bgra;
 
-	vec3 Position = (uWVMatrix * vec4(inVertexPosition, 1.0)).xyz;
+	vec3 WorldPosition = (uWVMatrix * vec4(skinPos.xyz, 1.0)).xyz;
 
-	vFogCoord = length(Position);
+	vFogCoord = length(WorldPosition);
 }

--- a/client/shaders/Irrlicht/TransparentAlphaChannel.fsh
+++ b/client/shaders/Irrlicht/TransparentAlphaChannel.fsh
@@ -1,5 +1,3 @@
-#version 100
-
 precision mediump float;
 
 /* Uniforms */

--- a/client/shaders/Irrlicht/TransparentAlphaChannelRef.fsh
+++ b/client/shaders/Irrlicht/TransparentAlphaChannelRef.fsh
@@ -1,5 +1,3 @@
-#version 100
-
 precision mediump float;
 
 /* Uniforms */

--- a/client/shaders/Irrlicht/TransparentVertexAlpha.fsh
+++ b/client/shaders/Irrlicht/TransparentVertexAlpha.fsh
@@ -1,5 +1,3 @@
-#version 100
-
 precision mediump float;
 
 /* Uniforms */

--- a/irr/include/IFileSystem.h
+++ b/irr/include/IFileSystem.h
@@ -7,6 +7,7 @@
 #include "IReferenceCounted.h"
 #include "IReadFile.h"
 #include "path.h"
+#include "irr_ptr.h"
 
 #include <string>
 #include <optional>
@@ -41,7 +42,7 @@ public:
 
 	std::optional<std::string> readFile(const path &filename)
 	{
-		IReadFile *file = createAndOpenFile(filename);
+		irr_ptr<IReadFile> file(createAndOpenFile(filename));
 		if (!file)
 			return std::nullopt;
 		return file->readAll();

--- a/irr/include/IFileSystem.h
+++ b/irr/include/IFileSystem.h
@@ -5,13 +5,16 @@
 #pragma once
 
 #include "IReferenceCounted.h"
+#include "IReadFile.h"
 #include "path.h"
+
+#include <string>
+#include <optional>
 
 namespace io
 {
 
 class IArchiveLoader;
-class IReadFile;
 class IWriteFile;
 class IFileList;
 
@@ -35,6 +38,14 @@ public:
 	The returned pointer should be dropped when no longer needed.
 	See IReferenceCounted::drop() for more information. */
 	virtual IReadFile *createAndOpenFile(const path &filename) = 0;
+
+	std::optional<std::string> readFile(const path &filename)
+	{
+		IReadFile *file = createAndOpenFile(filename);
+		if (!file)
+			return std::nullopt;
+		return file->readAll();
+	}
 
 	//! Creates an IReadFile interface for accessing memory like a file.
 	/** This allows you to use a pointer to memory where an IReadFile is requested.

--- a/irr/include/IReadFile.h
+++ b/irr/include/IReadFile.h
@@ -8,6 +8,8 @@
 #include "EReadFileType.h"
 #include "path.h"
 
+#include <string>
+
 namespace io
 {
 
@@ -20,6 +22,15 @@ public:
 	\param sizeToRead Amount of bytes to read from the file.
 	\return How many bytes were read. */
 	virtual size_t read(void *buffer, size_t sizeToRead) = 0;
+
+	std::string readAll()
+	{
+		std::string res;
+		const size_t size = getSize();
+		res.resize(size);
+		read(res.data(), size);
+		return res;
+	}
 
 	//! Changes position in file
 	/** \param finalPos Destination position in the file.

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -6,7 +6,10 @@
 
 #include "Driver.h"
 #include <cassert>
+#include <string>
 #include "CNullDriver.h"
+#include "EDriverTypes.h"
+#include "EMaterialTypes.h"
 #include "IContextManager.h"
 
 #include "COpenGLCoreTexture.h"
@@ -15,6 +18,7 @@
 
 #include "HWBuffer.h"
 #include "Common.h"
+#include "IShaderConstantSetCallBack.h"
 #include "WeightBuffer.h"
 #include "MaterialRenderer.h"
 #include "FixedPipelineRenderer.h"
@@ -23,6 +27,7 @@
 #include "EVertexAttributes.h"
 #include "CImage.h"
 #include "IReadFile.h"
+#include "irr_ptr.h"
 #include "matrix4.h"
 #include "os.h"
 
@@ -386,51 +391,66 @@ void COpenGL3DriverBase::loadShaderData(const io::path &vertexShaderName, const 
 
 void COpenGL3DriverBase::createMaterialRenderers()
 {
-	// Create callbacks.
-
-	COpenGL3MaterialSolidCB *SolidCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentAlphaChannelCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentAlphaChannelRefCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialSolidCB *TransparentVertexAlphaCB = new COpenGL3MaterialSolidCB();
-	COpenGL3MaterialOneTextureBlendCB *OneTextureBlendCB = new COpenGL3MaterialOneTextureBlendCB();
-
 	// Create built-in materials.
-	// The addition order must be the same as in the E_MATERIAL_TYPE enumeration. Thus the
+	// The order must be the same as in the E_MATERIAL_TYPE enumeration.
 
-	const core::stringc VertexShader = OGLES2ShaderPath + "Solid.vsh";
+	// TODO consolidate with src/client/shader.cpp
+	const core::stringc vsh_path = OGLES2ShaderPath + "Solid.vsh";
+	const auto vsh_prog_base = FileSystem->readFile(vsh_path);
+	if (!vsh_prog_base) {
+		os::Printer::log("Failed to read vertex shader", vsh_path, ELL_ERROR);
+		return;
+	}
+	std::string vsh_prog_header;
+	std::string sh_version;
+	if (getMaxJointTransforms() > 0) {
+		// c.f. ShaderSource::generateShader in src/client/shader.cpp
+		if (getDriverType() == EDT_OPENGL3) {
+			sh_version = "#version 150\n";
+		} else {
+			sh_version = "#version 300 es\n";
+		}
+		vsh_prog_header += "#define USE_SKINNING 1\n";
+		vsh_prog_header += "#define MAX_JOINTS " + std::to_string(getMaxJointTransforms()) + "\n";
+	} else {
+		sh_version = "#version 100\n";
+	}
+	vsh_prog_header += "#line 0\n";
 
-	// EMT_SOLID
-	core::stringc FragmentShader = OGLES2ShaderPath + "Solid.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "Solid",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, SolidCB, EMT_SOLID, 0);
+	std::string vsh_prog = sh_version + vsh_prog_header + *vsh_prog_base;
 
-	// EMT_TRANSPARENT_ALPHA_CHANNEL
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannel.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentAlphaChannel",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
+	const auto add_shader_material = [&](const E_MATERIAL_TYPE emt,
+			const char *name, IShaderConstantSetCallBack *cb)
+	{
+		irr_ptr<IShaderConstantSetCallBack> cb_dropper(cb);
+		core::stringc fsh_path = OGLES2ShaderPath + name + ".fsh";
+		const auto fsh_prog_base = FileSystem->readFile(fsh_path);
+		if (!fsh_prog_base) {
+			os::Printer::log("Failed to read fragment shader", fsh_path, ELL_ERROR);
+			return;
+		}
+		std::string fsh_prog = sh_version + "#line 0\n" + *fsh_prog_base;
+		addHighLevelShaderMaterial(
+				vsh_prog.data(), fsh_prog.data(), nullptr, name,
+				scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0,
+				cb, emt, 0);
+	};
 
-	// EMT_TRANSPARENT_ALPHA_CHANNEL_REF
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannelRef.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentAlphaChannelRef",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelRefCB, EMT_SOLID, 0);
-
-	// EMT_TRANSPARENT_VERTEX_ALPHA
-	FragmentShader = OGLES2ShaderPath + "TransparentVertexAlpha.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentVertexAlpha",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentVertexAlphaCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
-
-	// EMT_ONETEXTURE_BLEND
-	FragmentShader = OGLES2ShaderPath + "OneTextureBlend.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "OneTextureBlend",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, OneTextureBlendCB, EMT_ONETEXTURE_BLEND, 0);
-
-	// Drop callbacks.
-
-	SolidCB->drop();
-	TransparentAlphaChannelCB->drop();
-	TransparentAlphaChannelRefCB->drop();
-	TransparentVertexAlphaCB->drop();
-	OneTextureBlendCB->drop();
+	add_shader_material(EMT_SOLID,
+			"Solid",
+			new COpenGL3MaterialSolidCB());
+	add_shader_material(EMT_TRANSPARENT_ALPHA_CHANNEL,
+			"TransparentAlphaChannel",
+			new COpenGL3MaterialSolidCB());
+	add_shader_material(EMT_TRANSPARENT_ALPHA_CHANNEL_REF,
+			"TransparentAlphaChannelRef",
+			new COpenGL3MaterialSolidCB());
+	add_shader_material(EMT_TRANSPARENT_VERTEX_ALPHA,
+			"TransparentVertexAlpha",
+			new COpenGL3MaterialSolidCB());
+	add_shader_material(EMT_ONETEXTURE_BLEND,
+			"OneTextureBlend",
+			new COpenGL3MaterialOneTextureBlendCB());
 
 	// Create 2D material renderers
 


### PR DESCRIPTION
Regression from #16721

Irrlicht's own vertex shader doesn't do hardware skinning, and is used for `model[]`.

There would be an alternative way to fix this by falling back to software skinning, but that also wouldn't be pretty, and would result in inconsistent performance characteristics.

Yet another alternative would be to set up our own shader for `model[]`.

Assumption: If disabled, the vertex attributes (and branch) are close to zero cost.

## How to test

Install i3, open inventory, observe that Sam is animated.
