### PR TITLE
Craftrecipe Item Wear Feature

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -774,3 +774,37 @@ function core.get_node_or_nil(pos)
 			{name = get_name_from_content_id(content), param1 = param1, param2 = param2}
 			or nil
 end
+
+--
+-- Tool wear inside craftrecipe, uses {craft_wear = [uses]} group
+--
+
+core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
+	for index, item in ipairs(old_craft_grid) do
+		local item_name = item:get_name()
+		local can_wear = core.get_item_group(item_name, "craft_wear")
+		local is_tool = core.registered_tools[item_name]
+
+		if is_tool and can_wear > 0 then
+			local current_stack = craft_inv:get_stack("craft", index)
+			-- add wear only if tool is returned as a replacement
+			if current_stack:get_name() == item_name then
+				local new_wear = item:get_wear() + (65535 / can_wear + 1)
+				-- tool broken, remove and play sound
+				if new_wear > 65535 then
+					craft_inv:set_stack("craft", index, ItemStack(""))
+					local pos = player:get_pos()
+					if pos then
+						local sound = is_tool.sound and is_tool.sound.breaks or
+								"default_tool_breaks"
+						core.sound_play(sound,
+								{pos = pos, gain = 0.3, max_hear_distance = 1}, true)
+					end
+				else
+					current_stack:set_wear(new_wear)
+					craft_inv:set_stack("craft", index, current_stack)
+				end
+			end
+		end
+	end
+end)


### PR DESCRIPTION
Adds a new group { craft_uses = [total uses] } to a tool item, which adds wear to that item when returned via replacements table inside a craft recipe.  Once [total uses] has been reached the tool breaks and plays a sound as it is removed from the craftgrid.

## How to test

<!-- Example code or instructions -->

```
core.register_tool("mymod:cooking_orb", {
	description = "Cooking Orb",
	inventory_image = "mymod_cooking_orb.png",
	groups = {craft_wear = 20},
})

core.register_craft({
	output = "farming:bread",
	recipe = {
		{"farming:flour", "mymod:cooking_orb"}
	},
	replacements = {
		{"mymod:cooking_orb", "mymod:cooking_orb"},
	}
})
```
