### PR TITLE
[no sq] Fix `model[]` formspec element not animating

### DIFF
--- a/client/shaders/fs_model_shader/opengl_fragment.glsl
+++ b/client/shaders/fs_model_shader/opengl_fragment.glsl
@@ -1,0 +1,17 @@
+uniform sampler2D baseTexture;
+
+VARYING_ vec3 vNormal;
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+void main(void)
+{
+    vec2 uv = varTexCoord.st;
+    vec4 base = texture2D(baseTexture, uv).rgba;
+
+    // Handle transparency by discarding pixel as appropriate.
+    if (base.a == 0.0)
+        discard;
+
+    // TODO use vNormal for directional lighting, c.f. drawItemStack()
+    gl_FragColor = vec4(base.rgb, 1.0);
+}

--- a/client/shaders/fs_model_shader/opengl_vertex.glsl
+++ b/client/shaders/fs_model_shader/opengl_vertex.glsl
@@ -1,0 +1,39 @@
+uniform mat4 mWorld;
+
+VARYING_ vec3 vNormal;
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+#ifdef USE_SKINNING
+layout(std140) uniform JointMatrices {
+    mat4 joints[MAX_JOINTS];
+};
+#endif
+
+void main(void)
+{
+#ifdef USE_SKINNING
+    uvec4 jids = inVertexJointIDs;
+    vec4 skinPos = inVertexPosition;
+    vec3 skinNormal = inVertexNormal;
+    // Alternatively: Introduce neutral bone at index 0 with identity matrix?
+    if (inVertexWeights != vec4(0.0)) {
+        // Note that this deals correctly with a disabled vertex attribute.
+        mat4 mSkin =
+            inVertexWeights.x * joints[jids.x] +
+                inVertexWeights.y * joints[jids.y] +
+                inVertexWeights.z * joints[jids.z] +
+                inVertexWeights.w * joints[jids.w];
+        skinPos = vec4((mSkin * vec4(inVertexPosition.xyz, 1.0)).xyz, 1.0);
+        skinNormal = (mSkin * vec4(inVertexNormal, 0.0)).xyz;
+    }
+#else
+    vec4 skinPos = inVertexPosition;
+    vec3 skinNormal = inVertexNormal;
+#endif
+
+    varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
+
+    gl_Position = mWorldViewProj * skinPos;
+
+    vNormal = (mWorld * vec4(skinNormal, 0.0)).xyz;
+}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -596,8 +596,10 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 				material_type = (m_prop.use_texture_alpha) ?
 					TILE_MATERIAL_PLAIN_ALPHA : TILE_MATERIAL_PLAIN;
 
-			u32 shader_id = shader_source->getShader("object_shader", material_type, NDT_NORMAL,
-				false, hw_skin);
+			ShaderFeatures features;
+			features.skinning = hw_skin;
+			u32 shader_id = shader_source->getShader(
+					"object_shader", material_type, NDT_NORMAL, features);
 			m_material_type = shader_source->getShaderInfo(shader_id).material;
 		} else {
 			// Not used, so make sure it's not valid

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -405,13 +405,17 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 	}
 
 	GetShaderCallback tile_shader = [&] (bool array_texture) {
-		return shdsrc->getShader("nodes_shader", material_type, drawtype, array_texture);
+		ShaderFeatures features;
+		features.array_texture = array_texture;
+		return shdsrc->getShader("nodes_shader", material_type, drawtype, features);
 	};
 
 	MaterialType overlay_material = material_type_with_alpha(material_type);
 
 	GetShaderCallback overlay_shader = [&] (bool array_texture) {
-		return shdsrc->getShader("nodes_shader", overlay_material, drawtype, array_texture);
+		ShaderFeatures features;
+		features.array_texture = array_texture;
+		return shdsrc->getShader("nodes_shader", overlay_material, drawtype, features);
 	};
 
 	// minimap pixel color = average color of top tile
@@ -464,7 +468,9 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 	}
 
 	GetShaderCallback special_shader = [&] (bool array_texture) {
-		return shdsrc->getShader("nodes_shader", special_material, drawtype, array_texture);
+		ShaderFeatures features;
+		features.array_texture = array_texture;
+		return shdsrc->getShader("nodes_shader", special_material, drawtype, features);
 	};
 
 	// Special tiles (fill in f->special_tiles[])

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -874,20 +874,12 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 
 u32 IShaderSource::getShader(const std::string &name,
 	MaterialType material_type, NodeDrawType drawtype,
-	bool array_texture, bool skinning)
+	const ShaderFeatures &features)
 {
 	ShaderConstants input_const;
 	input_const["MATERIAL_TYPE"] = (int)material_type;
 	(void) drawtype; // unused
-	if (array_texture)
-		input_const["USE_ARRAY_TEXTURE"] = 1;
-	if (skinning) {
-		const auto max_joints = RenderingEngine::get_video_driver()->getMaxJointTransforms();
-		if (max_joints > 0) {
-			input_const["USE_SKINNING"] = 1;
-			input_const["MAX_JOINTS"] = max_joints;
-		}
-	}
+	features.setConstants(input_const);
 
 	video::E_MATERIAL_TYPE base_mat = video::EMT_SOLID;
 	switch (material_type) {
@@ -909,6 +901,19 @@ u32 IShaderSource::getShader(const std::string &name,
 	}
 
 	return getShader(name, input_const, base_mat);
+}
+
+void ShaderFeatures::setConstants(ShaderConstants &consts) const
+{
+	if (array_texture)
+		consts["USE_ARRAY_TEXTURE"] = 1;
+	if (skinning) {
+		const auto max_joints = RenderingEngine::get_video_driver()->getMaxJointTransforms();
+		if (max_joints > 0) {
+			consts["USE_SKINNING"] = 1;
+			consts["MAX_JOINTS"] = max_joints;
+		}
+	}
 }
 
 void dumpShaderProgram(std::ostream &os,

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -267,6 +267,8 @@ public:
 		IShaderUniformSetterRC *setter_cb = nullptr) = 0;
 
 	/// @brief Helper: Generates or gets a shader suitable for nodes and entities
+	/// @param skinning Enable hardware skinning support (mesh animation);
+	///                 static meshes will still render as expected.
 	u32 getShader(const std::string &name,
 		MaterialType material_type, NodeDrawType drawtype = NDT_NORMAL,
 		bool array_texture = false, bool skinning = false);

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -227,6 +227,19 @@ using CachedStructPixelShaderSetting = CachedStructShaderSetting<T, count, cache
 	It is uniquely identified by a name, base material and the input constants.
 */
 
+struct ShaderFeatures {
+	/// Enable support for array textures,
+	/// texture indices are expected in the Aux vertex attribute.
+	bool array_texture = false;
+	/// Enable hardware skinning support (mesh animation);
+	/// static meshes will still render as expected.
+	/// Joint transforms are expected in the JointMatrices UBO.
+	/// @see irr::video::IVideoDriver::setJointTransforms
+	bool skinning = false;
+
+	void setConstants(ShaderConstants &consts) const;
+};
+
 struct ShaderInfo {
 	std::string name;
 	video::E_MATERIAL_TYPE base_material = video::EMT_INVALID;
@@ -266,12 +279,10 @@ public:
 		const ShaderConstants &input_const, video::E_MATERIAL_TYPE base_mat,
 		IShaderUniformSetterRC *setter_cb = nullptr) = 0;
 
-	/// @brief Helper: Generates or gets a shader suitable for nodes and entities
-	/// @param skinning Enable hardware skinning support (mesh animation);
-	///                 static meshes will still render as expected.
+	/// Helper: Generates or gets a shader suitable for nodes and entities.
 	u32 getShader(const std::string &name,
 		MaterialType material_type, NodeDrawType drawtype = NDT_NORMAL,
-		bool array_texture = false, bool skinning = false);
+		const ShaderFeatures &features = {});
 
 	/**
 	 * Helper: Generates or gets a shader for common, general use.
@@ -279,11 +290,14 @@ public:
 	 * @param blendAlpha enable alpha blending for this material?
 	 * @return shader ID
 	 */
-	inline u32 getShaderRaw(const std::string &name, bool blendAlpha = false)
+	inline u32 getShaderRaw(const std::string &name, bool blendAlpha = false,
+			const ShaderFeatures &features = {})
 	{
 		auto base_mat = blendAlpha ? video::EMT_TRANSPARENT_ALPHA_CHANNEL :
 			video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-		return getShader(name, ShaderConstants(), base_mat);
+		ShaderConstants consts;
+		features.setConstants(consts);
+		return getShader(name, consts, base_mat);
 	}
 
 	/**

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -151,7 +151,9 @@ void getAdHocNodeShader(video::SMaterial &mat, IShaderSource *shdsrc,
 	if (mat.getTexture(0))
 		array_texture = mat.getTexture(0)->getType() == video::ETT_2D_ARRAY;
 
-	u32 shader_id = shdsrc->getShader(shader, type, NDT_NORMAL, array_texture);
+	ShaderFeatures features;
+	features.array_texture = array_texture;
+	u32 shader_id = shdsrc->getShader(shader, type, NDT_NORMAL, features);
 	mat.MaterialType = shdsrc->getShaderInfo(shader_id).material;
 }
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2832,8 +2832,12 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 
 	core::rect<s32> rect(pos, pos + geom);
 
-	GUIScene *e = new GUIScene(Environment, m_client->getSceneManager(),
-			data->current_parent, rect, spec.fid);
+	GUIScene *e = new GUIScene(Environment,
+			m_client->getSceneManager(),
+			data->current_parent,
+			m_client->getShaderSource(),
+			rect,
+			spec.fid);
 
 	auto meshnode = e->setMesh(mesh);
 	mesh->drop();

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -27,10 +27,9 @@ GUIScene::GUIScene(gui::IGUIEnvironment *env,
 	m_cam = m_smgr->addCameraSceneNode(0, v3f(0.f, 0.f, -100.f), v3f(0.f));
 	m_cam->setFOV(30.f * core::DEGTORAD);
 
-	u32 shader_id = shdsrc->getShader("fs_model_shader",
-			TILE_MATERIAL_ALPHA, // maps to video::EMT_TRANSPARENT_ALPHA_CHANNEL
-			NDT_MESH, // unused
-			false, true);
+	ShaderFeatures features;
+	features.skinning = true;
+	u32 shader_id = shdsrc->getShaderRaw("fs_model_shader", true, features);
 	m_material_type = shdsrc->getShaderInfo(shader_id).material;
 }
 

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -8,11 +8,17 @@
 #include <AnimatedMeshSceneNode.h>
 #include <IVideoDriver.h>
 #include <ISceneManager.h>
+#include "client/shader.h"
+#include "nodedef.h"
 #include "porting.h"
 #include "client/mesh.h"
 
-GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
-		   gui::IGUIElement *parent, core::recti rect, s32 id)
+GUIScene::GUIScene(gui::IGUIEnvironment *env,
+		scene::ISceneManager *smgr,
+		gui::IGUIElement *parent,
+		IShaderSource *shdsrc,
+		core::recti rect,
+		s32 id)
 	: IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rect)
 {
 	m_driver = env->getVideoDriver();
@@ -20,6 +26,12 @@ GUIScene::GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
 
 	m_cam = m_smgr->addCameraSceneNode(0, v3f(0.f, 0.f, -100.f), v3f(0.f));
 	m_cam->setFOV(30.f * core::DEGTORAD);
+
+	u32 shader_id = shdsrc->getShader("fs_model_shader",
+			TILE_MATERIAL_ALPHA, // maps to video::EMT_TRANSPARENT_ALPHA_CHANNEL
+			NDT_MESH, // unused
+			false, true);
+	m_material_type = shdsrc->getShaderInfo(shader_id).material;
 }
 
 GUIScene::~GUIScene()
@@ -49,10 +61,9 @@ scene::AnimatedMeshSceneNode *GUIScene::setMesh(scene::IAnimatedMesh *mesh)
 void GUIScene::setTexture(u32 idx, video::ITexture *texture)
 {
 	video::SMaterial &material = m_mesh->getMaterial(idx);
-	material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	material.MaterialTypeParam = 0.5f;
+	material.MaterialType = m_material_type;
 	material.TextureLayers[0].Texture = texture;
-	material.FogEnable = true;
+	material.FogEnable = false;
 	material.TextureLayers[0].MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 	material.TextureLayers[0].MagFilter = video::ETMAGF_NEAREST;
 	material.BackfaceCulling = false;

--- a/src/gui/guiScene.h
+++ b/src/gui/guiScene.h
@@ -6,16 +6,21 @@
 
 #include "ICameraSceneNode.h"
 #include "StyleSpec.h"
+#include "client/shader.h"
 #include <AnimatedMeshSceneNode.h>
 #include <IGUIElement.h>
 #include <IGUIEnvironment.h>
-
+#include <EMaterialTypes.h>
 
 class GUIScene : public gui::IGUIElement
 {
 public:
-	GUIScene(gui::IGUIEnvironment *env, scene::ISceneManager *smgr,
-		 gui::IGUIElement *parent, core::recti rect, s32 id = -1);
+	GUIScene(gui::IGUIEnvironment *env,
+			scene::ISceneManager *smgr,
+			gui::IGUIElement *parent,
+			IShaderSource *shdsrc,
+			core::recti rect,
+			s32 id = -1);
 
 	~GUIScene();
 
@@ -47,11 +52,13 @@ private:
 	v3f getCameraRotation() const { return (m_cam_pos - m_target_pos).getHorizontalAngle(); };
 	void rotateCamera(const v3f &delta) { setCameraRotation(getCameraRotation() + delta); };
 
-	scene::ISceneManager *m_smgr;
-	video::IVideoDriver *m_driver;
-	scene::ICameraSceneNode *m_cam;
+	scene::ISceneManager *m_smgr = nullptr;
+	video::IVideoDriver *m_driver = nullptr;
+	scene::ICameraSceneNode *m_cam = nullptr;
 	scene::ISceneNode *m_target = nullptr;
 	scene::AnimatedMeshSceneNode *m_mesh = nullptr;
+
+	video::E_MATERIAL_TYPE m_material_type = video::EMT_INVALID;
 
 	f32 m_cam_distance = 50.f;
 


### PR DESCRIPTION
Regression from #16721.

Alternative to #17190.

Test e.g. by using [i3](https://content.luanti.org/packages/mt-mods/i3/). Any animated `model[]` element will do.