### PR TITLE
IrrlichtMt: Fix MSVC and MinGW compiler warnings

### DIFF
--- a/irr/include/AnimatedMeshSceneNode.h
+++ b/irr/include/AnimatedMeshSceneNode.h
@@ -192,7 +192,7 @@ private:
 		std::vector<irr_ptr<BoneSceneNode>> SceneNodes;
 		std::vector<core::matrix4> GlobalMatrices;
 		std::vector<std::optional<core::Transform>> PreTransSaves;
-		void setN(u16 n) {
+		void setN(size_t n) {
 			SceneNodes.clear();
 			SceneNodes.resize(n);
 			GlobalMatrices.clear();

--- a/irr/include/WeightBuffer.h
+++ b/irr/include/WeightBuffer.h
@@ -54,7 +54,7 @@ struct WeightBuffer final : public HWBuffer
 	{ return HWBuffer::Type::WEIGHT; }
 
 	u32 getCount() const override
-	{ return weights.size(); }
+	{ return (u32)weights.size(); }
 
 	u32 getElementSize() const override
 	{ return sizeof(VertexWeights); }

--- a/irr/src/AnimatedMeshSceneNode.cpp
+++ b/irr/src/AnimatedMeshSceneNode.cpp
@@ -539,7 +539,7 @@ void AnimatedMeshSceneNode::addJoints()
 		assert(parent);
 		const auto *matrix = std::get_if<core::matrix4>(&joint->transform);
 		PerJoint.SceneNodes.push_back(irr_ptr<BoneSceneNode>(new BoneSceneNode(
-				parent, SceneManager, 0, i, joint->Name,
+				parent, SceneManager, 0, (u32)i, joint->Name,
 				matrix ? core::Transform{} : std::get<core::Transform>(joint->transform),
 				matrix ? *matrix : std::optional<core::matrix4>{})));
 	}

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -116,7 +116,7 @@ void CFileSystem::addArchiveLoader(IArchiveLoader *loader)
 //! Returns the total number of archive loaders added.
 u32 CFileSystem::getArchiveLoaderCount() const
 {
-	return ArchiveLoader.size();
+	return (u32)ArchiveLoader.size();
 }
 
 //! Gets the archive loader by index.

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -239,7 +239,7 @@ T SelfType::Accessor<T>::get(std::size_t i) const
 	// We differ slightly from glTF here in that
 	// we default-initialize quaternions and matrices properly,
 	// but this does not cause any discrepancies for valid glTF models.
-	(void)std::get<std::tuple<>>(source);
+	assert(std::holds_alternative<std::tuple<>>(source));
 	return T();
 }
 

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -239,7 +239,7 @@ T SelfType::Accessor<T>::get(std::size_t i) const
 	// We differ slightly from glTF here in that
 	// we default-initialize quaternions and matrices properly,
 	// but this does not cause any discrepancies for valid glTF models.
-	std::get<std::tuple<>>(source);
+	(void)std::get<std::tuple<>>(source);
 	return T();
 }
 

--- a/irr/src/CGUIButton.cpp
+++ b/irr/src/CGUIButton.cpp
@@ -290,7 +290,7 @@ void CGUIButton::drawSprite(EGUI_BUTTON_STATE state, u32 startTime, const core::
 	core::rect<s32> srcRect = SpriteBank->getPositions()[rectIdx];
 
 	IGUISkin *skin = Environment->getSkin();
-	s32 scale = std::max(std::floor(skin->getScale()), 1.0f);
+	s32 scale = std::max((s32)skin->getScale(), 1);
 	core::rect<s32> rect(center, srcRect.getSize() * scale);
 	rect -= rect.getSize() / 2;
 

--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -398,10 +398,10 @@ bool CGUIEditBox::processKey(const SEvent &event)
 
 				// This is a "good enough" approximation
 				u32 lineHeight = font->getDimension(L"A").Height + font->getKerning(L'A').Y;
-				f32 linesMax = WINDOW_SCROLL_FACTOR *
-					AbsoluteClippingRect.getHeight() / (f32)lineHeight;
+				u32 linesMax = (u32)std::roundf(WINDOW_SCROLL_FACTOR *
+					AbsoluteClippingRect.getHeight() / (f32)lineHeight);
 
-				if (!onKeyUpDown(event.KeyInput, newMarkBegin, newMarkEnd, linesMax + 0.5f)) {
+				if (!onKeyUpDown(event.KeyInput, newMarkBegin, newMarkEnd, linesMax)) {
 					return false;
 				}
 			}
@@ -553,7 +553,7 @@ bool CGUIEditBox::onKeyUpDown(const SEvent::SKeyInput &input, s32 &mark_begin,
 		}
 
 		s32 offset = new_pos - BrokenTextPositions[lineNo];
-		size_t next_len = BrokenText[lineNo + dir].size();
+		s32 next_len = (s32)BrokenText[lineNo + dir].size();
 		// Try to go to the same position in the next line, or clamp.
 		new_pos = BrokenTextPositions[lineNo + dir] +
 			std::max<s32>(0, std::min<s32>(offset, next_len));
@@ -1016,7 +1016,7 @@ bool CGUIEditBox::processMouse(const SEvent &event)
 				newMarkEnd = CursorPos;
 
 			const bool is_alnum = std::iswalnum(
-				Text[std::min<size_t>(CursorPos, Text.size() - 1)]
+				Text[std::min<s32>(CursorPos, (s32)Text.size() - 1)]
 			);
 			for (; newMarkEnd < (s32)Text.size(); ++newMarkEnd) {
 				if (!!std::iswalnum(Text[newMarkEnd]) != is_alnum)
@@ -1101,7 +1101,7 @@ bool CGUIEditBox::processMouse(const SEvent &event)
 		if (VScrollBar && VScrollBar->isVisible()) {
 			s32 pos = VScrollBar->getTargetPos();
 			s32 step = VScrollBar->getSmallStep();
-			VScrollBar->setPosInterpolated(pos - event.MouseInput.Wheel * step);
+			VScrollBar->setPosInterpolated(pos - s32(event.MouseInput.Wheel * step));
 			return true;
 		}
 		break;

--- a/irr/src/CGUIScrollBar.cpp
+++ b/irr/src/CGUIScrollBar.cpp
@@ -243,7 +243,7 @@ void CGUIScrollBar::setArrowsVisible(ArrowVisibility visible)
 //!
 s32 CGUIScrollBar::getPosFromMousePos(const core::position2di &pos) const
 {
-	f32 w, // tray width (size minus all buttons)
+	s32 w, // tray width (size minus all buttons)
 		p; // clicked position relative to the scrollbar
 
 	s32 occupied = 2 * BorderSize + DrawHeight;
@@ -258,7 +258,7 @@ s32 CGUIScrollBar::getPosFromMousePos(const core::position2di &pos) const
 		w = RelativeRect.getHeight() - occupied;
 		p = pos.Y - AbsoluteRect.UpperLeftCorner.Y - occupied / 2 - offset;
 	}
-	return (s32)(p / w * range()) + Min;
+	return (s32)(p * range() / w) + Min;
 }
 
 void CGUIScrollBar::updatePos()
@@ -281,8 +281,8 @@ void CGUIScrollBar::setPosRaw(const s32 pos)
 
 	if (PageSize >= 0) {
 		// Auto-scaling
-		DrawHeight = std::min<s32>(INT32_MAX,
-				thumb_area * (f32(thumb_area + BorderSize * 2)) / f32(PageSize));
+		DrawHeight = std::min<s32>(INT32_MAX, s32(
+				thumb_area * f32(thumb_area + BorderSize * 2) / f32(PageSize)));
 	}
 
 	DrawHeight = core::s32_clamp(DrawHeight, thumb_min, thumb_area);

--- a/irr/src/COpenGLCoreTexture.h
+++ b/irr/src/COpenGLCoreTexture.h
@@ -105,10 +105,10 @@ public:
 
 		TEST_GL_ERROR(Driver);
 
-		initTexture((u32)tmpImages->size());
+		initTexture(tmpImages->size());
 
 		if (Type == ETT_2D_ARRAY) {
-			upload2DArrayTexture((u32)tmpImages->size(), tmpImages->data());
+			upload2DArrayTexture(tmpImages->size(), tmpImages->data());
 		} else {
 			for (size_t i = 0; i < tmpImages->size(); ++i)
 				uploadTexture((u32)i, 0, (*tmpImages)[i]->getData());
@@ -527,7 +527,7 @@ protected:
 		}
 	}
 
-	void initTexture(u32 layers)
+	void initTexture(size_t layers)
 	{
 		// Compressed textures cannot be pre-allocated and are initialized on upload
 		if (IImage::isCompressedFormat(ColorFormat)) {
@@ -670,7 +670,7 @@ protected:
 		}
 	}
 
-	void upload2DArrayTexture(const u32 layers, video::IImage *const *images)
+	void upload2DArrayTexture(const size_t layers, video::IImage *const *images)
 	{
 		if (!layers)
 			return;
@@ -682,7 +682,7 @@ protected:
 		assert(TextureType == GL_TEXTURE_2D_ARRAY);
 
 		const u32 imageBytes = IImage::getDataSizeFromFormat(ColorFormat, width, height);
-		constexpr u32 MAX_TMP_BUFFER = 16 * 1024 * 1024;
+		constexpr size_t MAX_TMP_BUFFER = 16 * 1024 * 1024;
 
 		// Uploading small textures layer-by-layer can apparently be very slow.
 		// Maybe a PBO would be cleaner here but copying to a temporary buffer
@@ -699,7 +699,7 @@ protected:
 			tmpBuffer.clear();
 		};
 		CImage *tmpImage = nullptr;
-		for (u32 i = 0; i < layers; i++) {
+		for (size_t i = 0; i < layers; i++) {
 			u8 *data;
 			if (Converter) {
 				// this may look redundant but CImage does special alignment

--- a/irr/src/COpenGLCoreTexture.h
+++ b/irr/src/COpenGLCoreTexture.h
@@ -105,13 +105,13 @@ public:
 
 		TEST_GL_ERROR(Driver);
 
-		initTexture(tmpImages->size());
+		initTexture((u32)tmpImages->size());
 
 		if (Type == ETT_2D_ARRAY) {
-			upload2DArrayTexture(tmpImages->size(), tmpImages->data());
+			upload2DArrayTexture((u32)tmpImages->size(), tmpImages->data());
 		} else {
 			for (size_t i = 0; i < tmpImages->size(); ++i)
-				uploadTexture(i, 0, (*tmpImages)[i]->getData());
+				uploadTexture((u32)i, 0, (*tmpImages)[i]->getData());
 		}
 
 		if (HasMipMaps) {
@@ -692,7 +692,7 @@ protected:
 		u32 layerOffset = 0;
 		const auto &uploadMultiple = [&] () {
 			assert(tmpBuffer.size() % imageBytes == 0);
-			size_t curLayers = tmpBuffer.size() / imageBytes;
+			u32 curLayers = u32(tmpBuffer.size() / imageBytes);
 			assert(curLayers > 0);
 			GL.TexSubImage3D(TextureType, 0, 0, 0, layerOffset, width, height, curLayers, PixelFormat, PixelType, tmpBuffer.data());
 			layerOffset += curLayers;

--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -209,7 +209,8 @@ bool CZipReader::scanZipHeader(bool ignoreGPBits)
 	// move forward length of data
 	File->seek(entry.header.DataDescriptor.CompressedSize, true);
 
-	addItem(ZipFileName, entry.Offset, entry.header.DataDescriptor.UncompressedSize, ZipFileName.lastChar() == '/', FileInfo.size());
+	addItem(ZipFileName, entry.Offset, entry.header.DataDescriptor.UncompressedSize,
+			ZipFileName.lastChar() == '/', (u32)FileInfo.size());
 	FileInfo.push_back(entry);
 
 	return true;

--- a/irr/src/OpenGL/MaterialRenderer.cpp
+++ b/irr/src/OpenGL/MaterialRenderer.cpp
@@ -115,7 +115,7 @@ void COpenGL3MaterialRenderer::init(s32 &outMaterialTypeNr,
 		if (!createShader(GL_FRAGMENT_SHADER, pixelShaderProgram))
 			return;
 
-	for (size_t i = 0; i < EVA_COUNT; ++i)
+	for (u32 i = 0; i < EVA_COUNT; ++i)
 		GL.BindAttribLocation(Program, i, sBuiltInVertexAttributeNames[i]);
 
 	if (!linkProgram())


### PR DESCRIPTION
Fixes a few compiler warnings as seen here:

* MSVC: https://github.com/luanti-org/luanti/actions/runs/26627255199/job/78466921448#step:5:180
* MinGW: https://github.com/luanti-org/luanti/actions/runs/26627255199/job/78466921233#step:4:1137

I did *not* address issues in the GLTF loader (and relatives) as they are subject to change by other feature PRs.

## To do

This PR is Ready for Review.

## How to test

1. The changes must look good
2. It must compile
