### PR TITLE
Allow `core.log` to only log deprecation messages once

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6345,7 +6345,7 @@ Logging
 * `core.log([level,] text [, stack_level, once])`
     * `level` is one of `"none"`, `"error"`, `"warning"`, `"action"`,
       `"info"`, `"verbose"`, or "deprecated"`.  Default is `"none"`.
-    * `stack_level` and `once` are only used when `level` is `"deprecated"`. 
+    * `stack_level` and `once` are only used when `level` is `"deprecated"`.
       If `once` is true, the message will only be logged one time.
 
 Registration functions

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6342,9 +6342,11 @@ Logging
 * `core.debug(...)`
     * Calls `core.log` with all arguments converted to string and separated by tabs
       (similar to `print`).
-* `core.log([level,] text)`
+* `core.log([level,] text [, stack_level, once])`
     * `level` is one of `"none"`, `"error"`, `"warning"`, `"action"`,
-      `"info"`, or `"verbose"`.  Default is `"none"`.
+      `"info"`, `"verbose"`, or "deprecated"`.  Default is `"none"`.
+    * `stack_level` and `once` are only used when `level` is `"deprecated"`. 
+      If `once` is true, the message will only be logged one time.
 
 Registration functions
 ----------------------

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -53,13 +53,14 @@ int ModApiUtil::l_log(lua_State *L)
 		auto name = readParam<std::string_view>(L, 1);
 		text = readParam<std::string_view>(L, 2);
 		if (name == "deprecated") {
-			// core.log("deprecated", message [, stack_level])
+			// core.log("deprecated", message [, stack_level, once])
 			// Level 1 - immediate caller of core.log (probably engine code);
 			// Level 2 - caller of the function that called core.log, and so on
 			int stack_level = readParam<int>(L, 3, 2);
 			if (stack_level < 1)
 				throw LuaError("invalid stack level");
-			log_deprecated(L, text, stack_level);
+			bool once = readParam<bool>(L, 4, false);
+			log_deprecated(L, text, stack_level, once);
 			return 0;
 		}
 		level = Logger::stringToLevel(name);


### PR DESCRIPTION
Expands and documents the special `"deprecated"` level of `core.log`, adding an optional fourth parameter to only log  deprecation messages one time, to avoid log spam.

I wasn't sure about the formatting for the documentation, so that might need to be adjusted.

To test, add this code to a mod:
```lua
local function foo()
	core.log("deprecated", "This message is only logged once", 2, true)
end
local function bar()
	core.log("deprecated", "This message is repeated forever")
end
local function test_deprecated()
	foo()
	bar()
	core.after(1, test_deprecated)
end
core.after(10, test_deprecated)
```