### PR TITLE
amend misleading csm mods.conf enable instructions

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -42,8 +42,8 @@ In order to load client-side mods, the following conditions need to be satisfied
 
 1) `$path_user/minetest.conf` contains the setting `enable_client_modding = true`
 
-2) The client-side mod located in `$path_user/clientmods/<modname>` is added to
-    `$path_user/clientmods/mods.conf` as `load_mod_<modname> = true`.
+2) The client-side mod located in `$path_user/clientmods/<mod location>` is added to
+    `$path_user/clientmods/mods.conf` as `load_mod_<mod.conf name field> = true`.
 
 Note: Depending on the remote server's settings, client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR:
fix deceptive instructions on how to enable a csm in `clientmods/mods.conf`
- How does the PR work?
replaces reference to mod directory in csm enabling instructions with a reference to the `name` field in `mods.conf`
- Does it resolve any reported issue?
the PR *is* the issue, unless asked to create one
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
vaguely tangentially related to sscsm (no)
- If you have used an LLM/AI to help with code or assets, you must disclose this.
none used

## To do

This PR is Ready for Review.

- [x] specify that mods.conf uses the mod name in mod.conf and not the folder name

## How to test

1. get a csm newbie
2. have them read the csm enable instructions
3. see if they can enable a csm with a differing folder name and `mods.conf` name on their 1st try (within reason)