### PR TITLE
CSM: Don't allow changing unhideable HUD elements

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -812,6 +812,7 @@ Methods:
     * It is discouraged to change foreign HUD elements.
 * `hud_remove(id)`
     * remove the HUD element of the specified id, returns `true` on success
+    * Note: Elements with `hideable = false` cannot be changed or removed by CSM
 * `hud_change(id, stat, value)`
     * change a value of a previously added HUD element
     * element `stat` values: `position`, `name`, `scale`, `text`, `number`, `item`, `dir`

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -372,6 +372,13 @@ int LuaLocalPlayer::l_hud_remove(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 	u32 id = luaL_checkinteger(L, 2);
+
+	{ // CSM is not allowed to tamper with unhideable elements
+		HudElement *element = player->getHud(id);
+		if (element && !element->hideable)
+			return 0;
+	}
+
 	HudElement *element = player->removeHud(id);
 	if (!element)
 		lua_pushboolean(L, false);
@@ -389,7 +396,7 @@ int LuaLocalPlayer::l_hud_change(lua_State *L)
 	u32 id = luaL_checkinteger(L, 2);
 
 	HudElement *element = player->getHud(id);
-	if (!element)
+	if (!element || !element->hideable)
 		return 0;
 
 	HudElementStat stat;


### PR DESCRIPTION
You can still change and remove unhideable HUD elements using CSM.
This PR prevents that.

## To do

Ready for Review.

## How to test

Use the devtest command `/hudunhideable`
And the CSM mod:
``` lua
core.register_chatcommand("hudoff", {
	func = function()
		for id, _ in pairs(core.localplayer:hud_get_all()) do
			core.localplayer:hud_remove(id)
		end
	end
})

core.register_chatcommand("hudoff2", {
	func = function()
		for id, _ in pairs(core.localplayer:hud_get_all()) do
			core.localplayer:hud_change(id, "hideable", true)
		end
	end
})
```
