### PR TITLE
More efficient, approximate, layered server occlusion culling

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2383,8 +2383,8 @@ block_send_optimize_distance (Block send optimize distance) int 4 2 2047
 server_side_occlusion_culling (Server-side occlusion culling) bool true
 
 #    At this distance the server will perform a simpler and cheaper occlusion check.
-#    Smaller values potentially improve performance, at the expense of temporarily visible
-#    rendering glitches (missing blocks).
+#    Smaller values improve performance, at the expense of possibly loading more
+#    blocks (especially in caves of openings).
 #    This is especially useful for very large viewing range (upwards of 500).
 #    Stated in MapBlocks (16 nodes).
 block_cull_optimize_distance (Block cull optimize distance) int 25 2 2047

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2384,8 +2384,8 @@ server_side_occlusion_culling (Server-side occlusion culling) bool true
 
 #    At this distance the server will consider blocks as "far away".
 #    It will perform simpler and cheaper occlusion checks, update
-#    flowing water lazily, and limit the blocks sent to the client in
-#    one roundtrup.
+#    low priority block updates lazily, and limit the blocks sent to the
+#    client in one roundtrip.
 #    This is especially useful for very large viewing range (upwards of 500).
 #    Stated in MapBlocks (16 nodes).
 block_cull_optimize_distance (Block cull optimize distance) int 25 2 2047

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2382,9 +2382,10 @@ block_send_optimize_distance (Block send optimize distance) int 4 2 2047
 #    invisible blocks, so that the utility of noclip mode is reduced.
 server_side_occlusion_culling (Server-side occlusion culling) bool true
 
-#    At this distance the server will perform a simpler and cheaper occlusion check.
-#    Smaller values improve performance, at the expense of possibly loading more
-#    blocks (especially in caves of openings).
+#    At this distance the server will consider blocks as "far away".
+#    It will perform simpler and cheaper occlusion checks, update
+#    flowing water lazily, and limit the blocks sent to the client in
+#    one roundtrup.
 #    This is especially useful for very large viewing range (upwards of 500).
 #    Stated in MapBlocks (16 nodes).
 block_cull_optimize_distance (Block cull optimize distance) int 25 2 2047

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -667,7 +667,7 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	if (distance > 0.0f)
 		direction /= distance;
 
-	v3f pos_origin_f = intToFloat(pos_camera, BS);
+	const v3f pos_origin_f = intToFloat(pos_camera, BS);
 	u32 count = 0;
 	bool is_valid_position;
 	/*
@@ -682,14 +682,14 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	 * all-air blocks for example).
 	 * For a sparse map we need to check from the origin as before (cheap stays false).
 	 */
-	constexpr float DENSE_CHECK_DISTANCE = 3 * MAP_BLOCKSIZE;
+	constexpr float DENSE_CHECK_DISTANCE = 3 * MAP_BLOCKSIZE * 1.732f * BS;
 
 	// Starting offset
 	float offset = BS;
 	// Starting step size, value between 1m and sqrt(3)m
 	float step = BS * 1.2f;
 	// Multiply step by each iteration by 'stepfac' to reduce checks in distance
-	float stepfac = 1.05f;
+	const float stepfac = 1.05f;
 
 	bool cheap = false;
 
@@ -714,13 +714,13 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 				return true;
 			}
 		} else {
-			if (dense && offset >= DENSE_CHECK_DISTANCE * 1.732f * BS) {
+			if (dense && offset >= DENSE_CHECK_DISTANCE) {
 				// switch to "cheap" mode
 				cheap = true;
 				// reset precision
 				step = BS * 1.2f;
 				// And jump ahead to only a few blocks before our target block
-				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE * 1.732f * BS);
+				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
 			}
 			// treat unloaded blocks as transparent
 			// Cannot see through light-blocking nodes --> occluded

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -691,47 +691,42 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	// Multiply step by each iteration by 'stepfac' to reduce checks in distance
 	const float stepfac = 1.05f;
 
-	bool cheap = false;
+	// Phase 1: Preliminary search (standard sparse mode or until dense check distance)
+	for (; offset < (dense ? DENSE_CHECK_DISTANCE : distance + end_offset); offset += step) {
+		const v3f pos_node_f = pos_origin_f + direction * offset;
+		MapNode node = getNode(floatToInt(pos_node_f, BS), &is_valid_position);
 
-	for (; offset < distance + end_offset; offset += step) {
-		v3f pos_node_f = pos_origin_f + direction * offset;
-		v3s16 pos_node = floatToInt(pos_node_f, BS);
+		// treat unloaded blocks as transparent
+		// Cannot see through light-blocking nodes --> occluded
+		if (is_valid_position && !m_nodedef->getLightingFlags(node).light_propagates) {
+			if (++count >= needed_count)
+				return true;
+		}
+		step *= stepfac;
+	}
 
-		MapNode node = getNode(pos_node, &is_valid_position);
+	// Phase 2: Dense near-target search
+	if (dense && offset < distance + end_offset) {
+		// Jump ahead and reset precision for the final check
+		offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
+		step = BS * 1.2f;
 
-		if (cheap) {
+		for (; offset < distance + end_offset; offset += step) {
+			const v3f pos_node_f = pos_origin_f + direction * offset;
+			MapNode node = getNode(floatToInt(pos_node_f, BS), &is_valid_position);
+
 			// treat unloaded blocks as opaque
 			// Cannot see through non-existant blocks or light-blocking nodes --> occluded
-			if (!is_valid_position ||
-					!m_nodedef->getLightingFlags(node).light_propagates) {
+			if (!is_valid_position || !m_nodedef->getLightingFlags(node).light_propagates) {
 				/*
 				 * Note that we do not honor needed_count.
-				 * In the dense case we are more precise and traverse fewer
-				 * blocks before we reach the target block, and we *want*
-				 * the extra precisions (so that we can reuse the "unloaded"
-				 * block information)
+				 * In the dense case we *want* the extra precisions (so that we can reuse the
+				 * "unloaded" block information)
 				 */
 				return true;
 			}
-		} else {
-			// treat unloaded blocks as transparent
-			// Cannot see through light-blocking nodes --> occluded
-			if (is_valid_position &&
-					!m_nodedef->getLightingFlags(node).light_propagates) {
-				count++;
-				if (count >= needed_count)
-					return true;
-			}
-			if (dense && offset >= DENSE_CHECK_DISTANCE) {
-				// switch to "cheap" mode
-				cheap = true;
-				// reset precision
-				step = BS * 1.2f;
-				// And jump ahead to only a few blocks before our target block
-				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
-			}
+			step *= stepfac;
 		}
-		step *= stepfac;
 	}
 	return false;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -714,14 +714,6 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 				return true;
 			}
 		} else {
-			if (dense && offset >= DENSE_CHECK_DISTANCE) {
-				// switch to "cheap" mode
-				cheap = true;
-				// reset precision
-				step = BS * 1.2f;
-				// And jump ahead to only a few blocks before our target block
-				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
-			}
 			// treat unloaded blocks as transparent
 			// Cannot see through light-blocking nodes --> occluded
 			if (is_valid_position &&
@@ -729,6 +721,14 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 				count++;
 				if (count >= needed_count)
 					return true;
+			}
+			if (dense && offset >= DENSE_CHECK_DISTANCE) {
+				// switch to "cheap" mode
+				cheap = true;
+				// reset precision
+				step = BS * 1.2f;
+				// And jump ahead to only a few blocks before our target block
+				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
 			}
 		}
 		step *= stepfac;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -714,6 +714,14 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 				return true;
 			}
 		} else {
+			if (dense && offset >= DENSE_CHECK_DISTANCE * 1.732f * BS) {
+				// switch to "cheap" mode
+				cheap = true;
+				// reset precision
+				step = BS * 1.2f;
+				// And jump ahead to only a few blocks before our target block
+				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE * 1.732f * BS);
+			}
 			// treat unloaded blocks as transparent
 			// Cannot see through light-blocking nodes --> occluded
 			if (is_valid_position &&
@@ -721,14 +729,6 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 				count++;
 				if (count >= needed_count)
 					return true;
-			}
-			if (dense && offset >= DENSE_CHECK_DISTANCE * 1.732f * BS) {
-				/*
-				 * switch to "cheap" mode
-				 * And jump ahead to only a few blocks before our target block
-				 */
-				cheap = true;
-				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE * 1.732f * BS);
 			}
 		}
 		step *= stepfac;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -672,15 +672,17 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	bool is_valid_position;
 	/*
 	 * When the map is "dense" (when all visible blocks are loaded) we can start 3-4
-	 * layers before the block we want to check. Either the prior blocks are loaded
-	 * in which case we check them, or they not loaded (because they are invisible),
+	 * blocks before the target block. Either the prior blocks are loaded
+	 * in which case we check them, or they not loaded (because they are invisible,
+	 * see the occlusion logic RemoteClient::getNextBlocks(...)),
 	 * in which case we can treat them as opaque, because blocks behind cannot be
 	 * visible either. This saves a *lot* of CPU time.
-	 * The map is dense on the server, and sparse on the client (we do not even load
+	 * The map is dense on the server, and sparse on the client (we mostly don't even send
 	 * all-air blocks for example).
 	 * For a sparse map we need to check from the origin as before.
 	 */
-	float offset = dense ? std::max(BS, distance - 4.0f * 1.732f * MAP_BLOCKSIZE * BS) : BS;
+	constexpr float DENSE_CHECK_DISTANCE = 4 * MAP_BLOCKSIZE;
+	float offset = dense ? std::max(BS, distance - DENSE_CHECK_DISTANCE * 1.732f * BS) : BS;
 
 	for (; offset < distance + end_offset; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
@@ -693,6 +695,13 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 			if (!is_valid_position ||
 					!m_nodedef->getLightingFlags(node).light_propagates) {
 				// Cannot see through light-blocking nodes --> occluded
+				/*
+				 * Note that we do not honor needed_count.
+				 * In the dense case we are more precise and traverse fewer
+				 * blocks before we reach the target block, and we *want*
+				 * the extra precisions (so that we can reuse the "unloaded"
+				 * block information)
+				 */
 				return true;
 			}
 		} else {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -658,7 +658,7 @@ bool Map::determineAdditionalOcclusionCheck(const v3s16 pos_camera,
 }
 
 bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
-	float step, float stepfac, float end_offset, u32 needed_count, bool dense)
+	float end_offset, u32 needed_count, bool dense)
 {
 	v3f direction = intToFloat(pos_target - pos_camera, BS);
 	float distance = direction.getLength();
@@ -681,8 +681,16 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	 * all-air blocks for example).
 	 * For a sparse map we need to check from the origin as before.
 	 */
-	constexpr float DENSE_CHECK_DISTANCE = 4 * MAP_BLOCKSIZE;
-	float offset = dense ? std::max(BS, distance - DENSE_CHECK_DISTANCE * 1.732f * BS) : BS;
+	constexpr float DENSE_CHECK_DISTANCE = 3 * MAP_BLOCKSIZE;
+
+	// Starting offset
+	float offset = BS;
+	// Starting step size, value between 1m and sqrt(3)m
+	float step = BS * 1.2f;
+	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
+	float stepfac = 1.05f;
+
+	bool cheap = false;
 
 	for (; offset < distance + end_offset; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
@@ -690,11 +698,11 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 
 		MapNode node = getNode(pos_node, &is_valid_position);
 
-		if (dense) {
+		if (cheap) {
 			// treat unloaded blocks as opaque
+			// Cannot see through non-existant blocks or light-blocking nodes --> occluded
 			if (!is_valid_position ||
 					!m_nodedef->getLightingFlags(node).light_propagates) {
-				// Cannot see through light-blocking nodes --> occluded
 				/*
 				 * Note that we do not honor needed_count.
 				 * In the dense case we are more precise and traverse fewer
@@ -706,12 +714,20 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 			}
 		} else {
 			// treat unloaded blocks as transparent
+			// Cannot see through light-blocking nodes --> occluded
 			if (is_valid_position &&
 					!m_nodedef->getLightingFlags(node).light_propagates) {
-				// Cannot see through light-blocking nodes --> occluded
 				count++;
 				if (count >= needed_count)
 					return true;
+			}
+			if (dense && offset >= DENSE_CHECK_DISTANCE * 1.732f * BS) {
+				/*
+				 * switch to "cheap" mode
+				 * And jump ahead to only a few blocks before our target block
+				 */
+				cheap = true;
+				offset = std::max(offset, distance - DENSE_CHECK_DISTANCE * 1.732f * BS);
 			}
 		}
 		step *= stepfac;
@@ -738,11 +754,6 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool dense)
 
 	v3s16 pos_blockcenter = pos_relative + (MAP_BLOCKSIZE / 2);
 
-	// Starting step size, value between 1m and sqrt(3)m
-	float step = BS * 1.2f;
-	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
-	float stepfac = 1.05f;
-
 	// The occlusion search of 'isOccluded()' must stop short of the target
 	// point by distance 'end_offset' to not enter the target mapblock.
 	// For the 8 mapblock corners 'end_offset' must therefore be the maximum
@@ -759,13 +770,13 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool dense)
 	v3s16 check;
 	if (determineAdditionalOcclusionCheck(cam_pos_nodes, MapBlock::getBox(pos_relative), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
-		if (!isOccluded(cam_pos_nodes, check, step, stepfac,
+		if (!isOccluded(cam_pos_nodes, check,
 				-1.0f, needed_count, dense))
 			return false;
 	}
 
 	for (const v3s16 &dir : dir9) {
-		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
+		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir,
 				end_offset, needed_count, dense))
 			return false;
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -707,7 +707,7 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 
 	// Phase 2: Dense near-target search
 	if (dense && offset < distance + end_offset) {
-		// Jump ahead and reset precision for the final check
+		// Jump ahead and reset precision for the final checks
 		offset = std::max(offset, distance - DENSE_CHECK_DISTANCE);
 		step = BS * 1.2f;
 
@@ -716,13 +716,9 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 			MapNode node = getNode(floatToInt(pos_node_f, BS), &is_valid_position);
 
 			// treat unloaded blocks as opaque
-			// Cannot see through non-existant blocks or light-blocking nodes --> occluded
+			// Cannot see through non-existent blocks or light-blocking nodes --> occluded
 			if (!is_valid_position || !m_nodedef->getLightingFlags(node).light_propagates) {
-				/*
-				 * Note that we do not honor needed_count.
-				 * In the dense case we *want* the extra precisions (so that we can reuse the
-				 * "unloaded" block information)
-				 */
+				// Note: ignoring needed_count should be fine here since the preliminary search is already done
 				return true;
 			}
 			step *= stepfac;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -671,15 +671,16 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	u32 count = 0;
 	bool is_valid_position;
 	/*
-	 * When the map is "dense" (when all visible blocks are loaded) we can start 3-4
+	 * When the map is "dense" (when all visible blocks are loaded) we check
+	 * a few blocks close to the camera and then we can jump to a few
 	 * blocks before the target block. Either the prior blocks are loaded
-	 * in which case we check them, or they not loaded (because they are invisible,
-	 * see the occlusion logic RemoteClient::getNextBlocks(...)),
-	 * in which case we can treat them as opaque, because blocks behind cannot be
-	 * visible either. This saves a *lot* of CPU time.
+	 * in which case we check them, or they are not loaded, in which case we
+	 * assume this is because they are not visible and treat them as opaque.
+	 * (see the occlusion logic RemoteClient::getNextBlocks).
+	 * This saves a *lot* of CPU time.
 	 * The map is dense on the server, and sparse on the client (we mostly don't even send
 	 * all-air blocks for example).
-	 * For a sparse map we need to check from the origin as before.
+	 * For a sparse map we need to check from the origin as before (cheap stays false).
 	 */
 	constexpr float DENSE_CHECK_DISTANCE = 3 * MAP_BLOCKSIZE;
 
@@ -687,7 +688,7 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	float offset = BS;
 	// Starting step size, value between 1m and sqrt(3)m
 	float step = BS * 1.2f;
-	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
+	// Multiply step by each iteration by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
 	bool cheap = false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -658,7 +658,7 @@ bool Map::determineAdditionalOcclusionCheck(const v3s16 pos_camera,
 }
 
 bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
-	float step, float stepfac, float offset, float end_offset, u32 needed_count)
+	float step, float stepfac, float end_offset, u32 needed_count, bool dense)
 {
 	v3f direction = intToFloat(pos_target - pos_camera, BS);
 	float distance = direction.getLength();
@@ -670,6 +670,17 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	v3f pos_origin_f = intToFloat(pos_camera, BS);
 	u32 count = 0;
 	bool is_valid_position;
+	/*
+	 * When the map is "dense" (when all visible blocks are loaded) we can start 3-4
+	 * layers before the block we want to check. Either the prior blocks are loaded
+	 * in which case we check them, or they not loaded (because they are invisible),
+	 * in which case we can treat them as opaque, because blocks behind cannot be
+	 * visible either. This saves a *lot* of CPU time.
+	 * The map is dense on the server, and sparse on the client (we do not even load
+	 * all-air blocks for example).
+	 * For a sparse map we need to check from the origin as before.
+	 */
+	float offset = dense ? std::max(BS, distance - 4.0f * 1.732f * MAP_BLOCKSIZE * BS) : BS;
 
 	for (; offset < distance + end_offset; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
@@ -677,19 +688,29 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 
 		MapNode node = getNode(pos_node, &is_valid_position);
 
-		if (is_valid_position &&
-				!m_nodedef->getLightingFlags(node).light_propagates) {
-			// Cannot see through light-blocking nodes --> occluded
-			count++;
-			if (count >= needed_count)
+		if (dense) {
+			// treat unloaded blocks as opaque
+			if (!is_valid_position ||
+					!m_nodedef->getLightingFlags(node).light_propagates) {
+				// Cannot see through light-blocking nodes --> occluded
 				return true;
+			}
+		} else {
+			// treat unloaded blocks as transparent
+			if (is_valid_position &&
+					!m_nodedef->getLightingFlags(node).light_propagates) {
+				// Cannot see through light-blocking nodes --> occluded
+				count++;
+				if (count >= needed_count)
+					return true;
+			}
 		}
 		step *= stepfac;
 	}
 	return false;
 }
 
-bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check)
+bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool dense)
 {
 	// Check occlusion for center and all 8 corners of the mapblock
 	// Overshoot a little for less flickering
@@ -713,8 +734,6 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_c
 	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
-	float start_offset = BS * 1.0f;
-
 	// The occlusion search of 'isOccluded()' must stop short of the target
 	// point by distance 'end_offset' to not enter the target mapblock.
 	// For the 8 mapblock corners 'end_offset' must therefore be the maximum
@@ -727,27 +746,18 @@ bool Map::isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_c
 	// this is a HACK, we should think of a more precise algorithm
 	u32 needed_count = 2;
 
-	// This should be only used in server occlusion cullung.
-	// The client recalculates the complete drawlist periodically,
-	// and random sampling could lead to visible flicker.
-	if (simple_check) {
-		v3s16 random_point(myrand_range(-bs2, bs2), myrand_range(-bs2, bs2), myrand_range(-bs2, bs2));
-		return isOccluded(cam_pos_nodes, pos_blockcenter + random_point, step, stepfac,
-					start_offset, end_offset, 1);
-	}
-
 	// Additional occlusion check, see comments in that function
 	v3s16 check;
 	if (determineAdditionalOcclusionCheck(cam_pos_nodes, MapBlock::getBox(pos_relative), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
-		if (!isOccluded(cam_pos_nodes, check, step, stepfac, start_offset,
-				-1.0f, needed_count))
+		if (!isOccluded(cam_pos_nodes, check, step, stepfac,
+				-1.0f, needed_count, dense))
 			return false;
 	}
 
 	for (const v3s16 &dir : dir9) {
 		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
-				start_offset, end_offset, needed_count))
+				end_offset, needed_count, dense))
 			return false;
 	}
 	return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -680,7 +680,6 @@ bool Map::isOccluded(const v3s16 pos_camera, const v3s16 pos_target,
 	 * This saves a *lot* of CPU time.
 	 * The map is dense on the server, and sparse on the client (we mostly don't even send
 	 * all-air blocks for example).
-	 * For a sparse map we need to check from the origin as before (cheap stays false).
 	 */
 	constexpr float DENSE_CHECK_DISTANCE = 3 * MAP_BLOCKSIZE * 1.732f * BS;
 

--- a/src/map.h
+++ b/src/map.h
@@ -297,8 +297,7 @@ protected:
 	bool determineAdditionalOcclusionCheck(v3s16 pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &to_check);
 	bool isOccluded(v3s16 pos_camera, v3s16 pos_target,
-		float step, float stepfac, float end_offset,
-		u32 needed_count, bool dense);
+		float end_offset, u32 needed_count, bool dense);
 };
 
 class MMVManip : public VoxelManipulator

--- a/src/map.h
+++ b/src/map.h
@@ -273,9 +273,9 @@ public:
 
 	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	{
-		return isBlockOccluded(block->getPosRelative(), cam_pos_nodes, false);
+		return isBlockOccluded(block->getPosRelative(), cam_pos_nodes);
 	}
-	bool isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool simple_check = false);
+	bool isBlockOccluded(v3s16 pos_relative, v3s16 cam_pos_nodes, bool dense = false);
 
 protected:
 	IGameDef *m_gamedef;
@@ -297,8 +297,8 @@ protected:
 	bool determineAdditionalOcclusionCheck(v3s16 pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &to_check);
 	bool isOccluded(v3s16 pos_camera, v3s16 pos_target,
-		float step, float stepfac, float start_offset, float end_offset,
-		u32 needed_count);
+		float step, float stepfac, float end_offset,
+		u32 needed_count, bool dense);
 };
 
 class MMVManip : public VoxelManipulator


### PR DESCRIPTION
I realized that when have a map stored densely (when all visible blocks are in fact loaded) we can dramatically improve occlusion culling, by performing it in layers, making use of the work that previous layers did.

When the map is dense we only need to check at most layers prior to the block we want to check for occlusion (rather than starting from the origin each time).
The reasoning is as follows:
- If the prior blocks are loaded, check them and proceed normally
- If the prior blocks are not loaded, they are not visible (otherwise they would have been loaded by the prior layers) we can treat them as opaque (if they are not visible, surely something behind them, as seen from the camera, is also not visible.)

As a bonus because occlusion culling is now so much cheaper, we can also remove the stochastic culling at a distance, and avoid all temporary holes. See second commit (which also hardcodes some values previously randomly tied to block_culling, I think those do not need to be configurable).

Overall this a *massive* CPU saving *and* it improves culling precision!

The the map is sparse, such as it is at the client, when air-block et al are not even loaded, we have to do culling the "old" way starting from the origin.

- Does it resolve any reported issue?
Not that I know

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Not sure. But definitely helps with server side CPU usage especially at large viewing ranges

- If not a bug fix, why is this PR needed? What usecases does it solve?
Performance and correctness

- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope.

## To do

This PR is Ready for Review.

## How to test

Load any world, make sure all blocks there were visible before are still visible. Test with enabled_raytrayced_culling on and off, and client_mesh_chunk < 4 and >= 4.
Test in open land scapes, test is caves, etc. Test with small and large viewing_ranges.

*Iff* we wanted to be 100% safe we could only do the first commit, and the block_culling distance as switch between dense and sparse culling.