### PR TITLE
Add support for mesh items

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -56,6 +56,7 @@ core.features = {
 	get_modnames_load_order = true,
 	set_camera_resettable = true,
 	hud_hideable_field = true,
+	mesh_items = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6152,6 +6152,8 @@ Utilities
       set_camera_resettable = true,
       -- The HUD element field `hideable` exists (5.17.0)
       hud_hideable_field = true,
+      -- Item definitions support mesh item visuals (5.17.0)
+      mesh_items = true,
   }
   ```
 
@@ -10274,16 +10276,27 @@ Used by `core.register_node`, `core.register_craftitem`, and
     --      {bendy = 2, snappy = 1},
     --      {hard = 1, metal = 1, spikes = 1}
 
+    mesh = "",
+    -- Mesh model to use for non-node inventory, wield, and dropped item visuals.
+    -- Requires `textures` to be set.
+    -- `inventory_image` and `wield_image` override the mesh where they apply.
+    -- For nodes, `mesh` is used by the node drawtype instead.
+
+    textures = {},
+    -- Textures applied to the mesh materials in order.
+    -- If there are fewer textures than materials, the last texture is reused.
+
     inventory_image = <Item image definition>,
     -- Image shown in the inventory GUI
-    -- Defaults to a 3D rendering of the node if left empty.
+    -- Defaults to the mesh item visual, or a 3D rendering of the node, if left empty.
 
     inventory_overlay = <Item image definition>,
     -- An overlay image which is not affected by colorization
 
     wield_image = <Item image definition>,
     -- Image shown when item is held in hand
-    -- Defaults to a 3D rendering of the node if left empty.
+    -- Defaults to the mesh item visual, `inventory_image`, or a 3D rendering
+    -- of the node if left empty.
 
     wield_overlay = <Item image definition>,
     -- Like inventory_overlay but only used in the same situation as wield_image

--- a/games/devtest/mods/gltf/init.lua
+++ b/games/devtest/mods/gltf/init.lua
@@ -18,6 +18,11 @@ do
 	register_entity("blender_cube", cube_textures)
 	register_entity("blender_cube_scaled", cube_textures)
 	register_entity("blender_cube_matrix_transform", cube_textures)
+	core.register_craftitem("gltf:blender_cube_item", {
+		description = "glTF mesh item",
+		mesh = "gltf_blender_cube.gltf",
+		textures = cube_textures,
+	})
 	core.register_entity("gltf:blender_cube_glb", {
 		initial_properties = {
 			visual = "mesh",

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -18,6 +18,7 @@
 #include "client/texturesource.h"
 #include "util/numeric.h"
 #include <map>
+#include <IAnimatedMesh.h>
 #include <IMeshManipulator.h>
 #include "client/renderingengine.h"
 #include <SMesh.h>
@@ -27,6 +28,7 @@
 
 #define WIELD_SCALE_FACTOR 30.0f
 #define WIELD_SCALE_FACTOR_EXTRUDED 40.0f
+#define WIELD_SCALE_FACTOR_MESH 5.0f
 
 #define MIN_EXTRUSION_MESH_RESOLUTION 16
 #define MAX_EXTRUSION_MESH_RESOLUTION 512
@@ -134,6 +136,71 @@ static video::ITexture *extractTexture(const TileDef &def, const TileLayer &laye
 		return tsrc->getTextureForMesh(def.name);
 
 	return fallback ? tsrc->getTextureForMesh("no_texture.png") : nullptr;
+}
+
+static scene::SMesh *createMeshItemMesh(Client *client, const ItemDefinition &def,
+		const char *shader_name, bool inventory_filters,
+		std::vector<ItemMeshBufferInfo> *buffer_info)
+{
+	if (def.mesh.empty())
+		return nullptr;
+
+	scene::IAnimatedMesh *animated_mesh = client->getMesh(def.mesh);
+	if (!animated_mesh) {
+		errorstream << "createMeshItemMesh(): Mesh not found: \""
+				<< def.mesh << "\"" << std::endl;
+		return nullptr;
+	}
+
+	scene::SMesh *mesh = cloneStaticMesh(animated_mesh);
+	if (!mesh) {
+		animated_mesh->drop();
+		return nullptr;
+	}
+
+	ITextureSource *tsrc = client->getTextureSource();
+	IShaderSource *shdsrc = client->getShaderSource();
+	u32 shader_id = shdsrc->getShader(shader_name, TILE_MATERIAL_BASIC, NDT_NORMAL);
+	video::E_MATERIAL_TYPE material_type = shdsrc->getShaderInfo(shader_id).material;
+
+	for (u32 i = 0; i < mesh->getMeshBufferCount(); ++i) {
+		scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
+		video::SMaterial &material = buf->getMaterial();
+
+		std::string texture_name = "no_texture.png";
+		if (!def.textures.empty()) {
+			size_t texture_index = animated_mesh->getTextureSlot(i);
+			if (texture_index >= def.textures.size())
+				texture_index = def.textures.size() - 1;
+			if (!def.textures[texture_index].empty())
+				texture_name = def.textures[texture_index];
+		}
+
+		material.setTexture(0, tsrc->getTextureForMesh(texture_name));
+		material.MaterialType = material_type;
+		material.MaterialTypeParam = 0.5f;
+		material.BackfaceCulling = true;
+		if (inventory_filters) {
+			material.forEachTexture([] (auto &tex) {
+				tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
+				tex.MagFilter = video::ETMAGF_NEAREST;
+			});
+		} else {
+			bool bilinear = g_settings->getBool("bilinear_filter");
+			bool trilinear = g_settings->getBool("trilinear_filter");
+			bool anisotropic = g_settings->getBool("anisotropic_filter");
+			material.forEachTexture([=] (auto &tex) {
+				setMaterialFilters(tex, bilinear, trilinear, anisotropic);
+			});
+		}
+
+		if (buffer_info)
+			buffer_info->emplace_back(0);
+	}
+
+	mesh->recalculateBoundingBox();
+	animated_mesh->drop();
+	return mesh;
 }
 
 void getAdHocNodeShader(video::SMaterial &mat, IShaderSource *shdsrc,
@@ -490,6 +557,20 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		return;
 	}
 
+	if (def.type != ITEM_NODE && !def.mesh.empty()) {
+		mesh = createMeshItemMesh(client, def, "object_shader", false, &m_buffer_info);
+		if (mesh) {
+			changeToMesh(mesh);
+			mesh->drop();
+			m_meshnode->setScale(wield_scale * WIELD_SCALE_FACTOR_MESH);
+		} else {
+			setExtruded(tsrc->getTexture("no_texture.png"), nullptr, wield_scale);
+			m_buffer_info.emplace_back(0);
+		}
+		setColor(video::SColor(0xFFFFFFFF));
+		return;
+	}
+
 	// Handle nodes
 	if (def.type == ITEM_NODE) {
 		switch (f.drawtype) {
@@ -670,6 +751,18 @@ void createItemMesh(Client *client, const ItemDefinition &def,
 		// overlay is white, if present
 		result->buffer_info.emplace_back(1, &animation_overlay,
 				true, video::SColor(0xFFFFFFFF));
+	} else if (def.type != ITEM_NODE && !def.mesh.empty()) {
+		mesh = createMeshItemMesh(client, def, "inventory_shader", true,
+				&result->buffer_info);
+		if (mesh) {
+			scaleMesh(mesh, def.wield_scale * 0.12f);
+			rotateMeshXZby(mesh, -45);
+			rotateMeshYZby(mesh, -30);
+			result->needs_shading = true;
+		} else {
+			mesh = getExtrudedMesh(tsrc->getTexture("no_texture.png"));
+			result->buffer_info.emplace_back(0);
+		}
 	} else if (def.type == ITEM_NODE && f.drawtype == NDT_AIRLIKE) {
 		// Fallback image for airlike node
 		mesh = getExtrudedMesh(tsrc->getTexture("no_texture_airlike.png"),

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -120,6 +120,8 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	name = def.name;
 	description = def.description;
 	short_description = def.short_description;
+	mesh = def.mesh;
+	textures = def.textures;
 	inventory_image = def.inventory_image;
 	inventory_overlay = def.inventory_overlay;
 	wield_image = def.wield_image;
@@ -166,6 +168,8 @@ void ItemDefinition::reset()
 	name.clear();
 	description.clear();
 	short_description.clear();
+	mesh.clear();
+	textures.clear();
 	inventory_image.reset();
 	inventory_overlay.reset();
 	wield_image.reset();
@@ -267,6 +271,12 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	} else {
 		writeU8(os, 0);
 	}
+
+	os << serializeString16(mesh);
+	u16 texture_count = textures.size() > 65535 ? 65535 : static_cast<u16>(textures.size());
+	writeU16(os, texture_count);
+	for (u16 i = 0; i < texture_count; ++i)
+		os << serializeString16(textures[i]);
 }
 
 void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
@@ -368,8 +378,22 @@ void ItemDefinition::deSerialize(std::istream &is, u16 protocol_version)
 		if (readU8(is)) // "have wear bar params"
 			wear_bar_params = WearBarParams::deserialize(is);
 
-		//if (!canRead(is))
-		//	break;
+		if (!canRead(is))
+			break;
+
+		mesh = deSerializeString16(is);
+
+		if (!canRead(is))
+			break;
+
+		u16 texture_count = readU16(is);
+		textures.clear();
+		textures.reserve(texture_count);
+		for (u16 i = 0; i < texture_count; ++i)
+			textures.emplace_back(deSerializeString16(is));
+
+		// if (!canRead(is))
+		// 	break;
 		// Add new code here
 	} while (0);
 }

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -7,6 +7,7 @@
 
 #include "irrlichttypes_bloated.h"
 #include <string>
+#include <vector>
 #include <iostream>
 #include <optional>
 #include <set>
@@ -92,9 +93,11 @@ struct ItemDefinition
 	/*
 		Visual properties
 	*/
+	std::string mesh; // Optional mesh model for inventory, wield and dropped item visuals
+	std::vector<std::string> textures; // Mesh textures, in mesh material order
 	ItemImageDef inventory_image; // Optional for nodes, mandatory for tools/craftitems
 	ItemImageDef inventory_overlay; // Overlay of inventory_image.
-	ItemImageDef wield_image; // If empty, inventory_image or mesh (only nodes) is used
+	ItemImageDef wield_image; // If empty, inventory_image, mesh, or node mesh is used
 	ItemImageDef wield_overlay; // Overlay of wield_image.
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -74,6 +74,7 @@ void read_item_definition(lua_State *L, int index,
 
 	getstringfield(L, index, "description", def.description);
 	getstringfield(L, index, "short_description", def.short_description);
+	getstringfield(L, index, "mesh", def.mesh);
 
 	lua_getfield(L, index, "inventory_image");
 	def.inventory_image = read_item_image_definition(L, -1);
@@ -89,6 +90,27 @@ void read_item_definition(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	getstringfield(L, index, "palette", def.palette_image);
+
+	lua_getfield(L, index, "textures");
+	if (lua_istable(L, -1)) {
+		def.textures.clear();
+		LuaHelper::for_ipairs(L, -1, [&]() {
+			int type = lua_type(L, -1);
+			if (type == LUA_TSTRING) {
+				def.textures.emplace_back(lua_tostring(L, -1));
+			} else {
+				script_log_unique(L, std::string("Item textures must be strings, got ") +
+						lua_typename(L, type), warningstream);
+				def.textures.emplace_back("");
+			}
+		});
+	}
+	lua_pop(L, 1);
+
+	if (def.type == ITEM_NODE) {
+		def.mesh.clear();
+		def.textures.clear();
+	}
 
 	// Read item color.
 	lua_getfield(L, index, "color");
@@ -228,6 +250,19 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	}
 	lua_pushstring(L, type.c_str());
 	lua_setfield(L, -2, "type");
+	if (!i.mesh.empty()) {
+		lua_pushstring(L, i.mesh.c_str());
+		lua_setfield(L, -2, "mesh");
+	}
+	if (!i.textures.empty()) {
+		lua_createtable(L, i.textures.size(), 0);
+		int idx = 1;
+		for (const std::string &texture : i.textures) {
+			lua_pushlstring(L, texture.c_str(), texture.size());
+			lua_rawseti(L, -2, idx++);
+		}
+		lua_setfield(L, -2, "textures");
+	}
 	push_item_image_definition(L, i.inventory_image);
 	lua_setfield(L, -2, "inventory_image");
 	push_item_image_definition(L, i.inventory_overlay);


### PR DESCRIPTION
## Summary
- add `mesh` and `textures` item definition fields for non-node items
- render mesh items in inventories, wielded hands, and dropped item visuals
- add a devtest glTF mesh craftitem for manual verification

Closes #3551.

## Notes
- `inventory_image` and `wield_image` keep their existing precedence.
- Node definitions keep using `mesh` for node drawtypes; mesh item visuals are constrained to non-node items to avoid changing existing mesh-node rendering.

## Testing
- `git diff --check`
- Not run: local compile, because `cmake`, `ninja`, and MSVC `cl` are not installed in this environment.