### PR TITLE
Bump Alpine to 3.24 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-ARG DOCKER_IMAGE=alpine:3.23
+ARG DOCKER_IMAGE=alpine:3.24
 FROM $DOCKER_IMAGE AS dev
 
 ENV LUAJIT_VERSION=v2.1


### PR DESCRIPTION
Bump Alpine from 3.23 to 3.24

https://www.alpinelinux.org/posts/Alpine-3.24.0-released.html

## To do

This PR is Ready for Review.

## How to test

Build the image. Test it runs properly.

Minimal testing (better to test and actual server):

```shell
docker build --tag luanti:dev .
docker run --rm luanti:dev --version
```