### PR TITLE
Fix client crash in l_get_armor_groups

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -801,6 +801,7 @@ Methods:
 
 * `get_armor_groups()`
     * returns a table with the armor group ratings
+    * It can return `nil` if the player CAO is not yet initialized.
 * `hud_add(definition)`
     * add a HUD element described by HUD def, returns ID number on success and `nil` on failure.
     * See [`HUD definition`](#hud-definition-hud_add-hud_get)

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -346,6 +346,8 @@ int LuaLocalPlayer::l_get_movement(lua_State *L)
 int LuaLocalPlayer::l_get_armor_groups(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
+	if (!player->getCAO())
+		return 0;
 	push_groups(L, player->getCAO()->getGroups());
 	return 1;
 }


### PR DESCRIPTION
If CAO is not initialized on startup (ie: server very slow on connection and packets are not in order), client can crash when calling this Lua call

## How to test

<!-- Example code or instructions -->

If server don't send this information for a reason (mostly in unittesting scenario, but in very bad connection shape also), client can crash when calling this. We cannot make assumption that CAO is always here. That permits also to think about headless client without CAO
