### PR TITLE
Add raw deflate compression method

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -56,6 +56,7 @@ core.features = {
 	get_modnames_load_order = true,
 	set_camera_resettable = true,
 	hud_hideable_field = true,
+	compress_raw_deflate = true,
 }
 
 function core.has_feature(arg)

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -554,10 +554,12 @@ Call these functions only at load time!
     * `method` is a string identifying the compression method to be used.
     * Supported compression methods:
         * Deflate (zlib): `"deflate"`
+        * Deflate (raw): `"raw_deflate"`
         * Zstandard: `"zstd"`
     * `...` indicates method-specific arguments. Currently defined arguments
       are:
         * Deflate: `level` - Compression level, `0`-`9` or `nil`.
+          Supported by `"deflate"` and `"raw_deflate"`.
         * Zstandard: `level` - Compression level. Integer or `nil`. Default `3`.
         Note any supported Zstandard compression level could be used here,
         but these are subject to change between Zstandard versions.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6152,6 +6152,8 @@ Utilities
       set_camera_resettable = true,
       -- The HUD element field `hideable` exists (5.17.0)
       hud_hideable_field = true,
+      -- "raw_deflate" method for compress/decompress (5.17.0)
+      compress_raw_deflate = true,
   }
   ```
 
@@ -8047,10 +8049,12 @@ Misc.
     * `method` is a string identifying the compression method to be used.
     * Supported compression methods:
         * Deflate (zlib): `"deflate"`
+        * Deflate (raw): `"raw_deflate"`
         * Zstandard: `"zstd"`
     * `...` indicates method-specific arguments. Currently defined arguments
       are:
         * Deflate: `level` - Compression level, integer in range [0, 9] or `nil`.
+          Supported by `"deflate"` and `"raw_deflate"`.
         * Zstandard: `level` - Compression level. Integer or `nil`. Default `3`.
         Note any supported Zstandard compression level could be used here,
         but these are subject to change between Zstandard versions.

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -119,6 +119,7 @@ local function test_compress()
 	local text = "The\000 icey canoe couldn't move very well on the\128 lake. The\000 ice was too stiff and the icey canoe's paddles simply wouldn't punch through."
 	local methods = {
 		"deflate",
+		"raw_deflate",
 		"zstd",
 		-- "noodle", -- for warning alarm test
 	}

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -312,12 +312,14 @@ int ModApiUtil::l_get_user_path(lua_State *L)
 enum LuaCompressMethod
 {
 	LUA_COMPRESS_METHOD_DEFLATE,
+	LUA_COMPRESS_METHOD_RAW_DEFLATE,
 	LUA_COMPRESS_METHOD_ZSTD,
 };
 
 static const struct EnumString es_LuaCompressMethod[] =
 {
 	{LUA_COMPRESS_METHOD_DEFLATE, "deflate"},
+	{LUA_COMPRESS_METHOD_RAW_DEFLATE, "raw_deflate"},
 	{LUA_COMPRESS_METHOD_ZSTD, "zstd"},
 	{0, nullptr},
 };
@@ -348,12 +350,13 @@ int ModApiUtil::l_compress(lua_State *L)
 
 	std::ostringstream os(std::ios_base::binary);
 
-	if (method == LUA_COMPRESS_METHOD_DEFLATE) {
+	if (method == LUA_COMPRESS_METHOD_DEFLATE ||
+			method == LUA_COMPRESS_METHOD_RAW_DEFLATE) {
 		int level = -1;
 		if (!lua_isnoneornil(L, 3))
 			level = readParam<int>(L, 3);
 
-		compressZlib(data, os, level);
+		compressZlib(data, os, level, method == LUA_COMPRESS_METHOD_RAW_DEFLATE);
 	} else if (method == LUA_COMPRESS_METHOD_ZSTD) {
 		int level = ZSTD_CLEVEL_DEFAULT;
 		if (!lua_isnoneornil(L, 3))
@@ -381,8 +384,9 @@ int ModApiUtil::l_decompress(lua_State *L)
 	std::istringstream is(std::string(data), std::ios_base::binary);
 	std::ostringstream os(std::ios_base::binary);
 
-	if (method == LUA_COMPRESS_METHOD_DEFLATE) {
-		decompressZlib(is, os);
+	if (method == LUA_COMPRESS_METHOD_DEFLATE ||
+			method == LUA_COMPRESS_METHOD_RAW_DEFLATE) {
+		decompressZlib(is, os, 0, method == LUA_COMPRESS_METHOD_RAW_DEFLATE);
 	} else if (method == LUA_COMPRESS_METHOD_ZSTD) {
 		decompressZstd(is, os);
 	}

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -10,6 +10,8 @@
 #include <zstd.h>
 #include <memory>
 
+constexpr int DEFAULT_WBITS = 15; // window size: 2^DEFAULT_WBITS
+
 /* report a zlib or i/o error */
 static void zerr(int ret)
 {
@@ -49,7 +51,7 @@ private:
 	z_stream *ptr_;
 };
 
-void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level)
+void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level, bool raw)
 {
 	z_stream z;
 	const s32 bufsize = 16384;
@@ -61,7 +63,9 @@ void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level)
 	z.zfree = Z_NULL;
 	z.opaque = Z_NULL;
 
-	ret = deflateInit(&z, level);
+	ret = deflateInit2(&z, level, Z_DEFLATED,
+		raw ? -DEFAULT_WBITS : DEFAULT_WBITS,
+		8, Z_DEFAULT_STRATEGY);
 	if(ret != Z_OK)
 		throw SerializationError("compressZlib: deflateInit failed");
 
@@ -92,7 +96,7 @@ void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level)
 	}
 }
 
-void decompressZlib(std::istream &is, std::ostream &os, size_t limit)
+void decompressZlib(std::istream &is, std::ostream &os, size_t limit, bool raw)
 {
 	z_stream z;
 	const s32 bufsize = 16384;
@@ -107,7 +111,7 @@ void decompressZlib(std::istream &is, std::ostream &os, size_t limit)
 	z.zfree = Z_NULL;
 	z.opaque = Z_NULL;
 
-	ret = inflateInit(&z);
+	ret = inflateInit2(&z, raw ? -DEFAULT_WBITS : DEFAULT_WBITS);
 	if(ret != Z_OK)
 		throw SerializationError("dcompressZlib: inflateInit failed");
 
@@ -365,5 +369,3 @@ void decompress(std::istream &is, std::ostream &os, u8 version)
 			break;
 	}
 }
-
-

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -77,12 +77,12 @@ inline bool ser_ver_supported_write(s32 v)
 	Compression functions
 */
 
-void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level = -1);
-inline void compressZlib(std::string_view data, std::ostream &os, int level = -1)
+void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level = -1, bool raw = false);
+inline void compressZlib(std::string_view data, std::ostream &os, int level = -1, bool raw = false)
 {
-	compressZlib(reinterpret_cast<const u8*>(data.data()), data.size(), os, level);
+	compressZlib(reinterpret_cast<const u8*>(data.data()), data.size(), os, level, raw);
 }
-void decompressZlib(std::istream &is, std::ostream &os, size_t limit = 0);
+void decompressZlib(std::istream &is, std::ostream &os, size_t limit = 0, bool raw = false);
 
 void compressZstd(const u8 *data, size_t data_size, std::ostream &os, int level = 0);
 inline void compressZstd(std::string_view data, std::ostream &os, int level = 0)

--- a/src/unittest/test_compression.cpp
+++ b/src/unittest/test_compression.cpp
@@ -20,6 +20,7 @@ public:
 
 	void testRLECompression();
 	void testZlibCompression();
+	void testRawDeflateCompression();
 	void testZlibLargeData();
 	void testZstdLargeData();
 	void testZlibLimit();
@@ -32,6 +33,7 @@ void TestCompression::runTests(IGameDef *gamedef)
 {
 	TEST(testRLECompression);
 	TEST(testZlibCompression);
+	TEST(testRawDeflateCompression);
 	TEST(testZlibLargeData);
 	TEST(testZstdLargeData);
 	TEST(testZlibLimit);
@@ -122,6 +124,25 @@ void TestCompression::testZlibCompression()
 
 	for (u32 i = 0; i < str_out2.size(); i++)
 		UASSERT(str_out2[i] == fromdata[i]);
+}
+
+void TestCompression::testRawDeflateCompression()
+{
+	const std::string data_in = "raw deflate data can be embedded in other formats";
+
+	std::ostringstream os_compressed(std::ios::binary);
+	compressZlib(data_in, os_compressed, -1, true);
+	std::string compressed = os_compressed.str();
+
+	std::istringstream is_compressed(compressed, std::ios::binary);
+	std::ostringstream os_decompressed(std::ios::binary);
+	decompressZlib(is_compressed, os_decompressed, 0, true);
+
+	UASSERTEQ(std::string, os_decompressed.str(), data_in);
+
+	std::istringstream is_wrapped(compressed, std::ios::binary);
+	std::ostringstream os_wrapped(std::ios::binary);
+	EXCEPTION_CHECK(SerializationError, decompressZlib(is_wrapped, os_wrapped));
 }
 
 void TestCompression::testZlibLargeData()
@@ -254,4 +275,3 @@ void TestCompression::_testZlibLimit(u32 size, u32 limit)
 				i, str_decompressed[i], i, data_in[i]);
 	}
 }
-


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR: add support for raw DEFLATE streams in `core.compress` and `core.decompress`.
- How does the PR work? Adds a new `"raw_deflate"` compression method which reuses the existing zlib helpers with negative `windowBits`, while keeping existing `"deflate"` behavior as zlib-wrapped data for compatibility.
- Does it resolve any reported issue? Resolves #16894.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)? Not directly.
- If not a bug fix, why is this PR needed? It allows mods to read/write raw DEFLATE payloads such as those embedded in formats that do their own wrapping/checksums.
- If you have used an LLM/AI to help with code or assets, you must disclose this. I used Codex to help implement and test this patch.

## To do

Ready for Review.

## How to test

Tested locally on macOS with a server-only `RUN_IN_PLACE=TRUE` build:

- `git diff --check`
- `cmake -S . -B build-luanti -G Ninja -DRUN_IN_PLACE=TRUE -DBUILD_UNITTESTS=TRUE -DBUILD_CLIENT=FALSE -DBUILD_SERVER=TRUE -DZSTD_INCLUDE_DIR=/tmp/luanti-zstd-build/zstd-1.5.7/lib -DZSTD_LIBRARY=/tmp/luanti-zstd-build/zstd-1.5.7/lib/libzstd.a`
- `cmake --build build-luanti --target luantiserver -j$(sysctl -n hw.ncpu)`
- `./bin/luantiserver --run-unittests`
- `./bin/luantiserver --run-unittests --test-module TestCompression`

The devtest Lua compression test was updated as well, but I did not run `util/test_singleplayer.sh`/`util/test_multiplayer.sh` locally because this verification build was server-only and did not produce `bin/luanti`.
