### PR TITLE
SSCSM: Add register_on_pointed_update

### DIFF
--- a/builtin/sscsm_client/register.lua
+++ b/builtin/sscsm_client/register.lua
@@ -3,3 +3,4 @@ local builtin_shared = ...
 local make_registration = builtin_shared.make_registration
 
 core.registered_globalsteps, core.register_globalstep = make_registration()
+core.registered_on_pointed_updates, core.register_on_pointed_update = make_registration()

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -50,6 +50,7 @@ Functions that take or return paths always use virtual paths.
 ### Global callbacks
 
 * `core.register_globalstep(function(dtime))`
+* `code.register_on_pointed_update(function(pointed))`
 
 
 ### SSCSM-specific API

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -382,6 +382,7 @@ public:
 	ModStorageDatabase *getModStorageDatabase() override { return m_mod_storage_database; }
 
 	ItemVisualsManager *getItemVisualsManager() { return m_item_visuals_manager; }
+	SSCSMController* getSSCSMController() { return m_sscsm_controller.get(); }
 
 	// Migrates away old files-based mod storage if necessary
 	void migrateModStorage();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -39,6 +39,7 @@
 #include "server.h"
 #include "settings.h"
 #include "shader.h"
+#include "script/sscsm/sscsm_events.h"
 #include "sound_maker.h"
 #include "threading/lambda.h"
 #include "translation.h"
@@ -2717,8 +2718,14 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 			!runData.btn_down_for_dig,
 			camera_offset);
 
-	if (pointed != runData.pointed_old)
+	if (pointed != runData.pointed_old) {
 		infostream << "Pointing at " << pointed.dump() << std::endl;
+
+		// TODO eventually move the selection box update logic
+		// from updatePointedThing to CPSSCSM?
+		auto event = std::make_unique<SSCSMEventOnPointedUpdate>(pointed);
+		client->getSSCSMController()->runEvent(client, std::move(event));
+	}
 
 	if (g_touchcontrols) {
 		auto mode = selected_def.touch_interaction.getMode(selected_def, pointed.type);

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -5,6 +5,7 @@
 #include "s_sscsm.h"
 
 #include "s_internal.h"
+#include "script/common/c_content.h"
 #include "script/sscsm/sscsm_environment.h"
 
 void ScriptApiSSCSM::load_mods(const std::vector<std::pair<std::string, std::string>> &mods)
@@ -25,5 +26,17 @@ void ScriptApiSSCSM::environment_step(float dtime)
 	lua_getfield(L, -1, "registered_globalsteps");
 	// Call callbacks
 	lua_pushnumber(L, dtime);
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+}
+
+void ScriptApiSSCSM::pointed_update(const PointedThing &pointed)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_pointed_updates
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_pointed_updates");
+	// Call callbacks
+	push_pointed_thing(L, pointed, true);
 	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
 }

--- a/src/script/cpp_api/s_sscsm.h
+++ b/src/script/cpp_api/s_sscsm.h
@@ -6,10 +6,14 @@
 
 #include "cpp_api/s_base.h"
 
+struct PointedThing;
+
 class ScriptApiSSCSM : virtual public ScriptApiBase
 {
 public:
 	void load_mods(const std::vector<std::pair<std::string, std::string>> &mods);
 
 	void environment_step(float dtime);
+
+	void pointed_update(const PointedThing &pointed);
 };

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -8,6 +8,7 @@
 #include "debug.h"
 #include "irrlichttypes.h"
 #include "sscsm_environment.h"
+#include "util/pointedthing.h"
 
 struct SSCSMEventTearDown : public ISSCSMEvent
 {
@@ -46,6 +47,18 @@ struct SSCSMEventOnStep : public ISSCSMEvent
 	void exec(SSCSMEnvironment *env) override
 	{
 		env->getScript()->environment_step(dtime);
+	}
+};
+
+struct SSCSMEventOnPointedUpdate : public ISSCSMEvent
+{
+	PointedThing pointed;
+
+	SSCSMEventOnPointedUpdate(const PointedThing &p) : pointed(p) {};
+
+	void exec(SSCSMEnvironment *env) override
+	{
+		env->getScript()->pointed_update(pointed);
 	}
 };
 


### PR DESCRIPTION
With this you can register callbacks on a pointed update in SSCSM.
They get called whenever the pointedthing changes.

### Some possible future usecases
- Change the HUD to display information about the pointed node/object
- Change the selection box, e.g. select a 3x3 area of nodes while wielding the technic mining drill
- Graphical effects like spawning particles on pointing something




## To do

- [ ] Make sure it uses our SSCSM implementation as intended 

## How to test
Put this at the end of `builtin/sscsm_client/init.lua`
``` lua
core.register_on_pointed_update(function(pointed)
	print(dump(pointed))
end)
```
