### PR TITLE
[no squash] HUD: Divorce SSM and CSM

### DIFF
--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -204,3 +204,36 @@ core.register_chatcommand("text", {
 core.register_on_mods_loaded(function()
 	core.log("Yeah preview mod is loaded with other CSM mods.")
 end)
+
+
+-- Test commands
+
+local id_list = {}
+core.register_chatcommand("test_hud", {
+	func = function(param)
+		if param == "list" then
+			print(dump(core.localplayer:hud_get_all()))
+			return true, "See stdout"
+		elseif param == "add" then
+			local n = math.random(5) + 1
+			for i = 1, n do
+				id_list[#id_list + 1] = core.localplayer:hud_add({
+					type = "text",
+					position = {x=math.random(), y=math.random()},
+					name = "lab:" .. math.random(999),
+					text = math.random(999999)
+				})
+			end
+			return true, "Added " .. n .. " elements"
+		elseif param == "clear" then
+			local n = #id_list
+			for _, id in ipairs(id_list) do
+				assert(core.localplayer:hud_remove(id))
+			end
+			id_list = {}
+			return true, "Removed " .. n .. " elements"
+		end
+
+		return false, "Unknown command?"
+	end
+})

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2288,7 +2288,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 		return;
 	}
 
-	HudElement *e = new HudElement;
+	auto e = std::make_unique<HudElement>();
 	e->type   = static_cast<HudElementType>(event->hudadd->type);
 	e->pos    = event->hudadd->pos;
 	e->name   = event->hudadd->name;
@@ -2305,7 +2305,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
 	e->hideable  = event->hudadd->hideable;
-	m_hud_server_to_client[server_id] = player->addHud(e);
+	m_hud_server_to_client[server_id] = player->addHud(std::move(e));
 
 	delete event->hudadd;
 }
@@ -2316,8 +2316,7 @@ void Game::handleClientEvent_HudRemove(ClientEvent *event, CameraOrientation *ca
 
 	auto i = m_hud_server_to_client.find(event->hudrm.id);
 	if (i != m_hud_server_to_client.end()) {
-		HudElement *e = player->removeHud(i->second);
-		delete e;
+		player->removeHud(i->second);
 		m_hud_server_to_client.erase(i);
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2305,7 +2305,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
 	e->hideable  = event->hudadd->hideable;
-	m_hud_server_to_client[server_id] = player->addHud(std::move(e));
+	m_hud_server_to_client[server_id] = player->hud.add(std::move(e));
 
 	delete event->hudadd;
 }
@@ -2316,7 +2316,7 @@ void Game::handleClientEvent_HudRemove(ClientEvent *event, CameraOrientation *ca
 
 	auto i = m_hud_server_to_client.find(event->hudrm.id);
 	if (i != m_hud_server_to_client.end()) {
-		player->removeHud(i->second);
+		player->hud.remove(i->second);
 		m_hud_server_to_client.erase(i);
 	}
 
@@ -2330,7 +2330,7 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 	auto i = m_hud_server_to_client.find(event->hudchange->id);
 	if (i != m_hud_server_to_client.end()) {
-		e = player->getHud(i->second);
+		e = player->hud.get(i->second);
 	}
 
 	if (e == nullptr) {

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -308,7 +308,7 @@ void Hud::drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f al
 
 bool Hud::hasElementOfType(HudElementType type)
 {
-	for (HudElement *e : player->getHudElements()) {
+	for (auto const &e : player->getHudElements()) {
 		if (e && e->type == type)
 			return true;
 	}
@@ -342,10 +342,9 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 
 	std::vector<HudElement*> elems;
 
-	elems.reserve(player->getHudElements().size());
-	for (HudElement *e : player->getHudElements()) {
+	for (auto const &e : player->getHudElements()) {
 		if (e)
-			elems.push_back(e);
+			elems.push_back(e.get());
 	}
 
 	// Add builtin elements if the server doesn't send them.

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -308,7 +308,11 @@ void Hud::drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f al
 
 bool Hud::hasElementOfType(HudElementType type)
 {
-	for (auto const &e : player->getHudElements()) {
+	for (auto const &e : player->hud.getElements()) {
+		if (e && e->type == type)
+			return true;
+	}
+	for (auto const &e : player->csm_hud.getElements()) {
 		if (e && e->type == type)
 			return true;
 	}
@@ -342,7 +346,12 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 
 	std::vector<HudElement*> elems;
 
-	for (auto const &e : player->getHudElements()) {
+	elems.reserve(player->hud.getElements().size() + player->csm_hud.getElements().size());
+	for (auto const &e : player->hud.getElements()) {
+		if (e)
+			elems.push_back(e.get());
+	}
+	for (auto const &e : player->csm_hud.getElements()) {
 		if (e)
 			elems.push_back(e.get());
 	}

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -12,6 +12,7 @@
 #include "map.h"
 #include "client.h"
 #include "content_cao.h"
+#include "hud_element.h"
 
 /*
 	PlayerSettings

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -105,6 +105,8 @@ public:
 	float hurt_tilt_timer = 0.0f;
 	float hurt_tilt_strength = 0.0f;
 
+	PlayerHud csm_hud;
+
 	GenericCAO *getCAO() const { return m_cao; }
 
 	ClientActiveObject *getParent() const;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -72,7 +72,6 @@ Player::Player(const std::string &name, IItemDefManager *idef):
 
 Player::~Player()
 {
-	clearHud();
 }
 
 void Player::setWieldIndex(u16 index)
@@ -103,14 +102,14 @@ ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return (hand && selected->name.empty()) ? *hand : *selected;
 }
 
-u32 Player::addHud(HudElement *toadd)
+u32 Player::addHud(std::unique_ptr<HudElement> toadd)
 {
 	u32 id = getFreeHudID();
 
 	if (id < hud.size())
-		hud[id] = toadd;
+		hud[id] = std::move(toadd);
 	else
-		hud.push_back(toadd);
+		hud.push_back(std::move(toadd));
 
 	return id;
 }
@@ -118,29 +117,26 @@ u32 Player::addHud(HudElement *toadd)
 HudElement* Player::getHud(u32 id)
 {
 	if (id < hud.size())
-		return hud[id];
+		return hud[id].get();
 	return nullptr;
 }
 
-HudElement* Player::removeHud(u32 id)
+bool Player::removeHud(u32 id)
 {
-	HudElement* retval = nullptr;
+	bool removed = false;
 	if (id < hud.size()) {
-		retval = hud[id];
-		hud[id] = nullptr;
+		hud[id].reset();
+		removed = true;
 	}
 	// shrink list if possible
 	while (!hud.empty() && hud.back() == nullptr)
 		hud.pop_back();
-	return retval;
+	return removed;
 }
 
 void Player::clearHud()
 {
-	while (!hud.empty()) {
-		delete hud.back();
-		hud.pop_back();
-	}
+	hud.clear();
 }
 
 u16 Player::getMaxHotbarItemcount()

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -102,41 +102,51 @@ ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 	return (hand && selected->name.empty()) ? *hand : *selected;
 }
 
-u32 Player::addHud(std::unique_ptr<HudElement> toadd)
+u32 PlayerHud::getFreeID()
 {
-	u32 id = getFreeHudID();
+	size_t size = m_elements.size();
+	for (size_t i = 0; i != size; i++) {
+		if (!m_elements[i])
+			return i;
+	}
+	return size;
+}
 
-	if (id < hud.size())
-		hud[id] = std::move(toadd);
+u32 PlayerHud::add(std::unique_ptr<HudElement> toadd)
+{
+	u32 id = getFreeID();
+
+	if (id < m_elements.size())
+		m_elements[id] = std::move(toadd);
 	else
-		hud.push_back(std::move(toadd));
+		m_elements.push_back(std::move(toadd));
 
 	return id;
 }
 
-HudElement* Player::getHud(u32 id)
+HudElement* PlayerHud::get(u32 id)
 {
-	if (id < hud.size())
-		return hud[id].get();
+	if (id < m_elements.size())
+		return m_elements[id].get();
 	return nullptr;
 }
 
-bool Player::removeHud(u32 id)
+bool PlayerHud::remove(u32 id)
 {
 	bool removed = false;
-	if (id < hud.size()) {
-		hud[id].reset();
+	if (id < m_elements.size()) {
+		m_elements[id].reset();
 		removed = true;
 	}
 	// shrink list if possible
-	while (!hud.empty() && hud.back() == nullptr)
-		hud.pop_back();
+	while (!m_elements.empty() && m_elements.back() == nullptr)
+		m_elements.pop_back();
 	return removed;
 }
 
-void Player::clearHud()
+void PlayerHud::clear()
 {
-	hud.clear();
+	m_elements.clear();
 }
 
 u16 Player::getMaxHotbarItemcount()

--- a/src/player.h
+++ b/src/player.h
@@ -124,6 +124,25 @@ struct PlayerPhysicsOverride
 	}
 };
 
+struct HudElement;
+
+struct PlayerHud
+{
+	const auto &getElements() const { return m_elements; }
+	/// Returns `nullptr` if not found
+	HudElement *get(u32 id);
+	/// Returns the ID of the added element
+	u32         add(std::unique_ptr<HudElement> e);
+	/// Returns whether removal succeeded
+	bool        remove(u32 id);
+	void        clear();
+
+private:
+	u32 getFreeID();
+
+	std::vector<std::unique_ptr<HudElement>> m_elements;
+};
+
 /// @note numeric values are part of network protocol
 enum CameraMode : int {
 	// not a mode. indicates that any may be used.
@@ -136,8 +155,6 @@ enum CameraMode : int {
 };
 
 extern const struct EnumString es_CameraMode[];
-
-struct HudElement;
 
 class Player
 {
@@ -158,16 +175,6 @@ public:
 	v3f getSpeed() const { return m_speed; }
 
 	const std::string& getName() const { return m_name; }
-
-	u32 getFreeHudID()
-	{
-		size_t size = hud.size();
-		for (size_t i = 0; i != size; i++) {
-			if (!hud[i])
-				return i;
-		}
-		return size;
-	}
 
 	CameraMode allowed_camera_mode = CAMERA_MODE_ANY;
 
@@ -219,11 +226,7 @@ public:
 		return m_fov_override_spec;
 	}
 
-	const auto &getHudElements() const { return hud; }
-	HudElement* getHud(u32 id);
-	u32         addHud(std::unique_ptr<HudElement> hud);
-	bool        removeHud(u32 id);
-	void        clearHud();
+	PlayerHud hud;
 
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;
@@ -236,7 +239,4 @@ protected:
 	v3f m_speed; // velocity; in BS-space
 	u16 m_wield_index = 0;
 	PlayerFovSpec m_fov_override_spec = { 0.0f, false, 0.0f };
-
-private:
-	std::vector<std::unique_ptr<HudElement>> hud;
 };

--- a/src/player.h
+++ b/src/player.h
@@ -7,6 +7,7 @@
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
 #include "util/basic_macros.h"
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -220,8 +221,8 @@ public:
 
 	const auto &getHudElements() const { return hud; }
 	HudElement* getHud(u32 id);
-	u32         addHud(HudElement* hud);
-	HudElement* removeHud(u32 id);
+	u32         addHud(std::unique_ptr<HudElement> hud);
+	bool        removeHud(u32 id);
 	void        clearHud();
 
 	u32 hud_flags;
@@ -237,5 +238,5 @@ protected:
 	PlayerFovSpec m_fov_override_spec = { 0.0f, false, 0.0f };
 
 private:
-	std::vector<HudElement *> hud;
+	std::vector<std::unique_ptr<HudElement>> hud;
 };

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -357,12 +357,11 @@ int LuaLocalPlayer::l_hud_add(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 
-	HudElement *elem = new HudElement;
-	read_hud_element(L, elem);
+	auto elem = std::make_unique<HudElement>();
+	read_hud_element(L, elem.get());
 
-	u32 id = player->addHud(elem);
+	u32 id = player->addHud(std::move(elem));
 	if (id == U32_MAX) {
-		delete elem;
 		return 0;
 	}
 	lua_pushnumber(L, id);
@@ -374,12 +373,7 @@ int LuaLocalPlayer::l_hud_remove(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 	u32 id = luaL_checkinteger(L, 2);
-	HudElement *element = player->removeHud(id);
-	if (!element)
-		lua_pushboolean(L, false);
-	else
-		lua_pushboolean(L, true);
-	delete element;
+	lua_pushboolean(L, player->removeHud(id));
 	return 1;
 }
 
@@ -428,9 +422,9 @@ int LuaLocalPlayer::l_hud_get_all(lua_State *L)
 
 	lua_newtable(L);
 	u32 id = 0;
-	for (HudElement *elem : player->getHudElements()) {
+	for (auto const &elem : player->getHudElements()) {
 		if (elem != nullptr) {
-			push_hud_element(L, elem);
+			push_hud_element(L, elem.get());
 			lua_rawseti(L, -2, id);
 		}
 		++id;

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -360,7 +360,7 @@ int LuaLocalPlayer::l_hud_add(lua_State *L)
 	auto elem = std::make_unique<HudElement>();
 	read_hud_element(L, elem.get());
 
-	u32 id = player->addHud(std::move(elem));
+	u32 id = player->csm_hud.add(std::move(elem));
 	if (id == U32_MAX) {
 		return 0;
 	}
@@ -373,7 +373,7 @@ int LuaLocalPlayer::l_hud_remove(lua_State *L)
 {
 	LocalPlayer *player = getobject(L, 1);
 	u32 id = luaL_checkinteger(L, 2);
-	lua_pushboolean(L, player->removeHud(id));
+	lua_pushboolean(L, player->csm_hud.remove(id));
 	return 1;
 }
 
@@ -384,7 +384,7 @@ int LuaLocalPlayer::l_hud_change(lua_State *L)
 
 	u32 id = luaL_checkinteger(L, 2);
 
-	HudElement *element = player->getHud(id);
+	HudElement *element = player->csm_hud.get(id);
 	if (!element)
 		return 0;
 
@@ -403,7 +403,7 @@ int LuaLocalPlayer::l_hud_get(lua_State *L)
 
 	u32 id = luaL_checkinteger(L, -1);
 
-	HudElement *e = player->getHud(id);
+	HudElement *e = player->csm_hud.get(id);
 	if (!e) {
 		lua_pushnil(L);
 		return 1;
@@ -422,7 +422,7 @@ int LuaLocalPlayer::l_hud_get_all(lua_State *L)
 
 	lua_newtable(L);
 	u32 id = 0;
-	for (auto const &elem : player->getHudElements()) {
+	for (auto const &elem : player->csm_hud.getElements()) {
 		if (elem != nullptr) {
 			push_hud_element(L, elem.get());
 			lua_rawseti(L, -2, id);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1824,12 +1824,11 @@ int ObjectRef::l_hud_add(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	HudElement *elem = new HudElement;
-	read_hud_element(L, elem);
+	auto elem = std::make_unique<HudElement>();
+	read_hud_element(L, elem.get());
 
-	u32 id = getServer(L)->hudAdd(player, elem);
+	u32 id = getServer(L)->hudAdd(player, std::move(elem));
 	if (id == U32_MAX) {
-		delete elem;
 		return 0;
 	}
 
@@ -1912,9 +1911,9 @@ int ObjectRef::l_hud_get_all(lua_State *L)
 
 	lua_newtable(L);
 	u32 id = 0;
-	for (HudElement *elem : player->getHudElements()) {
+	for (auto const &elem : player->getHudElements()) {
 		if (elem != nullptr) {
-			push_hud_element(L, elem);
+			push_hud_element(L, elem.get());
 			lua_rawseti(L, -2, id);
 		}
 		++id;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1865,7 +1865,7 @@ int ObjectRef::l_hud_change(lua_State *L)
 
 	u32 id = luaL_checkint(L, 2);
 
-	HudElement *elem = player->getHud(id);
+	HudElement *elem = player->hud.get(id);
 	if (elem == nullptr)
 		return 0;
 
@@ -1892,7 +1892,7 @@ int ObjectRef::l_hud_get(lua_State *L)
 
 	u32 id = luaL_checkint(L, 2);
 
-	HudElement *elem = player->getHud(id);
+	HudElement *elem = player->hud.get(id);
 	if (elem == nullptr)
 		return 0;
 
@@ -1911,7 +1911,7 @@ int ObjectRef::l_hud_get_all(lua_State *L)
 
 	lua_newtable(L);
 	u32 id = 0;
-	for (auto const &elem : player->getHudElements()) {
+	for (auto const &elem : player->hud.getElements()) {
 		if (elem != nullptr) {
 			push_hud_element(L, elem.get());
 			lua_rawseti(L, -2, id);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1261,7 +1261,7 @@ PlayerSAO *Server::StageTwoClientInit(session_t peer_id)
 	m_env->addPlayer(player);
 
 	/* Clean up old HUD elements from previous sessions */
-	player->clearHud();
+	player->hud.clear();
 
 	/* Add object to environment */
 	PlayerSAO *playersao = sao.get();
@@ -3536,9 +3536,9 @@ u32 Server::hudAdd(RemotePlayer *player, std::unique_ptr<HudElement> form)
 	if (!player)
 		return -1;
 
-	u32 id = player->addHud(std::move(form));
+	u32 id = player->hud.add(std::move(form));
 
-	SendHUDAdd(player->getPeerId(), id, player->getHud(id));
+	SendHUDAdd(player->getPeerId(), id, player->hud.get(id));
 
 	return id;
 }
@@ -3547,7 +3547,7 @@ bool Server::hudRemove(RemotePlayer *player, u32 id) {
 	if (!player)
 		return false;
 
-	if (!player->removeHud(id))
+	if (!player->hud.remove(id))
 		return false;
 
 	SendHUDRemove(player->getPeerId(), id);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3531,14 +3531,14 @@ bool Server::showFormspec(const char *playername, const std::string &formspec,
 	return true;
 }
 
-u32 Server::hudAdd(RemotePlayer *player, HudElement *form)
+u32 Server::hudAdd(RemotePlayer *player, std::unique_ptr<HudElement> form)
 {
 	if (!player)
 		return -1;
 
-	u32 id = player->addHud(form);
+	u32 id = player->addHud(std::move(form));
 
-	SendHUDAdd(player->getPeerId(), id, form);
+	SendHUDAdd(player->getPeerId(), id, player->getHud(id));
 
 	return id;
 }
@@ -3547,12 +3547,8 @@ bool Server::hudRemove(RemotePlayer *player, u32 id) {
 	if (!player)
 		return false;
 
-	HudElement* todel = player->removeHud(id);
-
-	if (!todel)
+	if (!player->removeHud(id))
 		return false;
-
-	delete todel;
 
 	SendHUDRemove(player->getPeerId(), id);
 	return true;

--- a/src/server.h
+++ b/src/server.h
@@ -370,7 +370,7 @@ public:
 	ServerEnvironment & getEnv() { return *m_env; }
 	v3f findSpawnPos();
 
-	u32 hudAdd(RemotePlayer *player, HudElement *element);
+	u32 hudAdd(RemotePlayer *player, std::unique_ptr<HudElement> element);
 	bool hudRemove(RemotePlayer *player, u32 id);
 	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);


### PR DESCRIPTION
This is an alternative to #17214
CSM can no longer access SSM HUD elements.
They are stored in separate vectors, so no ID mapping is necessary.

In addition, this PR replaces the raw pointers in the HUD vector with unique pointers.

## To do

Ready for Review.

- [ ] Figure out if the client server ID mapping is still needed (`Game::m_hud_server_to_client`)

## How to test

Add this to a CSM mod:
``` lua
core.register_chatcommand("hudadd", {
	func = function()
		core.localplayer:hud_add({type = "text",text = "CSM", position = {x = 0.5, y = 0.5}})
		print(dump(core.localplayer:hud_get_all()))
	end
})
core.register_chatcommand("hudremove", {
	func = function()
		core.localplayer:hud_remove(0)
		print(dump(core.localplayer:hud_get_all()))
	end
})
```
Start devtest and execute:
`.hudadd`
`/hudprint`
`.hudremove`
