### PR TITLE
Document world.mt metadata usage

### DIFF
--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -164,7 +164,7 @@ content. The convention is `<modname>.<setting>`.
     auth_backend = sqlite3        - which DB backend to use for authentication data
     mod_storage_backend = sqlite3 - which DB backend to use for mod storage
     load_mod_<mod> = false        - whether <mod> is to be loaded in this world
-    blocksize = 32                - mapblock size, only written by non-standard builds
+    blocksize = 32                - mapblock size, only written if it's non-standard (16)
 
 For `load_mod_<mod>`, the possible values are:
 

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -143,10 +143,14 @@ See [Player File Format](#player-file-format) below.
 World metadata. This file is created and updated by Luanti when creating a
 world, changing per-world settings in the main menu, configuring world mods, or
 migrating database backends. It is not a per-world `minetest.conf` replacement,
-and is not usually meant to be edited by hand.
+Worlds launched from the main menu using managed ContentDB content usually do
+not require manual edits. Headless servers, advanced settings, custom mod paths,
+and database migrations may require editing this file directly.
 
 Games and mods may store their own settings in this file too. Such settings are
 not documented here; see the documentation for the game or mod that owns them.
+Custom keys should be namespaced to avoid conflicts with Luanti and other
+content. The convention is `<modname>.<setting>`.
 
     gameid = mesetint             - name of the game
     world_name = Sol III          - name of the world (if not set, the world folder name will be used)

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -140,20 +140,27 @@ See [Player File Format](#player-file-format) below.
 
 ## `world.mt`
 
-World metadata.
+World metadata. This file is created and updated by Luanti when creating a
+world, changing per-world settings in the main menu, configuring world mods, or
+migrating database backends. It is not a per-world `minetest.conf` replacement,
+and is not usually meant to be edited by hand.
+
+Games and mods may store their own settings in this file too. Such settings are
+not documented here; see the documentation for the game or mod that owns them.
 
     gameid = mesetint             - name of the game
+    world_name = Sol III          - name of the world (if not set, the world folder name will be used)
+                                    shown in the main menu and used as a technical identifier
     enable_damage = true          - whether damage is enabled or not
     creative_mode = false         - whether creative mode is enabled or not
+    server_announce = false       - whether the server is publicly announced or not
     backend = sqlite3             - which DB backend to use for blocks (sqlite3, dummy, leveldb, redis, postgresql)
     player_backend = sqlite3      - which DB backend to use for player data
     readonly_backend = sqlite3    - optionally read-only seed DB (DB file _must_ be located in "readonly" subfolder)
-    auth_backend = files          - which DB backend to use for authentication data
+    auth_backend = sqlite3        - which DB backend to use for authentication data
     mod_storage_backend = sqlite3 - which DB backend to use for mod storage
-    server_announce = false       - whether the server is publicly announced or not
     load_mod_<mod> = false        - whether <mod> is to be loaded in this world
-    world_name = Sol III          - name of the world (if not set, the world folder name will be used)
-                                    shown in the main menu and used as a technical identifier
+    blocksize = 32                - mapblock size, only written by non-standard builds
 
 For `load_mod_<mod>`, the possible values are:
 


### PR DESCRIPTION
## Summary
- clarify that `world.mt` is Luanti-managed world metadata, not a per-world `minetest.conf`
- document that games and mods may store additional settings there
- keep the existing table closer to current world creation defaults by listing `world_name` prominently and using `auth_backend = sqlite3`
- document the non-standard-build `blocksize` key

Fixes #16448.

## Verification
- `git diff --check`
- `./bin/luantiserver --run-unittests` (`0 / 44` failed modules, `0 / 317` failed individual tests)

## AI disclosure
I used Codex to help inspect the issue/code paths, edit the documentation, and run verification.
