### PR TITLE
[no squash] Misc hardening + less Irrlicht UB

### DIFF
--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -3,6 +3,8 @@
 This document contains a list of breaking changes to be made in the next major version.
 This list is largely advisory and items may be reevaluated once the time comes.
 
+* remove support for the `.x` model file format
+  * see https://github.com/luanti-org/luanti/issues/15619 for discussion
 * remove attachment space multiplier (*10)
 * remove space multiplier for models (*10)
 * remove player gravity multiplier (*2)

--- a/irr/include/SMaterial.h
+++ b/irr/include/SMaterial.h
@@ -7,6 +7,7 @@
 #include "SColor.h"
 #include "matrix4.h"
 #include "irrMath.h"
+#include "irrBitCast.h"
 #include "EMaterialTypes.h" // IWYU pragma: export
 #include "EMaterialProps.h" // IWYU pragma: export
 #include "SMaterialLayer.h"

--- a/irr/include/SMaterial.h
+++ b/irr/include/SMaterial.h
@@ -116,7 +116,7 @@ inline f32 pack_textureBlendFunc(const E_BLEND_FACTOR srcFact, const E_BLEND_FAC
 		const E_MODULATE_FUNC modulate = EMFN_MODULATE_1X, const u32 alphaSource = EAS_TEXTURE)
 {
 	const u32 tmp = (alphaSource << 20) | (modulate << 16) | (srcFact << 12) | (dstFact << 8) | (srcFact << 4) | dstFact;
-	return FR(tmp);
+	return irrBitCast<f32>(tmp);
 }
 
 //! Pack srcRGBFact, dstRGBFact, srcAlphaFact, dstAlphaFact, Modulate and alpha source to MaterialTypeParam or BlendFactor
@@ -126,7 +126,7 @@ inline f32 pack_textureBlendFuncSeparate(const E_BLEND_FACTOR srcRGBFact, const 
 		const E_MODULATE_FUNC modulate = EMFN_MODULATE_1X, const u32 alphaSource = EAS_TEXTURE)
 {
 	const u32 tmp = (alphaSource << 20) | (modulate << 16) | (srcAlphaFact << 12) | (dstAlphaFact << 8) | (srcRGBFact << 4) | dstRGBFact;
-	return FR(tmp);
+	return irrBitCast<f32>(tmp);
 }
 
 //! Unpack srcFact, dstFact, modulo and alphaSource factors
@@ -134,7 +134,7 @@ inline f32 pack_textureBlendFuncSeparate(const E_BLEND_FACTOR srcRGBFact, const 
 inline void unpack_textureBlendFunc(E_BLEND_FACTOR &srcFact, E_BLEND_FACTOR &dstFact,
 		E_MODULATE_FUNC &modulo, u32 &alphaSource, const f32 param)
 {
-	const u32 state = IR(param);
+	const u32 state = irrBitCast<u32>(param);
 	alphaSource = (state & 0x00F00000) >> 20;
 	modulo = E_MODULATE_FUNC((state & 0x000F0000) >> 16);
 	srcFact = E_BLEND_FACTOR((state & 0x000000F0) >> 4);
@@ -147,7 +147,7 @@ inline void unpack_textureBlendFuncSeparate(E_BLEND_FACTOR &srcRGBFact, E_BLEND_
 		E_BLEND_FACTOR &srcAlphaFact, E_BLEND_FACTOR &dstAlphaFact,
 		E_MODULATE_FUNC &modulo, u32 &alphaSource, const f32 param)
 {
-	const u32 state = IR(param);
+	const u32 state = irrBitCast<u32>(param);
 	alphaSource = (state & 0x00F00000) >> 20;
 	modulo = E_MODULATE_FUNC((state & 0x000F0000) >> 16);
 	srcAlphaFact = E_BLEND_FACTOR((state & 0x0000F000) >> 12);

--- a/irr/include/irrBitCast.h
+++ b/irr/include/irrBitCast.h
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Lars Müller
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+// This belongs in irrTypes.h next to IRR_DOWN_CAST,
+// but that would pollute all include chains with <cstring> and <type_traits> which is no bueno
+
+#pragma once
+
+#include <cstring>
+#include <type_traits>
+
+// TODO in C++ 20 we'll be able to replace this with bit_cast
+template <typename T, typename U>
+T irrBitCast(const U &x)
+{
+	T res;
+	static_assert(sizeof(T) == sizeof(U));
+	static_assert(std::is_trivially_copyable_v<T>);
+	static_assert(std::is_trivially_copyable_v<U>);
+	std::memcpy(&res, &x, sizeof(U));
+	return res;
+}

--- a/irr/include/irrMath.h
+++ b/irr/include/irrMath.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "irrTypes.h"
+#include "irrBitCast.h"
 #include <cmath>
 #include <cfloat>
 #include <cstdlib> // for abs() etc.

--- a/irr/include/irrMath.h
+++ b/irr/include/irrMath.h
@@ -190,17 +190,6 @@ inline bool equalsRelative(const T a, const T b, const T factor = relativeErrorF
 	return (maxMagnitude * factor + maxi) == (maxMagnitude * factor + mini); // MAD Wise
 }
 
-union FloatIntUnion32
-{
-	FloatIntUnion32(float f1 = 0.0f) :
-			f(f1) {}
-	// Portable sign-extraction
-	bool sign() const { return (i >> 31) != 0; }
-
-	s32 i;
-	f32 f;
-};
-
 //! We compare the difference in ULP's (spacing between floating-point numbers, aka ULP=1 means there exists no float between).
 //\result true when numbers have a ULP <= maxUlpDiff AND have the same sign.
 inline bool equalsByUlp(f32 a, f32 b, int maxUlpDiff)
@@ -211,19 +200,17 @@ inline bool equalsByUlp(f32 a, f32 b, int maxUlpDiff)
 	// by one integer number. Also works the other way round, an integer of 1 interpreted as float
 	// is for example the smallest possible float number.
 
-	const FloatIntUnion32 fa(a);
-	const FloatIntUnion32 fb(b);
+	const auto ai = irrBitCast<s32>(a);
+	const auto bi = irrBitCast<s32>(b);
 
 	// Different signs, we could maybe get difference to 0, but so close to 0 using epsilons is better.
-	if (fa.sign() != fb.sign()) {
+	if (std::signbit(a) != std::signbit(b)) {
 		// Check for equality to make sure +0==-0
-		if (fa.i == fb.i)
-			return true;
-		return false;
+		return a == b;
 	}
 
 	// Find the difference in ULPs.
-	const int ulpsDiff = abs_(fa.i - fb.i);
+	const int ulpsDiff = std::abs(ai - bi);
 	if (ulpsDiff <= maxUlpDiff)
 		return true;
 
@@ -284,6 +271,7 @@ inline s32 s32_clamp(s32 value, s32 low, s32 high)
 // integer log2 of an integer. returning 0 if denormal
 inline s32 u32_log2(u32 in)
 {
+	// TODO use std::bit_width once we're on C++ 20
 	s32 ret = 0;
 	while (in > 1) {
 		in >>= 1;
@@ -304,36 +292,6 @@ inline s32 u32_log2(u32 in)
 	+NaN   0x7fc00000 or 0x7ff00000
 	in general: number = (sign ? -1:1) * 2^(exponent) * 1.(mantissa bits)
 */
-
-typedef union
-{
-	u32 u;
-	s32 s;
-	f32 f;
-} inttofloat;
-
-//! code is taken from IceFPU
-//! Integer representation of a floating-point value.
-inline u32 IR(f32 x)
-{
-	inttofloat tmp;
-	tmp.f = x;
-	return tmp.u;
-}
-
-//! Floating-point representation of an integer value.
-inline f32 FR(u32 x)
-{
-	inttofloat tmp;
-	tmp.u = x;
-	return tmp.f;
-}
-inline f32 FR(s32 x)
-{
-	inttofloat tmp;
-	tmp.s = x;
-	return tmp.f;
-}
 
 #define F32_LOWER_0(n) ((n) < 0.0f)
 #define F32_LOWER_EQUAL_0(n) ((n) <= 0.0f)
@@ -435,6 +393,3 @@ inline f32 fract(f32 x)
 }
 
 } // end namespace core
-
-using core::FR;
-using core::IR;

--- a/irr/include/irrTypes.h
+++ b/irr/include/irrTypes.h
@@ -6,6 +6,8 @@
 
 #include <cstdint>
 #include <cassert>
+#include <cstring>
+#include <type_traits>
 
 //! 8 bit unsigned variable.
 typedef uint8_t u8;
@@ -71,6 +73,18 @@ typedef char fschar_t;
 #else
 #define IRR_DOWN_CAST dynamic_cast
 #endif
+
+// TODO in C++ 20 we'll be able to replace this with bit_cast
+template <typename T, typename U>
+T irrBitCast(const U &x)
+{
+	T res;
+	static_assert(sizeof(T) == sizeof(U));
+	static_assert(std::is_trivially_copyable_v<T>);
+	static_assert(std::is_trivially_copyable_v<U>);
+	std::memcpy(&res, &x, sizeof(U));
+	return res;
+}
 
 //! creates four CC codes used in Irrlicht for simple ids
 /** some compilers can create those by directly writing the

--- a/irr/include/irrTypes.h
+++ b/irr/include/irrTypes.h
@@ -6,8 +6,6 @@
 
 #include <cstdint>
 #include <cassert>
-#include <cstring>
-#include <type_traits>
 
 //! 8 bit unsigned variable.
 typedef uint8_t u8;
@@ -73,18 +71,6 @@ typedef char fschar_t;
 #else
 #define IRR_DOWN_CAST dynamic_cast
 #endif
-
-// TODO in C++ 20 we'll be able to replace this with bit_cast
-template <typename T, typename U>
-T irrBitCast(const U &x)
-{
-	T res;
-	static_assert(sizeof(T) == sizeof(U));
-	static_assert(std::is_trivially_copyable_v<T>);
-	static_assert(std::is_trivially_copyable_v<U>);
-	std::memcpy(&res, &x, sizeof(U));
-	return res;
-}
 
 //! creates four CC codes used in Irrlicht for simple ids
 /** some compilers can create those by directly writing the

--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -1827,8 +1827,7 @@ void COpenGLDriver::setBasicRenderStates(const SMaterial &material, const SMater
 	}
 
 	// Blend Factor
-	if (IR(material.BlendFactor) & 0xFFFFFFFF // TODO: why the & 0xFFFFFFFF?
-			&& material.MaterialType != EMT_ONETEXTURE_BLEND) {
+	if (material.BlendFactor != 0.0f && material.MaterialType != EMT_ONETEXTURE_BLEND) {
 		E_BLEND_FACTOR srcRGBFact = EBF_ZERO;
 		E_BLEND_FACTOR dstRGBFact = EBF_ZERO;
 		E_BLEND_FACTOR srcAlphaFact = EBF_ZERO;

--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -2,8 +2,9 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
-#include "COpenGLDriver.h"
 #include <cassert>
+
+#include "COpenGLDriver.h"
 #include "CNullDriver.h"
 #include "EHardwareBufferFlags.h"
 #include "HWBuffer.h"

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -1147,8 +1147,8 @@ bool CXMeshFileLoader::parseDataObjectMeshMaterialList(SXMesh &mesh)
 
 	// in version 03.02, the face indices end with two semicolons.
 	// commented out version check, as version 03.03 exported from blender also has 2 semicolons
-	if (!BinaryFormat) { // && MajorVersion == 3 && MinorVersion <= 2)
-		if (P[0] == ';')
+	if (!eof() && !BinaryFormat) { // && MajorVersion == 3 && MinorVersion <= 2)
+		if (*P == ';')
 			++P;
 	}
 
@@ -1584,47 +1584,37 @@ core::stringc CXMeshFileLoader::getNextToken()
 		// in binary mode it will only return NAME and STRING token
 		// and (correctly) skip over other tokens.
 
-		s16 tok = readBinWord();
+		const auto tok = readBinNum<u16>();
 		u32 len;
-		if (P >= End)
+		if (eof())
 			return core::stringc();
-
-		const auto read_string = [&]() {
-			u32 len = readBinDWord();
-			if (P >= End)
-				return core::stringc();
-			len = (u32) std::min<size_t>(len, End - P);
-			core::stringc res(P, len);
-			P += len;
-			return res;
-		};
 
 		// standalone tokens
 		switch (tok) {
 		case 1:
 			// name token
-			return read_string();
+			return readBinString();
 		case 2:
 			// string token
-			s = read_string();
+			s = readBinString();
 			// unclear what is being skipped here, probably a null terminator in UTF-16
-			P += 2;
+			advance(2);
 			return s;
 		case 3:
 			// integer token
-			P += 4;
+			advance(4);
 			return "<integer>";
 		case 5:
 			// GUID token
-			P += 16;
+			advance(16);
 			return "<guid>";
 		case 6:
-			len = readBinDWord();
-			P += (len * 4);
+			len = readBinNum<u32>();
+			advance(len * 4);
 			return "<int_list>";
 		case 7:
-			len = readBinDWord();
-			P += (len * FloatSize);
+			len = readBinNum<u32>();
+			advance(len * FloatSize);
 			return "<flt_list>";
 		case 0x0a:
 			return "{";
@@ -1682,19 +1672,19 @@ core::stringc CXMeshFileLoader::getNextToken()
 	else {
 		findNextNoneWhiteSpace();
 
-		if (P >= End)
+		if (eof())
 			return s;
 
-		while ((P < End) && !core::isspace(P[0])) {
+		while (!eof() && !core::isspace(*P)) {
 			// either keep token delimiters when already holding a token, or return if first valid char
-			if (P[0] == ';' || P[0] == '}' || P[0] == '{' || P[0] == ',') {
+			if (*P == ';' || *P == '}' || *P == '{' || *P == ',') {
 				if (!s.size()) {
-					s.append(P[0]);
+					s.append(*P);
 					++P;
 				}
 				break; // stop for delimiter
 			}
-			s.append(P[0]);
+			s.append(*P);
 			++P;
 		}
 	}
@@ -1708,8 +1698,8 @@ void CXMeshFileLoader::findNextNoneWhiteSpaceNumber()
 	if (BinaryFormat)
 		return;
 
-	while ((P < End) && (P[0] != '-') && (P[0] != '.') &&
-			!(core::isdigit(P[0]))) {
+	while (!eof() && (*P != '-') && (*P != '.') &&
+			!(core::isdigit(*P))) {
 		// check if this is a comment
 		if ((P[0] == '/' && P[1] == '/') || P[0] == '#')
 			readUntilEndOfLine();
@@ -1725,18 +1715,17 @@ void CXMeshFileLoader::findNextNoneWhiteSpace()
 		return;
 
 	while (true) {
-		while ((P < End) && core::isspace(P[0])) {
+		while (!eof() && core::isspace(*P)) {
 			if (*P == '\n')
 				++Line;
 			++P;
 		}
 
-		if (P >= End)
+		if (eof())
 			return;
 
 		// check if this is a comment
-		if ((P[0] == '/' && P[1] == '/') ||
-				P[0] == '#')
+		if ((P[0] == '/' && (!eof() && P[1] == '/')) || P[0] == '#')
 			readUntilEndOfLine();
 		else
 			break;
@@ -1752,19 +1741,22 @@ bool CXMeshFileLoader::getNextTokenAsString(core::stringc &out)
 	}
 	findNextNoneWhiteSpace();
 
-	if (P >= End)
+	if (eof())
 		return false;
 
-	if (P[0] != '"')
+	if (*P != '"')
 		return false;
 	++P;
 
-	while (P < End && P[0] != '"') {
-		out.append(P[0]);
+	while (!eof() && *P != '"') {
+		out.append(*P);
 		++P;
 	}
 
-	if (P[1] != ';' || P[0] != '"')
+	if (remainingBytes() < 2)
+		return false;
+
+	if (P[0] != '"' || P[1] != ';')
 		return false;
 	P += 2;
 
@@ -1776,8 +1768,8 @@ void CXMeshFileLoader::readUntilEndOfLine()
 	if (BinaryFormat)
 		return;
 
-	while (P < End) {
-		if (P[0] == '\n' || P[0] == '\r') {
+	while (!eof()) {
+		if (*P == '\n' || *P == '\r') {
 			++P;
 			++Line;
 			return;
@@ -1787,44 +1779,18 @@ void CXMeshFileLoader::readUntilEndOfLine()
 	}
 }
 
-u16 CXMeshFileLoader::readBinWord()
-{
-	if (P >= End)
-		return 0;
-#ifdef __BIG_ENDIAN__
-	const u16 tmp = os::Byteswap::byteswap(*(u16 *)P);
-#else
-	const u16 tmp = *(u16 *)P;
-#endif
-	P += 2;
-	return tmp;
-}
-
-u32 CXMeshFileLoader::readBinDWord()
-{
-	if (P >= End)
-		return 0;
-#ifdef __BIG_ENDIAN__
-	const u32 tmp = os::Byteswap::byteswap(*(u32 *)P);
-#else
-	const u32 tmp = *(u32 *)P;
-#endif
-	P += 4;
-	return tmp;
-}
-
 u32 CXMeshFileLoader::readInt()
 {
 	if (BinaryFormat) {
 		if (!BinaryNumCount) {
-			const u16 tmp = readBinWord(); // 0x06 or 0x03
+			const auto tmp = readBinNum<u16>(); // 0x06 or 0x03
 			if (tmp == 0x06)
-				BinaryNumCount = readBinDWord();
+				BinaryNumCount = readBinNum<u32>();
 			else
 				BinaryNumCount = 1; // single int
 		}
 		--BinaryNumCount;
-		return readBinDWord();
+		return readBinNum<u32>();
 	} else {
 		findNextNoneWhiteSpaceNumber();
 		char *end = nullptr;
@@ -1838,40 +1804,31 @@ f32 CXMeshFileLoader::readFloat()
 {
 	if (BinaryFormat) {
 		if (!BinaryNumCount) {
-			const u16 tmp = readBinWord(); // 0x07 or 0x42
+			const auto tmp = readBinNum<u16>(); // 0x07 or 0x42
 			if (tmp == 0x07)
-				BinaryNumCount = readBinDWord();
+				BinaryNumCount = readBinNum<u32>();
 			else
 				BinaryNumCount = 1; // single int
 		}
 		--BinaryNumCount;
-		if (FloatSize == 8) {
-#ifdef __BIG_ENDIAN__
-			// TODO: Check if data is properly converted here
-			f32 ctmp[2];
-			ctmp[1] = os::Byteswap::byteswap(*(f32 *)P);
-			ctmp[0] = os::Byteswap::byteswap(*(f32 *)(P + 4));
-			const f32 tmp = (f32)(*(f64 *)(void *)ctmp);
-#else
-			const f32 tmp = (f32)(*(f64 *)P);
-#endif
-			P += 8;
-			return tmp;
-		} else {
-#ifdef __BIG_ENDIAN__
-			const f32 tmp = os::Byteswap::byteswap(*(f32 *)P);
-#else
-			const f32 tmp = *(f32 *)P;
-#endif
-			P += 4;
-			return tmp;
-		}
+		return FloatSize == 8 ? static_cast<f32>(readBinNum<f64>()) : readBinNum<f32>();
 	}
 	findNextNoneWhiteSpaceNumber();
 	char *end = nullptr;
 	f32 ftmp = (f32)strtod(P, &end);
 	P = end;
 	return ftmp;
+}
+
+core::stringc CXMeshFileLoader::readBinString()
+{
+	auto len = readBinNum<u32>();
+	if (eof())
+		return core::stringc();
+	len = (u32) std::min<size_t>(len, End - P);
+	core::stringc res(P, len);
+	advance(len);
+	return res;
 }
 
 // read 2-dimensional vector. Stops at semicolon after second value for text file format

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -12,6 +12,8 @@
 #include "IVideoDriver.h"
 #include "IReadFile.h"
 
+#include <algorithm>
+
 #ifdef _DEBUG
 #define _XREADER_DEBUG
 #endif
@@ -963,8 +965,8 @@ bool CXMeshFileLoader::parseDataObjectMeshNormals(SXMesh &mesh)
 
 	// read face normal indices
 	const u32 nFNormals = readInt();
-	// if (nFNormals >= mesh.IndexCountPerFace.size())
-	if (0) { // this condition doesn't work for some reason
+
+	if (nFNormals > mesh.IndexCountPerFace.size()) {
 		os::Printer::log("Too many face normals found in x file", ELL_WARNING);
 		os::Printer::log("Line", core::stringc(Line).c_str(), ELL_WARNING);
 		SET_ERR_AND_RETURN();
@@ -983,11 +985,20 @@ bool CXMeshFileLoader::parseDataObjectMeshNormals(SXMesh &mesh)
 			SET_ERR_AND_RETURN();
 		}
 
+		const auto set_normal = [&](u32 normalnum) {
+			if (normalidx >= mesh.Indices.size())
+				return;
+			const auto idx = mesh.Indices[normalidx++];
+			if (normalnum >= normals.size())
+				return;
+			mesh.Vertices[idx].Normal.set(normals[normalnum]);
+		};
+
 		if (indexcount == 3) {
 			// default, only one triangle in this face
 			for (u32 h = 0; h < 3; ++h) {
 				const u32 normalnum = readInt();
-				mesh.Vertices[mesh.Indices[normalidx++]].Normal.set(normals[normalnum]);
+				set_normal(normalnum);
 			}
 		} else {
 			polygonfaces.set_used(fcnt);
@@ -996,9 +1007,9 @@ bool CXMeshFileLoader::parseDataObjectMeshNormals(SXMesh &mesh)
 				polygonfaces[h] = readInt();
 
 			for (u32 jk = 0; jk < triangles; ++jk) {
-				mesh.Vertices[mesh.Indices[normalidx++]].Normal.set(normals[polygonfaces[0]]);
-				mesh.Vertices[mesh.Indices[normalidx++]].Normal.set(normals[polygonfaces[jk + 1]]);
-				mesh.Vertices[mesh.Indices[normalidx++]].Normal.set(normals[polygonfaces[jk + 2]]);
+				set_normal(polygonfaces[0]);
+				set_normal(polygonfaces[jk + 1]);
+				set_normal(polygonfaces[jk + 2]);
 			}
 		}
 	}
@@ -1030,8 +1041,7 @@ bool CXMeshFileLoader::parseDataObjectMeshTextureCoords(SXMesh &mesh)
 	}
 
 	const u32 nCoords = readInt();
-	// if (nCoords >= mesh.Vertices.size())
-	if (0) { // this condition doesn't work for some reason
+	if (nCoords > mesh.Vertices.size()) {
 		os::Printer::log("Too many texture coords found in x file", ELL_WARNING);
 		os::Printer::log("Line", core::stringc(Line).c_str(), ELL_WARNING);
 		SET_ERR_AND_RETURN();
@@ -1106,8 +1116,8 @@ bool CXMeshFileLoader::parseDataObjectMeshMaterialList(SXMesh &mesh)
 	}
 
 	// read material count
-	const u32 nMaterials = readInt();
-	mesh.Materials.reallocate(nMaterials);
+	const u32 nMaterials = std::clamp<u32>(readInt(), 1U, 30000U /* well below s16 max */);
+	mesh.Materials.set_used(nMaterials);
 
 	// read non triangulated face material index count
 	const u32 nFaceIndices = readInt();
@@ -1125,7 +1135,7 @@ bool CXMeshFileLoader::parseDataObjectMeshMaterialList(SXMesh &mesh)
 	for (u32 tfi = 0; tfi < mesh.IndexCountPerFace.size(); ++tfi) {
 		if (tfi < nFaceIndices)
 			ind = readInt();
-		if (ind >= core::max_(nMaterials, 1U)) {
+		if (ind >= nMaterials) {
 			os::Printer::log("Out of range index found in x file", ELL_WARNING);
 			os::Printer::log("Line", core::stringc(Line).c_str(), ELL_WARNING);
 			SET_ERR_AND_RETURN();
@@ -1142,7 +1152,7 @@ bool CXMeshFileLoader::parseDataObjectMeshMaterialList(SXMesh &mesh)
 			++P;
 	}
 
-	// read following data objects
+	// Skip following data objects (materials); no material properties are read here.
 
 	while (true) {
 		core::stringc objectName = getNextToken();
@@ -1156,7 +1166,6 @@ bool CXMeshFileLoader::parseDataObjectMeshMaterialList(SXMesh &mesh)
 		} else if (objectName == "{") {
 			// template materials now available thanks to joeWright
 			objectName = getNextToken();
-			mesh.Materials.push_back(video::SMaterial());
 			getNextToken(); // skip }
 		} else if (objectName == "Material") {
 			mesh.Materials.push_back(video::SMaterial());
@@ -1577,20 +1586,29 @@ core::stringc CXMeshFileLoader::getNextToken()
 
 		s16 tok = readBinWord();
 		u32 len;
+		if (P >= End)
+			return core::stringc();
+
+		const auto read_string = [&]() {
+			u32 len = readBinDWord();
+			if (P >= End)
+				return core::stringc();
+			len = (u32) std::min<size_t>(len, End - P);
+			core::stringc res(P, len);
+			P += len;
+			return res;
+		};
 
 		// standalone tokens
 		switch (tok) {
 		case 1:
 			// name token
-			len = readBinDWord();
-			s = core::stringc(P, len);
-			P += len;
-			return s;
+			return read_string();
 		case 2:
 			// string token
-			len = readBinDWord();
-			s = core::stringc(P, len);
-			P += (len + 2);
+			s = read_string();
+			// unclear what is being skipped here, probably a null terminator in UTF-16
+			P += 2;
 			return s;
 		case 3:
 			// integer token
@@ -1832,7 +1850,7 @@ f32 CXMeshFileLoader::readFloat()
 			// TODO: Check if data is properly converted here
 			f32 ctmp[2];
 			ctmp[1] = os::Byteswap::byteswap(*(f32 *)P);
-			ctmp[0] = os::Byteswap::byteswap(*(f32 *)P + 4);
+			ctmp[0] = os::Byteswap::byteswap(*(f32 *)(P + 4));
 			const f32 tmp = (f32)(*(f64 *)(void *)ctmp);
 #else
 			const f32 tmp = (f32)(*(f64 *)P);

--- a/irr/src/CXMeshFileLoader.h
+++ b/irr/src/CXMeshFileLoader.h
@@ -17,7 +17,8 @@ class IReadFile;
 namespace scene
 {
 
-//! Meshloader capable of loading x meshes.
+//! Meshloader capable of loading .x meshes.
+//! See https://paulbourke.net/dataformats/directx/ for a specification.
 class CXMeshFileLoader : public IMeshLoader
 {
 public:

--- a/irr/src/CXMeshFileLoader.h
+++ b/irr/src/CXMeshFileLoader.h
@@ -10,6 +10,9 @@
 #include "S3DVertex.h"
 #include "SkinnedMesh.h"
 
+#include <algorithm>
+#include <cstring>
+
 namespace io
 {
 class IReadFile;
@@ -149,14 +152,51 @@ private:
 
 	void readUntilEndOfLine();
 
-	u16 readBinWord();
-	u32 readBinDWord();
+	size_t remainingBytes() { return End - P; }
+
+	// Incrementing P past End is UB, so don't do that.
+	void advance(size_t n) { P += std::min(n, remainingBytes()); }
+
+	// P == End should suffice, but P >= End is more robust.
+	bool eof() { return P >= End; }
+
+	template<size_t N>
+	std::array<u8, N> readBytes()
+	{
+		std::array<u8, N> res{}; // zeroed
+		size_t got = std::min(N, remainingBytes());
+		std::memcpy(res.data(), P, got);
+		P += got;
+		return res;
+	}
+
+	template<typename T>
+	T readBinNum()
+	{
+		const auto bytes = readBytes<sizeof(T)>();
+		T res;
+		std::memcpy(&res, bytes.data(), sizeof(T));
+#ifdef __BIG_ENDIAN__
+		res = os::Byteswap::byteswap(res);
+#endif
+		return res;
+	}
+
+	/// Read a binary-encoded string (u32 length followed by characters)
+	core::stringc readBinString();
+
 	u32 readInt();
+
 	f32 readFloat();
+
 	bool readVector2(core::vector2df &vec);
+
 	bool readVector3(core::vector3df &vec);
+
 	bool readMatrix(core::matrix4 &mat);
+
 	bool readRGB(video::SColor &color);
+
 	bool readRGBA(video::SColor &color);
 
 	SkinnedMeshBuilder AnimatedMesh;

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1301,8 +1301,7 @@ void COpenGL3DriverBase::setBasicRenderStates(const SMaterial &material, const S
 	}
 
 	// Blend Factor
-	if (IR(material.BlendFactor) & 0xFFFFFFFF // TODO: why the & 0xFFFFFFFF?
-			&& material.MaterialType != EMT_ONETEXTURE_BLEND) {
+	if (material.BlendFactor != 0.0f && material.MaterialType != EMT_ONETEXTURE_BLEND) {
 		E_BLEND_FACTOR srcRGBFact = EBF_ZERO;
 		E_BLEND_FACTOR dstRGBFact = EBF_ZERO;
 		E_BLEND_FACTOR srcAlphaFact = EBF_ZERO;

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -4,8 +4,9 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in Irrlicht.h
 
-#include "Driver.h"
 #include <cassert>
+
+#include "Driver.h"
 #include "CNullDriver.h"
 #include "IContextManager.h"
 

--- a/irr/src/os.cpp
+++ b/irr/src/os.cpp
@@ -5,6 +5,7 @@
 #include "os.h"
 #include "irrString.h"
 #include "irrMath.h"
+#include "irrBitCast.h"
 
 #if defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
 #ifdef _IRR_USE_SDL3_

--- a/irr/src/os.cpp
+++ b/irr/src/os.cpp
@@ -71,9 +71,9 @@ s64 Byteswap::byteswap(s64 num)
 }
 f32 Byteswap::byteswap(f32 num)
 {
-	u32 tmp = IR(num);
+	u32 tmp = irrBitCast<u32>(num);
 	tmp = bswap_32(tmp);
-	return (FR(tmp));
+	return irrBitCast<f32>(tmp);
 }
 }
 

--- a/irr/src/os.cpp
+++ b/irr/src/os.cpp
@@ -75,6 +75,12 @@ f32 Byteswap::byteswap(f32 num)
 	tmp = bswap_32(tmp);
 	return irrBitCast<f32>(tmp);
 }
+f64 Byteswap::byteswap(f64 num)
+{
+	u64 tmp = irrBitCast<u64>(num);
+	tmp = bswap_64(tmp);
+	return irrBitCast<f64>(tmp);
+}
 }
 
 #if defined(_IRR_WINDOWS_API_)

--- a/irr/src/os.h
+++ b/irr/src/os.h
@@ -22,6 +22,7 @@ public:
 	static u64 byteswap(u64 num);
 	static s64 byteswap(s64 num);
 	static f32 byteswap(f32 num);
+	static f64 byteswap(f64 num);
 	// prevent accidental swapping of chars
 	static inline u8 byteswap(u8 num) { return num; }
 	static inline c8 byteswap(c8 num) { return num; }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -585,7 +585,7 @@ void InventoryList::deSerialize(std::istream &is)
 		}
 		else if(name == "Item")
 		{
-			if(item_i > getSize() - 1)
+			if (item_i >= getSize())
 				throw SerializationError("too many items");
 			ItemStack item;
 			item.deSerialize(iss, m_itemdef);
@@ -593,7 +593,7 @@ void InventoryList::deSerialize(std::istream &is)
 		}
 		else if(name == "Empty")
 		{
-			if(item_i > getSize() - 1)
+			if (item_i >= getSize())
 				throw SerializationError("too many items");
 			m_items[item_i++].clear();
 		} else if (name == "Keep") {


### PR DESCRIPTION
I used Claude Fable to find potential vulnerabilities and to my surprise, it did find some memory safety issues, mostly in the `.x` loader.
So I wrote a few mostly trivial patches for them.

Related: Maybe we should take `.x` behind the shed sooner rather than later (#15619).

## How to test

`.x` models should still work. Fire up devtest and observe a healthy lava flan and cool guy.