### PR TITLE
NetworkPacket: Unify 'getString' uses

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -254,11 +254,11 @@ void Client::handleCommand_AddNode(NetworkPacket* pkt)
 	v3s16 p;
 	*pkt >> p;
 
-	auto *ptr = reinterpret_cast<const u8*>(pkt->getRemainingString());
+	std::string_view str = pkt->getRemainingNoCopy();
 	pkt->skip(MapNode::serializedLength(m_server_ser_ver)); // performs length check
 
 	MapNode n;
-	n.deSerialize(ptr, m_server_ser_ver);
+	n.deSerialize((const u8 *)str.data(), m_server_ser_ver);
 
 	bool keep_metadata;
 	*pkt >> keep_metadata;
@@ -301,8 +301,7 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 	v3s16 p;
 	*pkt >> p;
 
-	std::string datastring(pkt->getRemainingString(), pkt->getRemainingBytes());
-	std::istringstream istr(datastring, std::ios_base::binary);
+	std::istringstream istr(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 
 	MapSector *sector;
 	MapBlock *block;
@@ -350,7 +349,7 @@ void Client::handleCommand_Inventory(NetworkPacket* pkt)
 		datastring = pkt->readLongString();
 		*pkt >> m_skip_next_wield_animation;
 	} else {
-		datastring = std::string(pkt->getString(0), pkt->getSize());
+		datastring = pkt->getRemainingNoCopy();
 	}
 
 	std::istringstream is(datastring, std::ios_base::binary);
@@ -476,8 +475,7 @@ void Client::handleCommand_ActiveObjectMessages(NetworkPacket* pkt)
 			string message
 		}
 	*/
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 
 	while (canRead(is)) {
 		u16 id = readU16(is);
@@ -957,8 +955,7 @@ void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
 	// this used to be the length of the following string, ignore it
 	pkt->skip(2);
 
-	std::string contents(pkt->getRemainingString(), pkt->getRemainingBytes());
-	std::istringstream is(contents, std::ios::binary);
+	std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios::binary);
 	inv->deSerialize(is);
 }
 
@@ -980,8 +977,7 @@ void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
 
 void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 {
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 
 	ParticleParameters p;
 	p.deSerialize(is, m_proto_ver);
@@ -1018,8 +1014,7 @@ void Client::handleCommand_SpawnParticleBatch(NetworkPacket *pkt)
 
 void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 {
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 
 	ParticleSpawnerParameters p;
 	u32 server_id;
@@ -1366,8 +1361,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	if (m_proto_ver < 39) {
 		// Handle Protocol 38 and below servers with old set_sky,
 		// ensuring the classic look is kept.
-		std::string datastring(pkt->getString(0), pkt->getSize());
-		std::istringstream is(datastring, std::ios_base::binary);
+		std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 
 		SkyboxParams skybox;
 		skybox.bgcolor = video::SColor(readARGB8(is));

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -45,11 +45,13 @@ void NetworkPacket::clear()
 	m_peer_id = 0;
 }
 
-const char* NetworkPacket::getString(u32 from_offset) const
+std::string_view NetworkPacket::getRemainingNoCopy() const
 {
-	checkReadOffset(from_offset, 0);
+	size_t len = getRemainingBytes();
+	if (len == 0)
+		return "";
 
-	return reinterpret_cast<const char*>(&m_data[from_offset]);
+	return std::string_view(reinterpret_cast<const char*>(&m_data[m_read_offset]), len);
 }
 
 void NetworkPacket::skip(u32 count)

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -54,10 +54,10 @@ std::string_view NetworkPacket::getRemainingNoCopy() const
 	return std::string_view(reinterpret_cast<const char*>(&m_data[m_read_offset]), len);
 }
 
-void NetworkPacket::skip(u32 count)
+void NetworkPacket::seek(u32 offset)
 {
-	checkReadOffset(m_read_offset, count);
-	m_read_offset += count;
+	checkReadOffset(offset, 0);
+	m_read_offset = offset;
 }
 
 void NetworkPacket::putRawString(const char* src, u32 len)

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -7,15 +7,17 @@
 #include "util/serialize.h"
 #include "networkprotocol.h"
 
-void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size) const
+u32 NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size) const
 {
-	if (from_offset + field_size > m_datasize) {
+	u32 sum = from_offset + field_size;
+	if (sum > m_datasize || sum < field_size /* overflow? */) {
 		std::ostringstream ss;
 		ss << "Reading outside packet: cmd=" << getCommand()
 			<< " offset=" << from_offset
 			<< " size=" << getSize();
 		throw PacketError(ss.str());
 	}
+	return sum;
 }
 
 void NetworkPacket::putRawPacket(const u8 *data, u32 datasize, session_t peer_id)
@@ -52,12 +54,6 @@ std::string_view NetworkPacket::getRemainingNoCopy() const
 		return "";
 
 	return std::string_view(reinterpret_cast<const char*>(&m_data[m_read_offset]), len);
-}
-
-void NetworkPacket::seek(u32 offset)
-{
-	checkReadOffset(offset, 0);
-	m_read_offset = offset;
 }
 
 void NetworkPacket::putRawString(const char* src, u32 len)

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -43,10 +43,8 @@ public:
 	u32 getRemainingBytes() const { return m_datasize - m_read_offset; }
 	inline bool hasRemainingBytes() const { return getRemainingBytes() != 0; }
 
-	// Returns a pointer to buffer data.
-	// A better name for this would be getRawString()
-	const char *getString(u32 from_offset) const;
-	const char *getRemainingString() const { return getString(m_read_offset); }
+	//! Does not advance the data read offset!
+	std::string_view getRemainingNoCopy() const;
 
 	// Perform length check and skip ahead by `count` bytes.
 	void skip(u32 count);

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -47,7 +47,9 @@ public:
 	std::string_view getRemainingNoCopy() const;
 
 	// Perform length check and skip ahead by `count` bytes.
-	void skip(u32 count);
+	inline void skip(u32 count) { seek(m_read_offset + count); }
+	//! Sets the read OR write offset (context-dependent)
+	void seek(u32 position);
 
 	// Appends bytes from string buffer to packet
 	void putRawString(const char *src, u32 len);

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -47,9 +47,13 @@ public:
 	std::string_view getRemainingNoCopy() const;
 
 	// Perform length check and skip ahead by `count` bytes.
-	inline void skip(u32 count) { seek(m_read_offset + count); }
+	inline void skip(u32 count) {
+		m_read_offset = checkReadOffset(m_read_offset, count);
+	}
 	//! Sets the read OR write offset (context-dependent)
-	void seek(u32 position);
+	inline void seek(u32 position) {
+		m_read_offset = checkReadOffset(position, 0);
+	}
 
 	// Appends bytes from string buffer to packet
 	void putRawString(const char *src, u32 len);
@@ -128,7 +132,8 @@ public:
 	Buffer<u8> oldForgePacket();
 
 private:
-	void checkReadOffset(u32 from_offset, u32 field_size) const;
+	/// Returns `from_offset + field_size` on success
+	u32 checkReadOffset(u32 from_offset, u32 field_size) const;
 
 	// resize data buffer for writing
 	inline void checkDataSize(u32 field_size)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -583,8 +583,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	}
 
 	// Strip command and create a stream
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	std::istringstream is(std::string(pkt->getRemainingNoCopy()), std::ios_base::binary);
 	// Create an action
 	std::unique_ptr<InventoryAction> a(InventoryAction::deSerialize(is));
 	if (!a) {

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -287,10 +287,16 @@ void TestConnection::testConnectSendReceive()
 	*/
 	{
 		const int datasize = 30000;
+
 		NetworkPacket pkt(0xff, datasize);
 		for (u16 i=0; i<datasize; i++) {
 			pkt << static_cast<u8>(i/4);
 		}
+		// NOTE: There is only one offset counter, hence reset it before reading.
+		pkt.seek(0);
+
+		std::string_view raw = pkt.getRemainingNoCopy();
+		UASSERTEQ(size_t, raw.size(), datasize);
 
 		infostream << "Sending data (size=" << datasize << "):";
 		for (int i = 0; i < datasize && i < 20; i++) {
@@ -298,7 +304,7 @@ void TestConnection::testConnectSendReceive()
 				infostream << " ";
 			char buf[10];
 			porting::mt_snprintf(buf, sizeof(buf), "%.2X",
-				((int)(pkt.getRemainingNoCopy()[i])) & 0xff);
+				((int)raw[i]) & 0xff);
 			infostream<<buf;
 		}
 		if (datasize > 20)

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -96,6 +96,13 @@ void TestConnection::testNetworkPacketSerialize()
 		pkt >> pkt_s;
 
 		UASSERT(pkt_s == L"\U00020b9a");
+
+		// Test for out-of-range reads
+		UASSERT(pkt.getRemainingBytes() == 0);
+		EXCEPTION_CHECK(PacketError, pkt.readLongString());
+		EXCEPTION_CHECK(PacketError, pkt.skip((u32)-1));
+		pkt.seek(0);
+		UASSERTEQ(u32, pkt.getRemainingBytes(), sizeof(expected) - 2 /* u16 command */);
 	}
 }
 

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -273,7 +273,7 @@ void TestConnection::testConnectSendReceive()
 		UASSERT(server.ReceiveTimeoutMs(&recvpacket, timeout_ms));
 		infostream << "** Server received: peer_id=" << pkt.getPeerId()
 				<< ", size=" << pkt.getSize()
-				<< ", data=" << pkt.getString(0)
+				<< ", data=" << pkt.getRemainingNoCopy()
 				<< std::endl;
 
 		auto recvdata = pkt.oldForgePacket();
@@ -298,7 +298,7 @@ void TestConnection::testConnectSendReceive()
 				infostream << " ";
 			char buf[10];
 			porting::mt_snprintf(buf, sizeof(buf), "%.2X",
-				((int)(pkt.getString(0))[i]) & 0xff);
+				((int)(pkt.getRemainingNoCopy()[i])) & 0xff);
 			infostream<<buf;
 		}
 		if (datasize > 20)


### PR DESCRIPTION
This replaces separate pointer + length getters with 'std::string_view'.

Also fixes an issue where reading an empty `NetworkPacket` could cause unexpected behaviour.

## To do

This PR is Ready for Review.

## How to test

1. Check the code
2. Join singleplayer, place nodes
3. `--test-module TestConnection` must pass