### PR TITLE
IrrlichtMt: Improve ComboBox interaction and items <= 1 case

### DIFF
--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -29,8 +29,7 @@ CGUIComboBox::CGUIComboBox(IGUIEnvironment *environment, IGUIElement *parent,
 	ListButton = Environment->addButton(core::recti(0, 0, 1, 1), this, -1, L"");
 	if (skin && skin->getSpriteBank()) {
 		ListButton->setSpriteBank(skin->getSpriteBank());
-		ListButton->setSprite(EGBS_BUTTON_UP, skin->getIcon(EGDI_CURSOR_DOWN), skin->getColor(EGDC_WINDOW_SYMBOL));
-		ListButton->setSprite(EGBS_BUTTON_DOWN, skin->getIcon(EGDI_CURSOR_DOWN), skin->getColor(EGDC_WINDOW_SYMBOL));
+		// Use no icon for state EGBS_BUTTON_DISABLED
 	}
 	ListButton->setAlignment(EGUIA_LOWERRIGHT, EGUIA_LOWERRIGHT, EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT);
 	ListButton->setSubElement(true);
@@ -164,6 +163,9 @@ void CGUIComboBox::setSelected(s32 idx)
 		SelectedText->setText(L"");
 	else
 		SelectedText->setText(Items[Selected].Name.c_str());
+
+	if (ListButton)
+		ListButton->setEnabled(Items.size() > 1);
 }
 
 //! Sets the selected item and emits a change event.
@@ -269,9 +271,11 @@ bool CGUIComboBox::OnEvent(const SEvent &event)
 			switch (event.MouseInput.Event) {
 			case EMIE_LMOUSE_PRESSED_DOWN: {
 
-				if (!ListBox && isPointInside(p)) {
-					// Quick select: mouse down -> drag to position -> mouse up -> (selected)
-					openCloseMenu(); // open
+				if (isPointInside(p)) {
+					// If ListBox == nullptr: Quick select mode
+					//    Mouse down -> (open menu) -> drag to position -> mouse up -> (selected)
+					// If ListBox != nullptr: Close combo box
+					openCloseMenu();
 					return true;
 				}
 
@@ -383,8 +387,14 @@ void CGUIComboBox::draw()
 		SelectedText->setDrawBackground(false);
 		SelectedText->setOverrideColor(skin->getColor(EGDC_GRAY_TEXT));
 	}
-	ListButton->setSprite(EGBS_BUTTON_UP, skin->getIcon(EGDI_CURSOR_DOWN), skin->getColor(isEnabled() ? EGDC_WINDOW_SYMBOL : EGDC_GRAY_WINDOW_SYMBOL));
-	ListButton->setSprite(EGBS_BUTTON_DOWN, skin->getIcon(EGDI_CURSOR_DOWN), skin->getColor(isEnabled() ? EGDC_WINDOW_SYMBOL : EGDC_GRAY_WINDOW_SYMBOL));
+
+	{
+		u32           icon  = skin->getIcon (ListBox     ? EGDI_CURSOR_UP     : EGDI_CURSOR_DOWN);
+		video::SColor color = skin->getColor(isEnabled() ? EGDC_WINDOW_SYMBOL : EGDC_GRAY_WINDOW_SYMBOL);
+
+		ListButton->setSprite(EGBS_BUTTON_UP,   icon, color);
+		ListButton->setSprite(EGBS_BUTTON_DOWN, icon, color);
+	}
 
 	core::rect<s32> frameRect(AbsoluteRect);
 
@@ -405,6 +415,9 @@ void CGUIComboBox::openCloseMenu()
 		ListBox->remove();
 		ListBox = nullptr;
 	} else {
+		if (Items.size() <= 1)
+			return; // Too few entries. Do nothing.
+
 		if (Parent) {
 			SEvent event;
 			event.EventType = EET_GUI_EVENT;

--- a/irr/src/CGUIComboBox.cpp
+++ b/irr/src/CGUIComboBox.cpp
@@ -164,8 +164,7 @@ void CGUIComboBox::setSelected(s32 idx)
 	else
 		SelectedText->setText(Items[Selected].Name.c_str());
 
-	if (ListButton)
-		ListButton->setEnabled(Items.size() > 1);
+	ListButton->setEnabled(Items.size() > 1);
 }
 
 //! Sets the selected item and emits a change event.


### PR DESCRIPTION
**With this PR:**

Multiple options (items), regular look:
<img width="407" height="88" alt="grafik" src="https://github.com/user-attachments/assets/aef2c7be-a772-4e54-bae0-47a25510e5be" />

Multiple options, opened:
<img width="404" height="204" alt="grafik" src="https://github.com/user-attachments/assets/4ece8ec9-e573-4bee-878f-d0c023ee362b" />

Single option: (button is disabled)
<img width="396" height="84" alt="grafik" src="https://github.com/user-attachments/assets/1bf40810-5703-4370-beb7-6d384a0f3866" />

Fixes #16525


## To do

This PR is Ready for Review.

## How to test

1. Edit a `game.conf` file to contain `allowed_mapgens = singlenode`
2. Interact with the dropdown (the selection list cannot be opened because there is only one option)

Also:
1. Open the dropdown (with > 1 option)
2. Click into the dropdown to close the selection list
