### PR TITLE
Send detach update before player move

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,6 +418,7 @@ endif()
 # CHECK_CLIENT_BUILD() macro. If you wrongly add something here there will be
 # a compiler error and you need to instead add it to client_SRCS or common_SRCS.
 set(independent_SRCS
+	activeobject.cpp
 	chat.cpp
 	content_nodemeta.cpp
 	convert_json.cpp

--- a/src/activeobject.cpp
+++ b/src/activeobject.cpp
@@ -1,0 +1,14 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+#include "activeobject.h"
+#include "util/serialize.h"
+
+void ActiveObjectMessage::appendTo(std::string &data) const
+{
+	char idbuf[2];
+	writeU16((u8*) idbuf, id);
+	data.append(idbuf, sizeof(idbuf));
+	data.append(serializeString16(datastring));
+}

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -8,6 +8,7 @@
 #include "irr_v3d.h"
 #include <quaternion.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 
@@ -36,6 +37,8 @@ struct ActiveObjectMessage
 		reliable(reliable_),
 		datastring(data_)
 	{}
+
+	void appendTo(std::string &data) const;
 
 	u16 id;
 	bool reliable;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -965,12 +965,7 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 
 						// Add full new data to appropriate buffer
 						std::string &buffer = aom.reliable ? reliable_data : unreliable_data;
-						char idbuf[2];
-						writeU16((u8*) idbuf, aom.id);
-						// u16 id
-						// std::string data
-						buffer.append(idbuf, sizeof(idbuf));
-						buffer.append(serializeString16(aom.datastring));
+						aom.appendTo(buffer);
 					}
 				}
 				/*
@@ -2095,7 +2090,15 @@ void Server::SendPlayerBreath(PlayerSAO *sao)
 
 void Server::SendMovePlayer(PlayerSAO *sao)
 {
-	// Send attachment updates instantly to the client prior updating position
+	// Send attachment updates instantly to the client prior updating position.
+	// The update is still queued below for normal delivery to other observers.
+	if (sao->isAttachmentOutdated() && !sao->isAttached()) {
+		std::string data;
+		ActiveObjectMessage aom(
+				sao->getId(), true, sao->generateUpdateAttachmentCommand());
+		aom.appendTo(data);
+		SendActiveObjectMessages(sao->getPeerID(), data);
+	}
 	sao->sendOutdatedData();
 
 	NetworkPacket pkt(TOCLIENT_MOVE_PLAYER, sizeof(v3f) + sizeof(f32) * 2, sao->getPeerID());

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2091,7 +2091,6 @@ void Server::SendPlayerBreath(PlayerSAO *sao)
 void Server::SendMovePlayer(PlayerSAO *sao)
 {
 	// Send attachment updates instantly to the client prior updating position.
-	// The update is still queued below for normal delivery to other observers.
 	if (sao->isAttachmentOutdated() && !sao->isAttached()) {
 		std::string data;
 		ActiveObjectMessage aom(
@@ -2099,7 +2098,6 @@ void Server::SendMovePlayer(PlayerSAO *sao)
 		aom.appendTo(data);
 		SendActiveObjectMessages(sao->getPeerID(), data);
 	}
-	sao->sendOutdatedData();
 
 	NetworkPacket pkt(TOCLIENT_MOVE_PLAYER, sizeof(v3f) + sizeof(f32) * 2, sao->getPeerID());
 	pkt << sao->getBasePosition() << sao->getLookPitch() << sao->getRotation().Y;

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -77,6 +77,7 @@ public:
 	// Object properties
 	ObjectProperties *accessObjectProperties() override;
 	void notifyObjectPropertiesModified() override;
+	bool isAttachmentOutdated() const { return !m_attachment_sent; }
 	void sendOutdatedData();
 
 	// Update packets


### PR DESCRIPTION
## Summary
- send a pending attachment update directly to the moving player before `TOCLIENT_MOVE_PLAYER`
- let attachment updates for other observers use the normal active-object message path
- avoid sending the early object message before the player object is known by that client

Fixes #12092.

## Testing
- `git diff --check`

I could not run the CMake build or the multiplayer reproduction locally because this environment does not have CMake/build tools installed.
