### PR TITLE
Add binary cache for shaders in OpenGL backend

### DIFF
--- a/irr/include/IFileSystem.h
+++ b/irr/include/IFileSystem.h
@@ -153,6 +153,11 @@ public:
 	/** \param filename is the string identifying the file which should be tested for existence.
 	\return True if file exists, and false if it does not exist or an error occurred. */
 	virtual bool existFile(const path &filename) const = 0;
+
+	//! Deletes a file from the file system.
+	/** \param filename is the string identifying the file which should be deleted.
+	\return True if file was deleted, and false if it could not be deleted or an error occurred. */
+	virtual bool deleteFile(const path &filename) = 0;
 };
 
 } // end namespace io

--- a/irr/include/IFileSystem.h
+++ b/irr/include/IFileSystem.h
@@ -158,6 +158,11 @@ public:
 	/** \param filename is the string identifying the file which should be deleted.
 	\return True if file was deleted, and false if it could not be deleted or an error occurred. */
 	virtual bool deleteFile(const path &filename) = 0;
+
+	//! Create a directory.
+	/** \param directory is the string identifying the directory which should be created.
+	\return True if directory was created, and false if it could not be created or an error occurred. */
+	virtual bool createDirectory(const path &directory) = 0;
 };
 
 } // end namespace io

--- a/irr/include/IFileSystem.h
+++ b/irr/include/IFileSystem.h
@@ -163,6 +163,11 @@ public:
 	/** \param directory is the string identifying the directory which should be created.
 	\return True if directory was created, and false if it could not be created or an error occurred. */
 	virtual bool createDirectory(const path &directory) = 0;
+
+	//! Determines if a path exists and is specifically a directory.
+	/** \param filename is the string identifying the path which should be tested for existence.
+	\return True if path exists and is a directory, and false if it does not exist, is not a directory, or an error occurred. */
+	virtual bool existDirectory(const path &filename) const = 0;
 };
 
 } // end namespace io

--- a/irr/include/SIrrCreationParameters.h
+++ b/irr/include/SIrrCreationParameters.h
@@ -43,6 +43,7 @@ struct SIrrlichtCreationParameters
 #endif
 			PrivateData(0),
 			OGLES2ShaderPath("SHADER_PATH_WAS_NOT_SET"),
+			ShaderCachePath(""),
 			DriverDebug(false)
 	{
 	}
@@ -219,6 +220,9 @@ struct SIrrlichtCreationParameters
 	/** This is about the shaders which can be found in media/Shaders by default. It's only necessary
 	to set when using OGL-ES 2.0 */
 	io::path OGLES2ShaderPath;
+
+	//! Path to shader cache. If empty, shader cache is disabled.
+	io::path ShaderCachePath;
 
 	//! Enable debug and error checks in video driver.
 	bool DriverDebug;

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -479,6 +479,16 @@ bool CFileSystem::existFile(const io::path &filename) const
 #endif
 }
 
+//! Deletes a file from the file system.
+bool CFileSystem::deleteFile(const io::path &filename)
+{
+#if defined(_MSC_VER)
+	return (_unlink(filename.c_str()) == 0);
+#else
+	return (unlink(filename.c_str()) == 0);
+#endif
+}
+
 //! creates a filesystem which is able to open files from the ordinary file system,
 //! and out of zipfiles, which are able to be added to the filesystem.
 IFileSystem *createFileSystem()

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -472,19 +472,17 @@ IFileList *CFileSystem::createEmptyFileList(const io::path &path, bool ignoreCas
 //! determines if a file exists and would be able to be opened.
 bool CFileSystem::existFile(const io::path &filename) const
 {
-#if defined(_MSC_VER)
+#if defined(_IRR_WINDOWS_API_)
 	return (_access(filename.c_str(), 0) != -1);
-#elif defined(F_OK)
-	return (access(filename.c_str(), F_OK) != -1);
 #else
-	return (access(filename.c_str(), 0) != -1);
+	return (access(filename.c_str(), F_OK) != -1);
 #endif
 }
 
 //! Determines if a path exists and is specifically a directory
 bool CFileSystem::existDirectory(const io::path &filename) const
 {
-#if defined(_WIN32) || defined(_MSC_VER)
+#if defined(_IRR_WINDOWS_API_)
 	struct _stat info;
 	return (_stat(filename.c_str(), &info) == 0) && (info.st_mode & _S_IFDIR);
 #else
@@ -496,7 +494,7 @@ bool CFileSystem::existDirectory(const io::path &filename) const
 //! Deletes a file from the file system.
 bool CFileSystem::deleteFile(const io::path &filename)
 {
-#if defined(_MSC_VER)
+#if defined(_IRR_WINDOWS_API_)
 	return (_unlink(filename.c_str()) == 0);
 #else
 	return (unlink(filename.c_str()) == 0);
@@ -506,7 +504,7 @@ bool CFileSystem::deleteFile(const io::path &filename)
 //! Creates a directory.
 bool CFileSystem::createDirectory(const io::path &dirname)
 {
-#if defined(_MSC_VER)
+#if defined(_IRR_WINDOWS_API_)
 	return (_mkdir(dirname.c_str()) == 0);
 #else
 	return (mkdir(dirname.c_str(), 0755) == 0);

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -19,8 +19,10 @@
 #endif
 
 #if defined(_IRR_WINDOWS_API_)
-#include <direct.h> // for _chdir
-#include <io.h>     // for _access
+#include <direct.h>   // for _chdir
+#include <io.h>       // for _access
+#include <sys/types.h>
+#include <sys/stat.h> // for _stat, _S_IFDIR
 #include <tchar.h>
 #elif (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_) || defined(_IRR_ANDROID_PLATFORM_))
 #include <cstdio>
@@ -476,6 +478,18 @@ bool CFileSystem::existFile(const io::path &filename) const
 	return (access(filename.c_str(), F_OK) != -1);
 #else
 	return (access(filename.c_str(), 0) != -1);
+#endif
+}
+
+//! Determines if a path exists and is specifically a directory
+bool CFileSystem::existDirectory(const io::path &filename) const
+{
+#if defined(_WIN32) || defined(_MSC_VER)
+	struct _stat info;
+	return (_stat(filename.c_str(), &info) == 0) && (info.st_mode & _S_IFDIR);
+#else
+	struct stat info;
+	return (stat(filename.c_str(), &info) == 0) && S_ISDIR(info.st_mode);
 #endif
 }
 

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -489,6 +489,16 @@ bool CFileSystem::deleteFile(const io::path &filename)
 #endif
 }
 
+//! Creates a directory.
+bool CFileSystem::createDirectory(const io::path &dirname)
+{
+#if defined(_MSC_VER)
+	return (_mkdir(dirname.c_str()) == 0);
+#else
+	return (mkdir(dirname.c_str(), 0755) == 0);
+#endif
+}
+
 //! creates a filesystem which is able to open files from the ordinary file system,
 //! and out of zipfiles, which are able to be added to the filesystem.
 IFileSystem *createFileSystem()

--- a/irr/src/CFileSystem.h
+++ b/irr/src/CFileSystem.h
@@ -89,6 +89,9 @@ public:
 	//! Deletes a file from the file system.
 	bool deleteFile(const io::path &filename) override;
 
+	//! Determines if a path exists and is specifically a directory
+	bool existDirectory(const io::path &filename) const override;
+
 	//! Creates a directory.
 	bool createDirectory(const io::path &dirname) override;
 

--- a/irr/src/CFileSystem.h
+++ b/irr/src/CFileSystem.h
@@ -86,6 +86,9 @@ public:
 	//! determines if a file exists and would be able to be opened.
 	bool existFile(const io::path &filename) const override;
 
+	//! Deletes a file from the file system.
+	bool deleteFile(const io::path &filename) override;
+
 private:
 	//! Currently used FileSystemType
 	EFileSystemType FileSystemType = FILESYSTEM_NATIVE;

--- a/irr/src/CFileSystem.h
+++ b/irr/src/CFileSystem.h
@@ -89,6 +89,9 @@ public:
 	//! Deletes a file from the file system.
 	bool deleteFile(const io::path &filename) override;
 
+	//! Creates a directory.
+	bool createDirectory(const io::path &dirname) override;
+
 private:
 	//! Currently used FileSystemType
 	EFileSystemType FileSystemType = FILESYSTEM_NATIVE;

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -250,6 +250,8 @@ set(link_includes
 
 	${OPENGL_INCLUDE_DIR}
 	${EGL_INCLUDE_DIR}
+
+	"$<TARGET_PROPERTY:sha256,INTERFACE_INCLUDE_DIRECTORIES>"
 )
 
 # Source files
@@ -320,6 +322,7 @@ if(ENABLE_OPENGL3 OR ENABLE_GLES2)
 		OpenGL/ExtensionHandler.cpp
 		OpenGL/FixedPipelineRenderer.cpp
 		OpenGL/MaterialRenderer.cpp
+		OpenGL/ShaderCache.cpp
 		OpenGL/Renderer2D.cpp
 		OpenGL/BufferObject.cpp
 	)
@@ -513,6 +516,8 @@ target_link_libraries(IrrlichtMt PRIVATE
 
 	"$<$<BOOL:${OPENGL_DIRECT_LINK}>:${OPENGL_LIBRARIES}>"
 	${EGL_LIBRARY}
+
+	sha256
 
 	# incl. transitive SDL2 dependencies for static linking
 	"$<$<PLATFORM_ID:Android>:-landroid -llog -lGLESv2 -lGLESv1_CM -lOpenSLES>"

--- a/irr/src/CWriteFile.cpp
+++ b/irr/src/CWriteFile.cpp
@@ -21,7 +21,7 @@ CWriteFile::~CWriteFile()
 }
 
 //! returns if file is open
-inline bool CWriteFile::isOpen() const
+bool CWriteFile::isOpen() const
 {
 	return File != 0;
 }

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -19,6 +19,7 @@
 #include "MaterialRenderer.h"
 #include "FixedPipelineRenderer.h"
 #include "Renderer2D.h"
+#include "ShaderCache.h"
 
 #include "EVertexAttributes.h"
 #include "CImage.h"
@@ -157,7 +158,8 @@ COpenGL3DriverBase::COpenGL3DriverBase(const SIrrlichtCreationParameters &params
 		MaterialRenderer2DActive(0), MaterialRenderer2DTexture(0), MaterialRenderer2DNoTexture(0),
 		CurrentRenderMode(ERM_NONE), Transformation3DChanged(true),
 		OGLES2ShaderPath(params.OGLES2ShaderPath),
-		ContextManager(contextManager), EnableErrorTest(params.DriverDebug)
+		ContextManager(contextManager), EnableErrorTest(params.DriverDebug),
+		ShaderCache(this, io, params.ShaderCachePath)
 {
 	if (!ContextManager)
 		return;

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -275,6 +275,10 @@ bool COpenGL3DriverBase::genericDriverInit(const core::dimension2d<u32> &screenS
 		KHRDebugSupported = false;
 	}
 
+	if (BinaryCacheSupported) {
+		ShaderCache.prune();
+	}
+
 	initQuadsIndices();
 	initMaxJointTransforms();
 

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -15,6 +15,7 @@
 #include "EDriverFeatures.h"
 #include "ExtensionHandler.h"
 #include "IContextManager.h"
+#include "ShaderCache.h"
 
 namespace video
 {
@@ -239,6 +240,9 @@ public:
 
 	COpenGL3CacheHandler *getCacheHandler() const;
 
+	COpenGL3ShaderCache& getShaderCache() { return ShaderCache; }
+	const COpenGL3ShaderCache& getShaderCache() const { return ShaderCache; }
+
 protected:
 	virtual bool genericDriverInit(const core::dimension2d<u32> &screenSize, bool stencilBuffer);
 
@@ -362,6 +366,8 @@ private:
 
 	void debugCb(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message);
 	static void APIENTRY debugCb(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void *userParam);
+
+	COpenGL3ShaderCache ShaderCache;
 };
 
 } // end namespace video

--- a/irr/src/OpenGL/ExtensionHandler.h
+++ b/irr/src/OpenGL/ExtensionHandler.h
@@ -181,6 +181,7 @@ public:
 	bool Texture2DArraySupported = false;
 	bool KHRDebugSupported = false;
 	bool RenderToFloatTextureSupported = false;
+	bool BinaryCacheSupported = false;
 	u32 MaxLabelLength = 0;
 };
 

--- a/irr/src/OpenGL/MaterialRenderer.cpp
+++ b/irr/src/OpenGL/MaterialRenderer.cpp
@@ -11,6 +11,7 @@
 #include "os.h"
 
 #include "Driver.h"
+#include "ShaderCache.h"
 
 #include "COpenGLCoreTexture.h"
 #include "COpenGLCoreCacheHandler.h"
@@ -102,25 +103,54 @@ void COpenGL3MaterialRenderer::init(s32 &outMaterialTypeNr,
 {
 	outMaterialTypeNr = -1;
 
-	Program = GL.CreateProgram();
+	auto cachedProgram = Driver->getShaderCache().load(
+		vertexShaderProgram ? vertexShaderProgram : "",
+		pixelShaderProgram ? pixelShaderProgram : "");
 
-	if (!Program)
-		return;
+	if (cachedProgram) {
+		Program = *cachedProgram;
+		os::Printer::log("Successfully loaded shader binary from cache",
+			debugName ? debugName : "unknown", ELL_INFORMATION);
 
-	if (vertexShaderProgram)
-		if (!createShader(GL_VERTEX_SHADER, vertexShaderProgram))
+		if (!setupProgram())
+			return;
+	} else {
+		os::Printer::log("Cache miss", debugName ? debugName : "unknown", ELL_INFORMATION);
+
+		Program = GL.CreateProgram();
+
+		if (!Program)
 			return;
 
-	if (pixelShaderProgram)
-		if (!createShader(GL_FRAGMENT_SHADER, pixelShaderProgram))
+		if (vertexShaderProgram)
+			if (!createShader(GL_VERTEX_SHADER, vertexShaderProgram))
+				return;
+
+		if (pixelShaderProgram)
+			if (!createShader(GL_FRAGMENT_SHADER, pixelShaderProgram))
+				return;
+
+		for (u32 i = 0; i < EVA_COUNT; ++i)
+			GL.BindAttribLocation(Program, i, sBuiltInVertexAttributeNames[i]);
+
+		if (!linkProgram())
 			return;
 
-	for (u32 i = 0; i < EVA_COUNT; ++i)
-		GL.BindAttribLocation(Program, i, sBuiltInVertexAttributeNames[i]);
+		if (!setupProgram())
+			return;
 
-	if (!linkProgram())
-		return;
+        bool savedOk = Driver->getShaderCache().save(
+            vertexShaderProgram ? vertexShaderProgram : "",
+            pixelShaderProgram ? pixelShaderProgram : "", Program);
 
+        if (savedOk) {
+            os::Printer::log("Saved compiled shader binary to cache",
+           		debugName ? debugName : "unknown", ELL_INFORMATION);
+        } else {
+        	os::Printer::log("Failed to save compiled shader binary to cache",
+		   		debugName ? debugName : "unknown", ELL_WARNING);
+        }
+	}
 	if (debugName)
 		Driver->irrGlObjectLabel(GL_PROGRAM, Program, debugName);
 
@@ -242,7 +272,14 @@ bool COpenGL3MaterialRenderer::linkProgram()
 
 			return false;
 		}
+	}
 
+	return true;
+}
+
+bool COpenGL3MaterialRenderer::setupProgram()
+{
+	if (Program) {
 		GLuint blockIndex = GL.GetUniformBlockIndex(Program, "JointMatrices");
 		if (GL_INVALID_INDEX != blockIndex) {
 			GL.UniformBlockBinding(Program, blockIndex, 0);

--- a/irr/src/OpenGL/MaterialRenderer.cpp
+++ b/irr/src/OpenGL/MaterialRenderer.cpp
@@ -15,6 +15,7 @@
 
 #include "COpenGLCoreTexture.h"
 #include "COpenGLCoreCacheHandler.h"
+#include <optional>
 
 namespace video
 {
@@ -103,9 +104,12 @@ void COpenGL3MaterialRenderer::init(s32 &outMaterialTypeNr,
 {
 	outMaterialTypeNr = -1;
 
-	auto cachedProgram = Driver->getShaderCache().load(
-		vertexShaderProgram ? vertexShaderProgram : "",
-		pixelShaderProgram ? pixelShaderProgram : "");
+	std::optional<GLuint> cachedProgram;
+	if (Driver->BinaryCacheSupported) {
+		cachedProgram = Driver->getShaderCache().load(
+			vertexShaderProgram ? vertexShaderProgram : "",
+			pixelShaderProgram ? pixelShaderProgram : "");
+	}
 
 	if (cachedProgram) {
 		Program = *cachedProgram;
@@ -139,17 +143,20 @@ void COpenGL3MaterialRenderer::init(s32 &outMaterialTypeNr,
 		if (!setupProgram())
 			return;
 
-        bool savedOk = Driver->getShaderCache().save(
-            vertexShaderProgram ? vertexShaderProgram : "",
-            pixelShaderProgram ? pixelShaderProgram : "", Program);
+		// Try to save to cache if supported
+		if (Driver->BinaryCacheSupported) {
+			bool savedOk = Driver->getShaderCache().save(
+				vertexShaderProgram ? vertexShaderProgram : "",
+				pixelShaderProgram ? pixelShaderProgram : "", Program);
 
-        if (savedOk) {
-            os::Printer::log("Saved compiled shader binary to cache",
-           		debugName ? debugName : "unknown", ELL_INFORMATION);
-        } else {
-        	os::Printer::log("Failed to save compiled shader binary to cache",
-		   		debugName ? debugName : "unknown", ELL_WARNING);
-        }
+			if (savedOk) {
+				os::Printer::log("Saved compiled shader binary to cache",
+					debugName ? debugName : "unknown", ELL_INFORMATION);
+			} else {
+				os::Printer::log("Failed to save compiled shader binary to cache",
+					debugName ? debugName : "unknown", ELL_WARNING);
+			}
+		}
 	}
 	if (debugName)
 		Driver->irrGlObjectLabel(GL_PROGRAM, Program, debugName);

--- a/irr/src/OpenGL/MaterialRenderer.h
+++ b/irr/src/OpenGL/MaterialRenderer.h
@@ -71,6 +71,7 @@ protected:
 
 	bool createShader(GLenum shaderType, const char *shader);
 	bool linkProgram();
+	bool setupProgram();
 
 	COpenGL3DriverBase *Driver;
 	IShaderConstantSetCallBack *CallBack;

--- a/irr/src/OpenGL/ShaderCache.cpp
+++ b/irr/src/OpenGL/ShaderCache.cpp
@@ -7,6 +7,7 @@
 
 #include "CReadFile.h"
 #include "CWriteFile.h"
+#include "IFileList.h"
 #include "coreutil.h"
 #include "mt_opengl.h"
 #include "os.h"
@@ -23,6 +24,8 @@
 
 namespace
 {
+
+constexpr std::string_view SHADER_EXTENSION = ".bin";
 
 // Used when hashing multiple strings together to separate them
 constexpr std::string_view HASH_KEY_SEPARATOR{"\0", 1};
@@ -86,16 +89,84 @@ COpenGL3ShaderCache::SHA256Hash COpenGL3ShaderCache::calculateHash(
 std::optional<GLuint> COpenGL3ShaderCache::load(
 		std::string_view vertexShaderProgram, std::string_view pixelShaderProgram) const
 {
-	if (m_cache_dir.empty() || !m_driver->BinaryCacheSupported) {
+	if (m_cache_dir.empty()) {
 		return std::nullopt;
 	}
 
-	// Calculate the hash and the corresponding cache file path
-	auto hash = calculateHash(vertexShaderProgram, pixelShaderProgram);
+	SHA256Hash hash   = calculateHash(vertexShaderProgram, pixelShaderProgram);
 	io::path filepath = getCacheFilename(hash);
 
-	if (!m_fs->existFile(filepath)) {
-		return std::nullopt; // Cache file does not exist
+	return loadFromFile(filepath);
+}
+
+bool COpenGL3ShaderCache::save(std::string_view vertexShaderProgram,
+		std::string_view pixelShaderProgram, GLuint program) const
+{
+	if (m_cache_dir.empty()) {
+		return false;
+	}
+
+	GLint binaryLength = 0;
+	GL.GetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
+	if (m_driver->testGLError(__FILE__, __LINE__) || binaryLength <= 0) {
+		os::Printer::log("Failed to get shader program binary length", ELL_WARNING);
+		return false;
+	}
+
+	std::vector<char> binary(binaryLength);
+	GLenum file_format = 0;
+	GLsizei file_effective_size = 0;
+
+	GL.GetProgramBinary(program, binaryLength, &file_effective_size, &file_format, binary.data());
+	if (m_driver->testGLError(__FILE__, __LINE__)) {
+		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
+		return false;
+	}
+	if (file_effective_size <= 0) {
+		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
+		return false;
+	}
+
+	io::path filepath = getCacheFilename(calculateHash(vertexShaderProgram, pixelShaderProgram));
+
+	if (!m_fs->existDirectory(m_cache_dir) && !m_fs->createDirectory(m_cache_dir)) {
+		os::Printer::log("Failed to create shader cache directory", m_cache_dir.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	io::CWriteFile writer(filepath.c_str(), false);
+	if (!writer.isOpen()) {
+		os::Printer::log("Failed to open shader cache file for writing", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (writer.write(&file_format, sizeof(file_format)) != sizeof(file_format)) {
+		os::Printer::log("Failed to write shader cache format", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (writer.write(binary.data(), file_effective_size) != static_cast<size_t>(file_effective_size)) {
+		os::Printer::log("Failed to write shader cache binary data", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (!writer.flush()) {
+		os::Printer::log("Failed to flush shader cache file", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	return true;
+}
+
+io::path COpenGL3ShaderCache::getCacheFilename(const SHA256Hash &hash) const
+{
+	return core::mergeFilename(m_cache_dir, to_hex(hash) + std::string(SHADER_EXTENSION));
+}
+
+std::optional<GLuint> COpenGL3ShaderCache::loadFromFile(const io::path &filepath) const
+{
+	if (filepath.empty() || !m_fs->existFile(filepath)) {
+		return std::nullopt;
 	}
 
 	io::CReadFile reader(filepath.c_str());
@@ -163,68 +234,44 @@ std::optional<GLuint> COpenGL3ShaderCache::load(
 	return std::make_optional(program);
 }
 
-bool COpenGL3ShaderCache::save(std::string_view vertexShaderProgram,
-		std::string_view pixelShaderProgram, GLuint program) const
+void COpenGL3ShaderCache::prune() const
 {
-	if (m_cache_dir.empty() || !m_driver->BinaryCacheSupported) {
-		return false;
+	if (m_cache_dir.empty() || !m_fs->existDirectory(m_cache_dir)) {
+		return;
 	}
 
-	GLint binaryLength = 0;
-	GL.GetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
-	if (m_driver->testGLError(__FILE__, __LINE__) || binaryLength <= 0) {
-		os::Printer::log("Failed to get shader program binary length", ELL_WARNING);
-		return false;
+	auto check_file = [this](const io::path &filename) {
+		// Ignore files that don't have the expected shader cache extension
+		if (filename.size() <= SHADER_EXTENSION.size()
+			|| !core::hasFileExtension(filename, SHADER_EXTENSION.data())) {
+			return;
+		}
+
+		// Attempt to load the shader program from the cache file. If it fails, delete the file.
+		auto program = loadFromFile(filename);
+		if (!program) {
+			os::Printer::log("Removing invalid shader cache file", filename.c_str(), ELL_WARNING);
+			m_fs->deleteFile(filename);
+		} else {
+			GL.DeleteProgram(*program);
+		}
+	};
+
+	auto old_working_dir = m_fs->getWorkingDirectory();
+	m_fs->changeWorkingDirectoryTo(m_cache_dir);
+
+	io::IFileList *file_list = m_fs->createFileList();
+	if (file_list) {
+		for (u32 i = 0; i < file_list->getFileCount(); ++i) {
+			io::path filename = file_list->getFileName(i);
+			check_file(filename);
+		}
+		file_list->drop();
+	} else {
+		os::Printer::log("Failed to create file list for shader cache pruning", m_cache_dir.c_str(), ELL_WARNING);
 	}
 
-	std::vector<char> binary(binaryLength);
-	GLenum file_format = 0;
-	GLsizei file_effective_size = 0;
-
-	GL.GetProgramBinary(program, binaryLength, &file_effective_size, &file_format, binary.data());
-	if (m_driver->testGLError(__FILE__, __LINE__)) {
-		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
-		return false;
-	}
-	if (file_effective_size <= 0) {
-		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
-		return false;
-	}
-
-	io::path filepath = getCacheFilename(calculateHash(vertexShaderProgram, pixelShaderProgram));
-
-	if (!m_fs->existDirectory(m_cache_dir) && !m_fs->createDirectory(m_cache_dir)) {
-		os::Printer::log("Failed to create shader cache directory", m_cache_dir.c_str(), ELL_WARNING);
-		return false;
-	}
-
-	io::CWriteFile writer(filepath.c_str(), false);
-	if (!writer.isOpen()) {
-		os::Printer::log("Failed to open shader cache file for writing", filepath.c_str(), ELL_WARNING);
-		return false;
-	}
-
-	if (writer.write(&file_format, sizeof(file_format)) != sizeof(file_format)) {
-		os::Printer::log("Failed to write shader cache format", filepath.c_str(), ELL_WARNING);
-		return false;
-	}
-
-	if (writer.write(binary.data(), file_effective_size) != static_cast<size_t>(file_effective_size)) {
-		os::Printer::log("Failed to write shader cache binary data", filepath.c_str(), ELL_WARNING);
-		return false;
-	}
-
-	if (!writer.flush()) {
-		os::Printer::log("Failed to flush shader cache file", filepath.c_str(), ELL_WARNING);
-		return false;
-	}
-
-	return true;
-}
-
-io::path COpenGL3ShaderCache::getCacheFilename(const SHA256Hash &hash) const
-{
-	return core::mergeFilename(m_cache_dir, to_hex(hash) + ".bin");
+	m_fs->changeWorkingDirectoryTo(old_working_dir);
 }
 
 } // end namespace video

--- a/irr/src/OpenGL/ShaderCache.cpp
+++ b/irr/src/OpenGL/ShaderCache.cpp
@@ -1,0 +1,230 @@
+// Copyright (C) 2026 VaiTon
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "ShaderCache.h"
+#include "Driver.h"
+
+#include "CReadFile.h"
+#include "CWriteFile.h"
+#include "coreutil.h"
+#include "mt_opengl.h"
+#include "os.h"
+#include "path.h"
+
+#include "my_sha256.h"
+
+#include <cstddef>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Used when hashing multiple strings together to separate them
+constexpr std::string_view HASH_KEY_SEPARATOR{"\0", 1};
+
+/// Get a string from OpenGL and return it as a std::string_view
+std::string_view gl_string(GLenum name)
+{
+	auto s = GL.GetString(name);
+	return s ? std::string_view(reinterpret_cast<const char *>(s))
+		: std::string_view{};
+}
+
+
+std::string to_hex(const std::array<std::byte, 32> &bytes)
+{
+	std::ostringstream oss;
+	for (auto b : bytes)
+		oss << std::hex << std::setw(2) << std::setfill('0')
+			<< std::to_integer<unsigned>(b);
+	return oss.str();
+}
+
+} // namespace
+
+namespace video
+{
+
+COpenGL3ShaderCache::SHA256Hash COpenGL3ShaderCache::calculateHash(
+		std::string_view vertexShaderProgram, std::string_view pixelShaderProgram)
+{
+	auto vendor     = gl_string(GL_VENDOR);
+	auto renderer   = gl_string(GL_RENDERER);
+	auto version    = gl_string(GL_VERSION);
+	auto sl_version = gl_string(GL_SHADING_LANGUAGE_VERSION);
+
+	SHA256_CTX sha_ctx;
+	SHA256_Init(&sha_ctx);
+
+	auto update_hash = [&sha_ctx](std::string_view data) {
+		SHA256_Update(&sha_ctx, data.data(), data.size());
+	};
+
+	update_hash(vertexShaderProgram);
+	update_hash(HASH_KEY_SEPARATOR);
+	update_hash(pixelShaderProgram);
+	update_hash(HASH_KEY_SEPARATOR);
+	update_hash(vendor);
+	update_hash(HASH_KEY_SEPARATOR);
+	update_hash(renderer);
+	update_hash(HASH_KEY_SEPARATOR);
+	update_hash(version);
+	update_hash(HASH_KEY_SEPARATOR);
+	update_hash(sl_version);
+
+	SHA256Hash hash;
+	SHA256_Final(reinterpret_cast<unsigned char *>(hash.data()), &sha_ctx);
+
+	return hash;
+}
+
+std::optional<GLuint> COpenGL3ShaderCache::load(
+		std::string_view vertexShaderProgram, std::string_view pixelShaderProgram) const
+{
+	if (m_cache_dir.empty() || !m_driver->BinaryCacheSupported) {
+		return std::nullopt;
+	}
+
+	// Calculate the hash and the corresponding cache file path
+	auto hash = calculateHash(vertexShaderProgram, pixelShaderProgram);
+	io::path filepath = getCacheFilename(hash);
+
+	if (!m_fs->existFile(filepath)) {
+		return std::nullopt; // Cache file does not exist
+	}
+
+	io::CReadFile reader(filepath.c_str());
+	if (!reader.isOpen()) {
+		os::Printer::log("Failed to open shader cache file", filepath.c_str(), ELL_WARNING);
+		return std::nullopt;
+	}
+
+	GLenum file_format = 0;
+	size_t file_size = reader.getSize();
+	if (file_size <= sizeof(file_format)) {
+		os::Printer::log("Invalid shader cache file size", filepath.c_str(), ELL_WARNING);
+		// If the file is too small to contain the format, it's invalid
+		m_fs->deleteFile(filepath);
+		return std::nullopt;
+	}
+
+	size_t file_effective_size = file_size - sizeof(file_format);
+
+	// Read the format from the file
+	if (reader.read(&file_format, sizeof(file_format)) != sizeof(file_format)) {
+		os::Printer::log("Failed to read shader cache format", filepath.c_str(), ELL_WARNING);
+		return std::nullopt;
+	}
+
+	// Load the binary data in memory
+	std::vector<std::byte> binary(file_effective_size);
+	if (!reader.read(binary.data(), file_effective_size)) {
+		os::Printer::log("Failed to read shader cache binary data", filepath.c_str(), ELL_WARNING);
+		return std::nullopt;
+	}
+
+	// Create the program and load the binary data
+	GLuint program = GL.CreateProgram();
+	if (program == 0) {
+		os::Printer::log("Failed to create shader program", ELL_WARNING);
+		return std::nullopt;
+	}
+
+	// Load the binary data into the program
+	GL.ProgramBinary(program, file_format, binary.data(), file_effective_size);
+	if (m_driver->testGLError(__FILE__, __LINE__)) {
+		os::Printer::log("Failed to load shader program binary", filepath.c_str(), ELL_WARNING);
+		// If loading the binary fails, cache is invalid (at least for this driver)
+		GL.DeleteProgram(program);
+		m_fs->deleteFile(filepath);
+		return std::nullopt;
+	}
+
+	GLint linkStatus = 0;
+	GL.GetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+	if (m_driver->testGLError(__FILE__, __LINE__)) {
+		os::Printer::log("Failed to get shader program link status", filepath.c_str(), ELL_WARNING);
+		GL.DeleteProgram(program);
+		return std::nullopt;
+	}
+	if (linkStatus != GL_TRUE) {
+		os::Printer::log("Failed to load shader program from cache", filepath.c_str(), ELL_WARNING);
+		GL.DeleteProgram(program);
+		// If the program fails to link, the cache is invalid (at least for this driver)
+		m_fs->deleteFile(filepath);
+		return std::nullopt;
+	}
+
+	return std::make_optional(program);
+}
+
+bool COpenGL3ShaderCache::save(std::string_view vertexShaderProgram,
+		std::string_view pixelShaderProgram, GLuint program) const
+{
+	if (m_cache_dir.empty() || !m_driver->BinaryCacheSupported) {
+		return false;
+	}
+
+	GLint binaryLength = 0;
+	GL.GetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
+	if (m_driver->testGLError(__FILE__, __LINE__) || binaryLength <= 0) {
+		os::Printer::log("Failed to get shader program binary length", ELL_WARNING);
+		return false;
+	}
+
+	std::vector<char> binary(binaryLength);
+	GLenum file_format = 0;
+	GLsizei file_effective_size = 0;
+
+	GL.GetProgramBinary(program, binaryLength, &file_effective_size, &file_format, binary.data());
+	if (m_driver->testGLError(__FILE__, __LINE__)) {
+		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
+		return false;
+	}
+	if (file_effective_size <= 0) {
+		os::Printer::log("Failed to retrieve shader program binary", ELL_WARNING);
+		return false;
+	}
+
+	io::path filepath = getCacheFilename(calculateHash(vertexShaderProgram, pixelShaderProgram));
+
+	if (!m_fs->existDirectory(m_cache_dir) && !m_fs->createDirectory(m_cache_dir)) {
+		os::Printer::log("Failed to create shader cache directory", m_cache_dir.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	io::CWriteFile writer(filepath.c_str(), false);
+	if (!writer.isOpen()) {
+		os::Printer::log("Failed to open shader cache file for writing", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (writer.write(&file_format, sizeof(file_format)) != sizeof(file_format)) {
+		os::Printer::log("Failed to write shader cache format", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (writer.write(binary.data(), file_effective_size) != static_cast<size_t>(file_effective_size)) {
+		os::Printer::log("Failed to write shader cache binary data", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	if (!writer.flush()) {
+		os::Printer::log("Failed to flush shader cache file", filepath.c_str(), ELL_WARNING);
+		return false;
+	}
+
+	return true;
+}
+
+io::path COpenGL3ShaderCache::getCacheFilename(const SHA256Hash &hash) const
+{
+	return core::mergeFilename(m_cache_dir, to_hex(hash) + ".bin");
+}
+
+} // end namespace video

--- a/irr/src/OpenGL/ShaderCache.h
+++ b/irr/src/OpenGL/ShaderCache.h
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 VaiTon
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include "Common.h"
+#include "IFileSystem.h"
+#include "path.h"
+
+#include <optional>
+#include <string_view>
+#include <array>
+
+namespace video
+{
+
+class COpenGL3DriverBase;
+
+/// Binary shader cache for OpenGL shader programs.
+///
+/// This class allows caching compiled shader programs to disk, so that they can
+/// be loaded quickly on subsequent runs without needing to recompile the
+/// shaders.
+///
+/// This class is not thread-safe. If multiple threads need to access the shader
+/// cache, external synchronization is required.
+///
+/// The cache key is based on a hash of the shader source code and the OpenGL
+/// context (GL_VENDOR, GL_RENDERER, GL_VERSION, GL_SHADING_LANGUAGE_VERSION).
+class COpenGL3ShaderCache
+{
+public:
+	COpenGL3ShaderCache(COpenGL3DriverBase *driver, io::IFileSystem *fs, const io::path &cache_dir) :
+		m_driver(driver), m_fs(fs), m_cache_dir(cache_dir) {}
+
+	/// Loads a shader program from the cache.
+	/// Returns the program ID if successful, std::nullopt otherwise.
+	std::optional<GLuint> load(std::string_view vertexShaderProgram,
+		std::string_view pixelShaderProgram) const;
+
+	/// Saves a shader program to the cache.
+	/// Returns true if successful, false otherwise.
+	bool save(std::string_view vertexShaderProgram, std::string_view pixelShaderProgram,
+		GLuint program) const;
+
+private:
+	typedef std::array<std::byte, 32> SHA256Hash;
+
+	/// Gets the cache filename for a given hash.
+	io::path getCacheFilename(const SHA256Hash &hash) const;
+
+	/// Calculates a hash for the given shader programs and the current
+	/// OpenGL context.
+	static SHA256Hash calculateHash(std::string_view vertexShaderProgram,
+		std::string_view pixelShaderProgram);
+
+	COpenGL3DriverBase *m_driver;
+	io::IFileSystem *m_fs;
+	io::path m_cache_dir;
+};
+
+} // end namespace video

--- a/irr/src/OpenGL/ShaderCache.h
+++ b/irr/src/OpenGL/ShaderCache.h
@@ -31,8 +31,9 @@ class COpenGL3DriverBase;
 class COpenGL3ShaderCache
 {
 public:
-	COpenGL3ShaderCache(COpenGL3DriverBase *driver, io::IFileSystem *fs, const io::path &cache_dir) :
-		m_driver(driver), m_fs(fs), m_cache_dir(cache_dir) {}
+	COpenGL3ShaderCache(COpenGL3DriverBase *driver, io::IFileSystem *fs,
+		const io::path &cache_dir) :
+		m_cache_dir(cache_dir), m_driver(driver), m_fs(fs) {}
 
 	/// Loads a shader program from the cache.
 	/// Returns the program ID if successful, std::nullopt otherwise.
@@ -44,20 +45,27 @@ public:
 	bool save(std::string_view vertexShaderProgram, std::string_view pixelShaderProgram,
 		GLuint program) const;
 
+	/// Prunes the cache by removing entries that are no longer valid for the current OpenGL context
+	void prune() const;
+
 private:
 	typedef std::array<std::byte, 32> SHA256Hash;
 
 	/// Gets the cache filename for a given hash.
 	io::path getCacheFilename(const SHA256Hash &hash) const;
 
+	/// Loads a shader program from a cache file.
+	/// Returns the program ID if successful, std::nullopt otherwise.
+	std::optional<GLuint> loadFromFile(const io::path &filepath) const;
+
 	/// Calculates a hash for the given shader programs and the current
 	/// OpenGL context.
 	static SHA256Hash calculateHash(std::string_view vertexShaderProgram,
 		std::string_view pixelShaderProgram);
 
+	io::path m_cache_dir;
 	COpenGL3DriverBase *m_driver;
 	io::IFileSystem *m_fs;
-	io::path m_cache_dir;
 };
 
 } // end namespace video

--- a/irr/src/OpenGL3/DriverGL3.cpp
+++ b/irr/src/OpenGL3/DriverGL3.cpp
@@ -71,6 +71,11 @@ void COpenGL3Driver::initFeatures()
 		MaxLabelLength = GetInteger(GL.MAX_LABEL_LENGTH);
 	RenderToFloatTextureSupported = true;
 
+	// https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetProgramBinary.xhtml
+	GLint numFormats = 0;
+	GL.GetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &numFormats);
+	BinaryCacheSupported = (isVersionAtLeast(4, 1) || queryExtension("GL_ARB_get_program_binary")) && numFormats > 0;
+
 	// COGLESCoreExtensionHandler::Feature
 	static_assert(MATERIAL_MAX_TEXTURES <= 16, "Only up to 16 textures are guaranteed");
 	Feature.BlendOperation = true;

--- a/irr/src/OpenGLES2/DriverGLES2.cpp
+++ b/irr/src/OpenGLES2/DriverGLES2.cpp
@@ -130,6 +130,9 @@ void COpenGLES2Driver::initFeatures()
 	}
 	RenderToFloatTextureSupported = isVersionAtLeast(3, 2)|| queryExtension("GL_EXT_color_buffer_float");
 
+	// https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGetProgramBinary.xhtml
+	BinaryCacheSupported = Version.Major >= 3 || queryExtension("GL_OES_get_program_binary");
+
 	// COGLESCoreExtensionHandler::Feature
 	static_assert(MATERIAL_MAX_TEXTURES <= 8, "Only up to 8 textures are guaranteed");
 	Feature.BlendOperation = true;

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -205,6 +205,7 @@ RenderingEngine::RenderingEngine(MyEventReceiver *receiver)
 	std::string rel_path = std::string("client") + DIR_DELIM
 			+ "shaders" + DIR_DELIM + "Irrlicht";
 	params.OGLES2ShaderPath = (porting::path_share + DIR_DELIM + rel_path + DIR_DELIM).c_str();
+	params.ShaderCachePath = (porting::path_cache + DIR_DELIM + "shader" + DIR_DELIM).c_str();
 
 	m_device = createDevice(params, driverType);
 	driver = m_device->getVideoDriver();


### PR DESCRIPTION
#### Background

I was looking at the shadow mapping code and saw this comment:

https://github.com/luanti-org/luanti/blob/4e0ac7e6bd06860b9285493aa90f26fc728f90c3/src/client/shadows/dynamicshadowsrender.cpp#L460-L467

To activate the shadow map code on demand we have two ways:

- at compile time, using a define
- at runtime, using a boolean uniform

At compile time we pay the penalty of having to compile another shader, but then the runtime impact is zero; vice versa with the boolean uniform, we'd have just a single shader but we'd pay the cost at runtime. It is to be said that branching on a uniform should not cost a lot, since we would not break the GPU workgroup convergency, but still we'd rely on a driver intrinsic characteristic which is not guaranteed.

For the first approach, a way to reduce the impact of having another shader to compile is having a binary cache, which is, apart from this, a good thing in general.

This PR does just this, creating a binary shader cache for the OpenGL backends.

#### How does the PR work?

- Creates a binary shader cache initialized in `OpenGL/Driver.{h,cpp}` and used every time we need to compile a new shader.

- Splits the shader setup code in `MaterialRenderer.cpp`: `setupProgram` is called both when the shader is loaded from cache or freshly compiled, while `linkProgram` is only called for cache misses.

## To do

This PR is Ready for Review.

If the logging is too much I can reduce it or make it DEBUG lvl. Let me know!

I also have a doubt about initializing ShaderCachePath with `""` in `irr/include/SIrrCreationParameters.h`, but apart from using a placeholder value I didn't find a way that cleaner than this.

## How to test

Spin up Luanti and it shouldn't crash :)
