### PR TITLE
Disable Visual Scale For Unsupported Drawtypes: Attempt 2.

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10515,6 +10515,7 @@ Used by `core.register_node`.
     -- node. For torchlike, the image will start at the surface to which the
     -- node "attaches". For the other drawtypes the image will be centered
     -- on the node.
+    -- note: Do not set a visual_scale != 1.0 for drawtypes that don't support it.
 
     tiles = {tile definition 1, def2, def3, def4, def5, def6},
     -- Textures of node; +Y, -Y, +X, -X, +Z, -Z

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -754,7 +754,7 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 				<< " has unknown drawtype \"" << str << '"' << std::endl;
 	}
 
-	getfloatfield(L, index, "visual_scale", f.visual_scale);'
+	getfloatfield(L, index, "visual_scale", f.visual_scale);
 
 	if (f.visual_scale != 1.0f &&
 			(f.drawtype != NDT_PLANTLIKE &&

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -754,7 +754,22 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 				<< " has unknown drawtype \"" << str << '"' << std::endl;
 	}
 
-	getfloatfield(L, index, "visual_scale", f.visual_scale);
+	getfloatfield(L, index, "visual_scale", f.visual_scale);'
+
+	if (f.visual_scale != 1.0f &&
+			(f.drawtype != NDT_PLANTLIKE &&
+			f.drawtype != NDT_SIGNLIKE &&
+			f.drawtype != NDT_TORCHLIKE &&
+			f.drawtype != NDT_FIRELIKE &&
+			f.drawtype != NDT_MESH &&
+			f.drawtype != NDT_NODEBOX &&
+			f.drawtype != NDT_ALLFACES)) {
+		warningstream << "Node " << f.name
+				<< " specifies visual_scale, but the selected drawtype does not support it."
+				<< std::endl;
+
+		f.visual_scale = 1.0f;
+	}
 
 	/* Meshnode model filename */
 	getstringfield(L, index, "mesh", f.mesh);


### PR DESCRIPTION
- Goal of the PR

Ensure that visual scale works properly. (And better than the last pr)
- How does the PR work?

Updates the Lua Api to add a note about not using visual scale with unsupported drawtypes as well as restricts unsupported drawtypes to always have a visual scale of 1.0
- Does it resolve any reported issue?

Closes #17227
- If you have used an LLM/AI to help with code or assets, you must disclose this.

I have not used an LLM.

## To do

Ready for Review.

## How to test.

Attempt to set visual scale to a number != 1 on an unsupported drawtype.
Look at the logs and make sure it gives an error, also make sure that supported drawtypes do not give errors.

<img width="1920" height="1008" alt="screenshot_20260605_172145" src="https://github.com/user-attachments/assets/ae32b5fb-5431-49f4-9263-9f990fefebd4" />

## Additional Notes.

The previous pr actually caused a regression due to a logic error. I used "OR" logic when I should've used "AND".
We can discuss additions to the "supported" drawtypes list??
Replacement for #17242 