### PR TITLE
IrrlichtMt: Remove clamping of mouse pointer to window bounds with SDL driver

### DIFF
--- a/irr/include/ICursorControl.h
+++ b/irr/include/ICursorControl.h
@@ -133,7 +133,8 @@ public:
 		When false return the last known (buffered) position ( this is useful to
 		check what has become of a setPosition call with float numbers).
 	\return Returns the current position of the cursor. The returned position
-	is the position of the mouse cursor in pixel units. */
+	is the position of the mouse cursor in pixel units. The returned position
+	may be outside of the window bounds. */
 	virtual const core::position2d<s32> &getPosition(bool updateCursor = true) = 0;
 
 	//! Returns the current position of the mouse cursor.

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -261,15 +261,6 @@ public:
 #else
 			CursorPos.X = Device->MouseX;
 			CursorPos.Y = Device->MouseY;
-
-			if (CursorPos.X < 0)
-				CursorPos.X = 0;
-			if (CursorPos.X > (s32)Device->Width)
-				CursorPos.X = Device->Width;
-			if (CursorPos.Y < 0)
-				CursorPos.Y = 0;
-			if (CursorPos.Y > (s32)Device->Height)
-				CursorPos.Y = Device->Height;
 #endif
 		}
 


### PR DESCRIPTION
Hello.  I was having an issue under Wayland on Linux using the SDL driver with a slow moving camera.  Moving the camera too fast would cause it to reach a top speed, resulting in a sluggish-feeling camera.  I found the cause to be clamping of the mouse pointer's position in the SDL driver to be within the window bounds.  Removing the clamping makes the camera behave as expected, and with some basic testing I could not find any issues caused by removing the clamping.

I tried looking into the commit history to see why clamping is done here, and this code dates back to at least the root commit for the IrrlichtMt repo on GitHub, which was over 6 years ago.  I gave up after that, as I don't know how to use SVN.  Thus, I'm not sure why this clamping was added in the first place.

## To do

This PR is Ready for Review.

## How to test

Run the game with a small window size and try moving the mouse quickly.  Before, the camera speed would get clamped.  Now, it works as expected.