### PR TITLE
networkpacket: Include m_command in checkReadOffset

### DIFF
--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -13,7 +13,8 @@ void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size) const
 		std::ostringstream ss;
 		ss << "Reading outside packet: cmd=" << getCommand()
 			<< " offset=" << from_offset
-			<< " size=" << getSize();
+			<< " size=" << getSize()
+		    << " command" << m_command;
 		throw PacketError(ss.str());
 	}
 }


### PR DESCRIPTION
I'm doing some rust experiments for a server implementation. I found that tiny change that would help a bit when we have network read issues.

## To do

Ready for Review.

## How to test

<!-- Example code or instructions -->

Here is my testing

`Some exception: "Reading outside packet (offset: 0, packet size: 4, command = 42)"`