### PR TITLE
Implement gyro aiming using gamepad sensor

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -264,6 +264,11 @@ local function load()
 		["disable"] = fgettext_ne("Disable"),
 		["invert"] = fgettext_ne("Invert"),
 	}
+
+	get_setting_info("gyro_turn_axis").option_labels = {
+		["yaw"] = fgettext_ne("Yaw"),
+		["roll"] = fgettext_ne("Roll"),
+	}
 end
 
 

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -258,6 +258,12 @@ local function load()
 		-- TRANSLATORS: Touchscreen gesture
 		["long_tap"] = fgettext_ne("Long tap"),
 	}
+
+	get_setting_info("gyro_toggle_mode").option_labels = {
+		["enable"] = fgettext_ne("Enable"),
+		["disable"] = fgettext_ne("Disable"),
+		["invert"] = fgettext_ne("Invert"),
+	}
 end
 
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -442,6 +442,14 @@ joystick_outer_deadzone (Joystick outer dead zone) float 0 0 1
 #    in-game view frustum around.
 joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170.0 0.001
 
+[**Gyro]
+
+# Gyro sensitivity on the yaw axis as a multiplier of gamepad rotation
+gyro_yaw_sensitivity (Yaw sensitivity) float 2.5 0.1 20.0
+
+# Gyro sensitivity on the pitch axis as a multiplier of gamepad rotation
+gyro_pitch_sensitivity (Pitch sensitivity) float 2.5 0.1 20.0
+
 [Graphics and Audio] [client]
 
 [*Graphics]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -465,6 +465,16 @@ gyro_pitch_sensitivity (Pitch sensitivity) float 2.5 0.1 20.0
 #
 gyro_toggle_mode (Gyro Toggle Mode) enum disable enable,disable,invert
 
+# Which gyro axis to use for horizontal camera turning
+#
+#    * Yaw
+#      Use the yaw axis, best used with gamepads
+#
+#    * Roll
+#      Use the roll axis, best used with handhelds
+#
+gyro_turn_axis (Turn Axis) enum yaw yaw,roll
+
 [Graphics and Audio] [client]
 
 [*Graphics]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -245,6 +245,8 @@ keymap_camera_yaw_right (Look right) key GAMEPAD_AXIS_PLUS_2
 keymap_camera_pitch_up (Look up) key GAMEPAD_AXIS_MINUS_3
 keymap_camera_pitch_down (Look down) key GAMEPAD_AXIS_PLUS_3
 
+keymap_gyro_toggle (Toggle Gyro) key
+
 keymap_toggle_hud (Toggle HUD) key SYSTEM_SCANCODE_58
 
 keymap_toggle_chat (Toggle chat log) key SYSTEM_SCANCODE_59
@@ -449,6 +451,19 @@ gyro_yaw_sensitivity (Yaw sensitivity) float 2.5 0.1 20.0
 
 # Gyro sensitivity on the pitch axis as a multiplier of gamepad rotation
 gyro_pitch_sensitivity (Pitch sensitivity) float 2.5 0.1 20.0
+
+# Behavior of the "Toggle Gyro" action
+#
+#    * Enable
+#      Gyro is disabled by default, holding the button enables it
+#
+#    * Disable
+#      Gyro is enabled by default, holding the button disables it
+#
+#    * Invert
+#      Gyro is always enabled, holding the button inverts direction
+#
+gyro_toggle_mode (Gyro Toggle Mode) enum disable enable,disable,invert
 
 [Graphics and Audio] [client]
 

--- a/irr/include/IEventReceiver.h
+++ b/irr/include/IEventReceiver.h
@@ -53,6 +53,9 @@ enum EEVENT_TYPE
 	//! A gamepad axis event.
 	EET_GAMEPAD_AXIS_EVENT,
 
+	//! A gamepad sensor event.
+	EET_GAMEPAD_SENSOR_EVENT,
+
 	//! A log event
 	/** Log events are only passed to the user receiver if there is one. If they are absorbed by the
 	user receiver then no text will be sent to the console. */
@@ -482,6 +485,29 @@ struct SEvent
 		s16 Value;
 	};
 
+	//! A gamepad sensor event.
+	struct SGamepadSensorEvent
+	{
+		//! The ID of the gamepad.
+		u32 ID;
+
+		//! the type of sensor
+		SensorType Type;
+
+		// accel: left-right
+		// gyro: pitch
+		f64 X;
+
+		// accel: up-down
+		// gyro: yaw
+		f64 Y;
+
+		// accel: forward-backwards
+		// gyro: roll
+		f64 Z;
+
+	};
+
 	//! Any kind of log event.
 	struct SLogEvent
 	{
@@ -524,6 +550,7 @@ struct SEvent
 		struct SDeviceMotionEvent DeviceMotionEvent;
 		struct SGamepadButtonEvent GamepadButtonEvent;
 		struct SGamepadAxisEvent GamepadAxisEvent;
+		struct SGamepadSensorEvent GamepadSensorEvent;
 		struct SLogEvent LogEvent;
 		struct SUserEvent UserEvent;
 		struct SApplicationEvent ApplicationEvent;
@@ -532,7 +559,7 @@ struct SEvent
 	SEvent() {
 		EventType = static_cast<EEVENT_TYPE>(0);
 		// zero the biggest union member we have, which clears all others too
-		memset(&AccelerometerEvent, 0, sizeof(AccelerometerEvent));
+		memset(&GamepadSensorEvent, 0, sizeof(GamepadSensorEvent));
 	}
 };
 

--- a/irr/include/IEventReceiver.h
+++ b/irr/include/IEventReceiver.h
@@ -192,6 +192,19 @@ enum ETOUCH_INPUT_EVENT
 	ETIE_COUNT
 };
 
+// A SensorType represents different sensors either built into the device itself or a gamepad.
+// The values are taken from SDL_SensorType
+enum SENSOR_TYPE {
+	UNKNOWN,
+    ACCEL,
+    GYRO,
+    ACCEL_L,
+    GYRO_L,
+    ACCEL_R,
+    GYRO_R,
+    COUNT
+};
+
 //! Enumeration for a commonly used application state events (it's useful mainly for mobile devices)
 enum EAPPLICATION_EVENT_TYPE
 {
@@ -492,7 +505,7 @@ struct SEvent
 		u32 ID;
 
 		//! the type of sensor
-		SensorType Type;
+		SENSOR_TYPE Type;
 
 		// accel: left-right
 		// gyro: pitch

--- a/irr/include/IEventReceiver.h
+++ b/irr/include/IEventReceiver.h
@@ -194,15 +194,15 @@ enum ETOUCH_INPUT_EVENT
 
 // A SensorType represents different sensors either built into the device itself or a gamepad.
 // The values are taken from SDL_SensorType
-enum SENSOR_TYPE {
-	UNKNOWN,
-    ACCEL,
-    GYRO,
-    ACCEL_L,
-    GYRO_L,
-    ACCEL_R,
-    GYRO_R,
-    COUNT
+enum ESENSOR_TYPE {
+	ESENSOR_UNKNOWN,
+    ESENSOR_ACCEL,
+    ESENSOR_GYRO,
+    ESENSOR_ACCEL_L,
+    ESENSOR_GYRO_L,
+    ESENSOR_ACCEL_R,
+    ESENSOR_GYRO_R,
+    ESENSOR_COUNT
 };
 
 //! Enumeration for a commonly used application state events (it's useful mainly for mobile devices)
@@ -505,7 +505,7 @@ struct SEvent
 		u32 ID;
 
 		//! the type of sensor
-		SENSOR_TYPE Type;
+		ESENSOR_TYPE Type;
 
 		// accel: left-right
 		// gyro: pitch

--- a/irr/include/Keycodes.h
+++ b/irr/include/Keycodes.h
@@ -201,6 +201,18 @@ public:
 	}
 };
 
+// A SensorType represents different sensors either built into the device itself or a gamepad.
+// The values are taken from SDL_SensorType
+enum class SensorType {
+    ACCEL,
+    GYRO,
+    ACCEL_L,
+    GYRO_L,
+    ACCEL_R,
+    GYRO_R,
+    COUNT
+};
+
 /// A GamepadAxis represents a physical axis on the gamepad.
 /// The values are taken from SDL_GamepadAxis.
 enum class GamepadAxis {

--- a/irr/include/Keycodes.h
+++ b/irr/include/Keycodes.h
@@ -201,18 +201,6 @@ public:
 	}
 };
 
-// A SensorType represents different sensors either built into the device itself or a gamepad.
-// The values are taken from SDL_SensorType
-enum class SensorType {
-    ACCEL,
-    GYRO,
-    ACCEL_L,
-    GYRO_L,
-    ACCEL_R,
-    GYRO_R,
-    COUNT
-};
-
 /// A GamepadAxis represents a physical axis on the gamepad.
 /// The values are taken from SDL_GamepadAxis.
 enum class GamepadAxis {

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1226,13 +1226,13 @@ bool CIrrDeviceSDL::run()
 			irrevent.EventType = EET_GAMEPAD_SENSOR_EVENT;
 #if _IRR_USE_SDL3_
 			auto id = SDL_event.gsensor.which;
-			irrevent.GamepadSensorEvent.Type = static_cast<SensorType>(SDL_event.gsensor.sensor);
+			irrevent.GamepadSensorEvent.Type = static_cast<SENSOR_TYPE>(SDL_event.gsensor.sensor);
 			irrevent.GamepadSensorEvent.X = SDL_event.gsensor.data[0];
 			irrevent.GamepadSensorEvent.Y = SDL_event.gsensor.data[1];
 			irrevent.GamepadSensorEvent.Z = SDL_event.gsensor.data[2];
 #else
 			auto id = SDL_event.csensor.which;
-			irrevent.GamepadSensorEvent.Type = static_cast<SensorType>(SDL_event.csensor.sensor);
+			irrevent.GamepadSensorEvent.Type = static_cast<SENSOR_TYPE>(SDL_event.csensor.sensor);
 			irrevent.GamepadSensorEvent.X = SDL_event.csensor.data[0];
 			irrevent.GamepadSensorEvent.Y = SDL_event.csensor.data[1];
 			irrevent.GamepadSensorEvent.Z = SDL_event.csensor.data[2];

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1226,13 +1226,13 @@ bool CIrrDeviceSDL::run()
 			irrevent.EventType = EET_GAMEPAD_SENSOR_EVENT;
 #if _IRR_USE_SDL3_
 			auto id = SDL_event.gsensor.which;
-			irrevent.GamepadSensorEvent.Type = static_cast<SENSOR_TYPE>(SDL_event.gsensor.sensor);
+			irrevent.GamepadSensorEvent.Type = static_cast<ESENSOR_TYPE>(SDL_event.gsensor.sensor);
 			irrevent.GamepadSensorEvent.X = SDL_event.gsensor.data[0];
 			irrevent.GamepadSensorEvent.Y = SDL_event.gsensor.data[1];
 			irrevent.GamepadSensorEvent.Z = SDL_event.gsensor.data[2];
 #else
 			auto id = SDL_event.csensor.which;
-			irrevent.GamepadSensorEvent.Type = static_cast<SENSOR_TYPE>(SDL_event.csensor.sensor);
+			irrevent.GamepadSensorEvent.Type = static_cast<ESENSOR_TYPE>(SDL_event.csensor.sensor);
 			irrevent.GamepadSensorEvent.X = SDL_event.csensor.data[0];
 			irrevent.GamepadSensorEvent.Y = SDL_event.csensor.data[1];
 			irrevent.GamepadSensorEvent.Z = SDL_event.csensor.data[2];

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -76,6 +76,7 @@
 	#define SDL_EVENT_GAMEPAD_BUTTON_DOWN SDL_CONTROLLERBUTTONDOWN
 	#define SDL_EVENT_GAMEPAD_BUTTON_UP SDL_CONTROLLERBUTTONUP
 	#define SDL_EVENT_GAMEPAD_AXIS_MOTION SDL_CONTROLLERAXISMOTION
+	#define SDL_EVENT_GAMEPAD_SENSOR_UPDATE SDL_CONTROLLERSENSORUPDATE
 
 	#define SDL_OpenGamepad SDL_GameControllerOpen
 	#define SDL_CloseGamepad SDL_GameControllerClose
@@ -1205,6 +1206,27 @@ bool CIrrDeviceSDL::run()
 			auto id = SDL_event.caxis.which;
 			irrevent.GamepadAxisEvent.Axis = static_cast<GamepadAxis>(SDL_event.caxis.axis);
 			irrevent.GamepadAxisEvent.Value = SDL_event.caxis.value;
+#endif
+			irrevent.GamepadAxisEvent.ID = id;
+			recentGamepadID = id;
+			postEventFromUser(irrevent);
+			break;
+		}
+
+		case SDL_EVENT_GAMEPAD_SENSOR_UPDATE: {
+			irrevent.EventType = EET_GAMEPAD_SENSOR_EVENT;
+#if _IRR_USE_SDL3_
+			auto id = SDL_event.gsensor.which;
+			irrevent.GamepadSensorEvent.Type = static_cast<SensorType>(SDL_event.gsensor.sensor);
+			irrevent.GamepadSensorEvent.X = SDL_event.gsensor.data[0];
+			irrevent.GamepadSensorEvent.Y = SDL_event.gsensor.data[1];
+			irrevent.GamepadSensorEvent.Z = SDL_event.gsensor.data[2];
+#else
+			auto id = SDL_event.csensor.which;
+			irrevent.GamepadSensorEvent.Type = static_cast<SensorType>(SDL_event.csensor.sensor);
+			irrevent.GamepadSensorEvent.X = SDL_event.csensor.data[0];
+			irrevent.GamepadSensorEvent.Y = SDL_event.csensor.data[1];
+			irrevent.GamepadSensorEvent.Z = SDL_event.csensor.data[2];
 #endif
 			irrevent.GamepadAxisEvent.ID = id;
 			recentGamepadID = id;

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -84,6 +84,7 @@
 	#define SDL_GetGamepadMapping SDL_GameControllerMapping
 	#define SDL_GetGamepadType SDL_GameControllerGetType
 	#define SDL_GetGamepadStringForType(type) nullptr
+	#define SDL_GamepadHasSensor SDL_GameControllerHasSensor
 
 	#define SDL_GetWindowSizeInPixels SDL_GL_GetDrawableSize
 	#define SDL_DestroySurface SDL_FreeSurface
@@ -1158,6 +1159,14 @@ bool CIrrDeviceSDL::run()
 				if (auto mapping = SDL_GetGamepadMapping(gamepad); mapping != nullptr) {
 					os::Printer::log("Gamepad mapping", mapping, ELL_INFORMATION);
 					SDL_free(mapping);
+				}
+				if (SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO)) {
+#ifdef _IRR_USE_SDL3_
+					SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, true);
+#else
+					SDL_GameControllerSetSensorEnabled(gamepad, SDL_SENSOR_GYRO, SDL_TRUE);
+#endif
+					os::Printer::log("Gyro enabled", ELL_INFORMATION);
 				}
 			} else {
 				os::Printer::log("Unable to open gamepad", SDL_GetError(), ELL_ERROR);

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1237,7 +1237,7 @@ bool CIrrDeviceSDL::run()
 			irrevent.GamepadSensorEvent.Y = SDL_event.csensor.data[1];
 			irrevent.GamepadSensorEvent.Z = SDL_event.csensor.data[2];
 #endif
-			irrevent.GamepadAxisEvent.ID = id;
+			irrevent.GamepadSensorEvent.ID = id;
 			recentGamepadID = id;
 			postEventFromUser(irrevent);
 			break;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -5,6 +5,7 @@
 #include "gui/mainmenumanager.h"
 #include "clouds.h"
 #include "gui/touchcontrols.h"
+#include "gui/gyrocontrols.h"
 #include "filesys.h"
 #include "gui/guiMainMenu.h"
 #include "game.h"
@@ -246,6 +247,9 @@ bool ClientLauncher::run(const GameParams &game_params, const Settings &cmd_args
 
 		delete g_touchcontrols;
 		g_touchcontrols = nullptr;
+
+		delete g_gyrocontrols;
+		g_gyrocontrols = nullptr;
 
 		/* Save the settings when leaving the game.
 		 * This makes sure that setting changes made in-game are persisted even

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2018,7 +2018,7 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 
 	// Gyro look
 	if (g_gyrocontrols) {
-		v2f32 vec = g_gyrocontrols->getVector();
+		v2f32 vec = g_gyrocontrols->getCameraOffset();
 		cam->camera_yaw += vec.X * dtime;
 		cam->camera_pitch -= vec.Y * dtime;
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2014,10 +2014,13 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 	}
 
 	// Gyro look
-	if (g_gyrocontrols) {
+	if (g_gyrocontrols && g_gyrocontrols->isActive(input->isKeyDown(KeyType::GYRO_TOGGLE))) {
+		const int dir = (g_settings->get("gyro_toggle_mode") == "invert"
+			&& !input->isKeyDown(KeyType::GYRO_TOGGLE))?
+			1 : -1;
 		v2f32 vec = g_gyrocontrols->getVector();
-		cam->camera_yaw += vec.X * dtime;
-		cam->camera_pitch -= vec.Y * dtime;
+		cam->camera_yaw += vec.X * dtime * dir;
+		cam->camera_pitch -= vec.Y * dtime * dir;
 	}
 
 	// Keyboard look

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -954,6 +954,8 @@ bool Game::initGui()
 	if (shouldShowTouchControls())
 		g_touchcontrols = new TouchControls(device, texture_src);
 
+	g_gyrocontrols = new GyroControls(device);
+
 	return true;
 }
 
@@ -2009,6 +2011,13 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 
 		if (dist.X != 0 || dist.Y != 0)
 			input->setMousePos(center.X, center.Y);
+	}
+
+	// Gyro look
+	if (g_gyrocontrols) {
+		v2f32 vec = g_gyrocontrols->getVector();
+		cam->camera_yaw += vec.X * dtime;
+		cam->camera_pitch -= vec.Y * dtime;
 	}
 
 	// Keyboard look

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1531,6 +1531,9 @@ void Game::processKeyInput()
 		runData.jump_timer_up = 0.0f;
 	}
 
+	if (wasKeyPressed(KeyType::GYRO_TOGGLE) || wasKeyReleased(KeyType::GYRO_TOGGLE))
+		g_gyrocontrols->toggle();
+
 	if (quicktune->hasMessage()) {
 		m_game_ui->showStatusText(utf8_to_wide(quicktune->getMessage()));
 	}
@@ -2014,13 +2017,10 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 	}
 
 	// Gyro look
-	if (g_gyrocontrols && g_gyrocontrols->isActive(input->isKeyDown(KeyType::GYRO_TOGGLE))) {
-		const int dir = (g_settings->get("gyro_toggle_mode") == "invert"
-			&& !input->isKeyDown(KeyType::GYRO_TOGGLE))?
-			1 : -1;
+	if (g_gyrocontrols) {
 		v2f32 vec = g_gyrocontrols->getVector();
-		cam->camera_yaw += vec.X * dtime * dir;
-		cam->camera_pitch -= vec.Y * dtime * dir;
+		cam->camera_yaw += vec.X * dtime;
+		cam->camera_pitch -= vec.Y * dtime;
 	}
 
 	// Keyboard look

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -17,6 +17,7 @@
 #include "clientdynamicinfo.h"
 #include "clouds.h"
 #include "gui/touchcontrols.h"
+#include "gui/gyrocontrols.h"
 #include "irr_ptr.h"
 #include "irrlichttypes_bloated.h"
 #include "log_internal.h"

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -85,6 +85,7 @@ void MyEventReceiver::reloadKeybindings()
 	keybindings[KeyType::CAMERA_YAW_RIGHT] = getKeySetting("keymap_camera_yaw_right");
 	keybindings[KeyType::CAMERA_PITCH_UP] = getKeySetting("keymap_camera_pitch_up");
 	keybindings[KeyType::CAMERA_PITCH_DOWN] = getKeySetting("keymap_camera_pitch_down");
+	keybindings[KeyType::GYRO_TOGGLE] = getKeySetting("keymap_gyro_toggle");
 
 	keybindings[KeyType::QUICKTUNE_NEXT] = getKeySetting("keymap_quicktune_next");
 	keybindings[KeyType::QUICKTUNE_PREV] = getKeySetting("keymap_quicktune_prev");

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -9,6 +9,7 @@
 #include "inputhandler.h"
 #include "gui/mainmenumanager.h"
 #include "gui/touchcontrols.h"
+#include "gui/gyrocontrols.h"
 #include "hud_element.h"
 #include "log_internal.h"
 #include "client/renderingengine.h"
@@ -274,6 +275,9 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		return true;
 	} else if (event.EventType == EET_MOUSE_INPUT_EVENT && event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
 		mouse_wheel += event.MouseInput.Wheel;
+	} else if (g_gyrocontrols && event.EventType == EET_GAMEPAD_SENSOR_EVENT) {
+		g_gyrocontrols->OnEvent(event);
+		return true;
 	} else if (event.EventType == EET_USER_EVENT && event.UserEvent.type == EUET_GAME_KEY) {
 		KeyPress keyCode(static_cast<GameKeyType>(event.UserEvent.UserData1));
 		setKeyDown(keyCode, InputHandler::intToAnalog(event.UserEvent.UserData2));

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -29,6 +29,9 @@ public:
 		CAMERA_PITCH_UP,
 		CAMERA_PITCH_DOWN,
 
+		// Gyro
+		GYRO_TOGGLE,
+
 		// Other
 		DROP,
 		INVENTORY,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -389,6 +389,8 @@ void set_default_settings()
 	settings->setDefault("joystick_outer_deadzone", "0");
 	settings->setDefault("gyro_yaw_sensitivity", "2.5");
 	settings->setDefault("gyro_pitch_sensitivity", "2.5");
+	settings->setDefault("gyro_toggle_mode", "disable");
+	settings->setDefault("gyro_turn_axis", "yaw");
 
 	// Main menu
 	settings->setDefault("main_menu_path", "");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -386,6 +386,8 @@ void set_default_settings()
 	settings->setDefault("joystick_frustum_sensitivity", "170");
 	settings->setDefault("joystick_inner_deadzone", "0.25");
 	settings->setDefault("joystick_outer_deadzone", "0");
+	settings->setDefault("gyro_yaw_sensitivity", "2.5");
+	settings->setDefault("gyro_pitch_sensitivity", "2.5");
 
 	// Main menu
 	settings->setDefault("main_menu_path", "");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -180,6 +180,7 @@ void set_default_settings()
 	settings->setDefault("keymap_camera_yaw_right", "GAMEPAD_AXIS_PLUS_2"); // Right Joystick
 	settings->setDefault("keymap_camera_pitch_up", "GAMEPAD_AXIS_MINUS_3"); // Right Joystick
 	settings->setDefault("keymap_camera_pitch_down", "GAMEPAD_AXIS_PLUS_3"); // Right Joystick
+	settings->setDefault("keymap_gyro_toggle", "");
 	settings->setDefault("keymap_screenshot", "SYSTEM_SCANCODE_69|GAMEPAD_BUTTON_14"); // KEY_F12|D-Pad Right
 	settings->setDefault("keymap_fullscreen", "SYSTEM_SCANCODE_68"); // KEY_F11
 	settings->setDefault("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46"); // +

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -25,6 +25,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiTable.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiHyperText.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/gyrocontrols.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/touchcontrols.cpp

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -21,7 +21,7 @@ GyroControls::~GyroControls()
 
 bool GyroControls::OnEvent(const SEvent &event)
 {
-	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != GYRO)
+	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != ESENSOR_GYRO)
 		return false;
 
 	vec.X += radToDeg(event.GamepadSensorEvent.Y);

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -1,10 +1,26 @@
 
 #include "gyrocontrols.h"
 
+#include "log.h"
 #include "settings.h"
 #include "client/inputhandler.h"
 #include <IrrlichtDevice.h>
 #include "irrMath.h"
+#include "util/enum_string.h"
+
+static const char *setting_names[] = {
+	"gyro_yaw_sensitivity",
+	"gyro_pitch_sensitivity",
+	"gyro_toggle_mode"
+};
+
+const struct EnumString es_GyroToggleMode[] =
+{
+	{GYRO_ENABLE, "enable"},
+	{GYRO_DISABLE, "disable"},
+	{GYRO_INVERT, "invert"},
+	{0, NULL},
+};
 
 GyroControls *g_gyrocontrols;
 
@@ -12,7 +28,9 @@ GyroControls::GyroControls(IrrlichtDevice *device):
 		m_device(device),
 		m_receiver(device->getEventReceiver())
 {
-
+	readSettings();
+	for (auto name : setting_names)
+		g_settings->registerChangedCallback(name, settingChangedCallback, this);
 }
 
 GyroControls::~GyroControls()
@@ -20,27 +38,50 @@ GyroControls::~GyroControls()
 
 }
 
-bool GyroControls::isActive(const bool toggle)
+void GyroControls::readSettings()
 {
-	if (g_settings->get("gyro_toggle_mode") == "enable" && !toggle)
-		return false;
-	else if (g_settings->get("gyro_toggle_mode") == "disable" && toggle)
-		return false;
+	const std::string &s = g_settings->get("gyro_toggle_mode");
+	if (!string_to_enum(es_GyroToggleMode, m_toggle_mode, s)) {
+		m_toggle_mode = GYRO_DISABLE;
+		warningstream << "Invalid gyro_toggle_mode value" << std::endl;
+	}
+	initActive();
 
-	return true;
+	m_yaw_sensitivity = g_settings->getFloat("gyro_yaw_sensitivity", 0.1f, 20.0f);
+	m_pitch_sensitivity = g_settings->getFloat("gyro_pitch_sensitivity", 0.1f, 20.0f);
+}
+
+void GyroControls::settingChangedCallback(const std::string &name, void *data)
+{
+	static_cast<GyroControls *>(data)->readSettings();
+}
+
+void GyroControls::initActive()
+{
+	if (m_toggle_mode == GYRO_DISABLE || m_toggle_mode == GYRO_INVERT)
+		m_active = true;
+	if (m_toggle_mode == GYRO_ENABLE)
+		m_active = false;
+}
+
+void GyroControls::toggle()
+{
+	if (m_toggle_mode == GYRO_ENABLE || m_toggle_mode == GYRO_DISABLE)
+		m_active = !m_active;
+	if (m_toggle_mode == GYRO_INVERT)
+		m_dir = -m_dir;
 }
 
 bool GyroControls::OnEvent(const SEvent &event)
 {
+	if (!m_active)
+		return false;
 	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != ESENSOR_GYRO)
 		return false;
 
-	const double yaw_sens = g_settings->getFloat("gyro_yaw_sensitivity", 0.1f, 20.0f);
-	const double pitch_sens = g_settings->getFloat("gyro_pitch_sensitivity", 0.1f, 20.0f);
-
-	vec.X += radToDeg(event.GamepadSensorEvent.Y) * yaw_sens;
-	vec.Y += radToDeg(event.GamepadSensorEvent.X) * pitch_sens;
-	samples++;
+	m_vector.X += radToDeg(event.GamepadSensorEvent.Y) * m_yaw_sensitivity* m_dir;
+	m_vector.Y += radToDeg(event.GamepadSensorEvent.X) * m_pitch_sensitivity * m_dir;
+	m_samples++;
 
 	return false;
 }

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -11,7 +11,8 @@
 static const char *setting_names[] = {
 	"gyro_yaw_sensitivity",
 	"gyro_pitch_sensitivity",
-	"gyro_toggle_mode"
+	"gyro_toggle_mode",
+	"gyro_turn_axis"
 };
 
 const struct EnumString es_GyroToggleMode[] =
@@ -19,6 +20,13 @@ const struct EnumString es_GyroToggleMode[] =
 	{GYRO_ENABLE, "enable"},
 	{GYRO_DISABLE, "disable"},
 	{GYRO_INVERT, "invert"},
+	{0, NULL},
+};
+
+const struct EnumString es_GyroTurnAxis[] =
+{
+	{GYRO_YAW, "yaw"},
+	{GYRO_ROLL, "roll"},
 	{0, NULL},
 };
 
@@ -40,12 +48,18 @@ GyroControls::~GyroControls()
 
 void GyroControls::readSettings()
 {
-	const std::string &s = g_settings->get("gyro_toggle_mode");
-	if (!string_to_enum(es_GyroToggleMode, m_toggle_mode, s)) {
+	const std::string &toggle = g_settings->get("gyro_toggle_mode");
+	if (!string_to_enum(es_GyroToggleMode, m_toggle_mode, toggle)) {
 		m_toggle_mode = GYRO_DISABLE;
 		warningstream << "Invalid gyro_toggle_mode value" << std::endl;
 	}
 	initActive();
+
+	const std::string &axis = g_settings->get("gyro_turn_axis");
+	if (!string_to_enum(es_GyroTurnAxis, m_turn_axis, axis)) {
+		m_turn_axis = GYRO_YAW;
+		warningstream << "Invalid gyro_turn_axis value" << std::endl;
+	}
 
 	m_yaw_sensitivity = g_settings->getFloat("gyro_yaw_sensitivity", 0.1f, 20.0f);
 	m_pitch_sensitivity = g_settings->getFloat("gyro_pitch_sensitivity", 0.1f, 20.0f);
@@ -79,9 +93,10 @@ bool GyroControls::OnEvent(const SEvent &event)
 	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != ESENSOR_GYRO)
 		return false;
 
-	m_vector.X += radToDeg(event.GamepadSensorEvent.Y) * m_yaw_sensitivity* m_dir;
-	m_vector.Y += radToDeg(event.GamepadSensorEvent.X) * m_pitch_sensitivity * m_dir;
-	m_samples++;
+	m_gyro_samples.X += radToDeg(event.GamepadSensorEvent.Y);
+	m_gyro_samples.Y += radToDeg(event.GamepadSensorEvent.X);
+	m_gyro_samples.Z += radToDeg(event.GamepadSensorEvent.Z);
+	m_gyro_samples_count++;
 
 	return false;
 }

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -1,0 +1,32 @@
+
+#include "gyrocontrols.h"
+#include "client/inputhandler.h"
+
+#include <IrrlichtDevice.h>
+#include "irrMath.h"
+
+GyroControls *g_gyrocontrols;
+
+GyroControls::GyroControls(IrrlichtDevice *device):
+		m_device(device),
+		m_receiver(device->getEventReceiver())
+{
+
+}
+
+GyroControls::~GyroControls()
+{
+
+}
+
+bool GyroControls::OnEvent(const SEvent &event)
+{
+	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != GYRO)
+		return false;
+
+	vec.X += radToDeg(event.GamepadSensorEvent.Y);
+	vec.Y += radToDeg(event.GamepadSensorEvent.X);
+	samples++;
+
+	return false;
+}

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -1,7 +1,8 @@
 
 #include "gyrocontrols.h"
-#include "client/inputhandler.h"
 
+#include "settings.h"
+#include "client/inputhandler.h"
 #include <IrrlichtDevice.h>
 #include "irrMath.h"
 
@@ -24,8 +25,11 @@ bool GyroControls::OnEvent(const SEvent &event)
 	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != ESENSOR_GYRO)
 		return false;
 
-	vec.X += radToDeg(event.GamepadSensorEvent.Y);
-	vec.Y += radToDeg(event.GamepadSensorEvent.X);
+	const double yaw_sens = g_settings->getFloat("gyro_yaw_sensitivity", 0.1f, 20.0f);
+	const double pitch_sens = g_settings->getFloat("gyro_pitch_sensitivity", 0.1f, 20.0f);
+
+	vec.X += radToDeg(event.GamepadSensorEvent.Y) * yaw_sens;
+	vec.Y += radToDeg(event.GamepadSensorEvent.X) * pitch_sens;
 	samples++;
 
 	return false;

--- a/src/gui/gyrocontrols.cpp
+++ b/src/gui/gyrocontrols.cpp
@@ -20,6 +20,16 @@ GyroControls::~GyroControls()
 
 }
 
+bool GyroControls::isActive(const bool toggle)
+{
+	if (g_settings->get("gyro_toggle_mode") == "enable" && !toggle)
+		return false;
+	else if (g_settings->get("gyro_toggle_mode") == "disable" && toggle)
+		return false;
+
+	return true;
+}
+
 bool GyroControls::OnEvent(const SEvent &event)
 {
 	if (event.EventType != EET_GAMEPAD_SENSOR_EVENT || event.GamepadSensorEvent.Type != ESENSOR_GYRO)

--- a/src/gui/gyrocontrols.h
+++ b/src/gui/gyrocontrols.h
@@ -20,7 +20,14 @@ enum GyroToggleMode : u8
 	GYRO_DISABLE,
 	GYRO_INVERT
 };
-extern const struct EnumString es_TouchInteractionStyle[];
+extern const struct EnumString es_GyroToggleMode[];
+
+enum GyroTurnAxis : u8
+{
+	GYRO_YAW,
+	GYRO_ROLL
+};
+extern const struct EnumString es_GyroTurnAxis[];
 
 class GyroControls
 {
@@ -35,14 +42,31 @@ public:
 	bool OnEvent(const SEvent &event);
 	void toggle();
 
-	v2f32 getVector()
+	v2f32 getCameraOffset()
 	{
-		if (m_samples == 0)
-			return v2f32(0.0, 0.0);
-		v2f32 v = m_vector / m_samples;
-		m_vector = v2f32(0.0, 0.0);
-		m_samples = 0;
-		return v;
+		v3f average_vector = getAverageGyro();
+		v2f32 out_vector = v2f32(0.0, 0.0);
+		if (m_turn_axis == GYRO_YAW) {
+			out_vector.X = average_vector.X;
+			out_vector.Y = average_vector.Y;
+		} else if (m_turn_axis == GYRO_ROLL) {
+			// roll needs to be inverted
+			out_vector.X = -average_vector.Z;
+			out_vector.Y = average_vector.Y;
+		}
+		out_vector.X *= m_yaw_sensitivity * m_dir;
+		out_vector.Y *= m_pitch_sensitivity * m_dir;
+		return out_vector;
+	}
+
+	v3f getAverageGyro()
+	{
+		if (m_gyro_samples_count == 0)
+			return v3f(0.0, 0.0, 0.0);
+		v3f average_vector = m_gyro_samples / m_gyro_samples_count;
+		m_gyro_samples = v3f(0.0, 0.0, 0.0);
+		m_gyro_samples_count = 0;
+		return average_vector;
 	}
 
 private:
@@ -53,6 +77,7 @@ private:
 
 	// cached settings
 	GyroToggleMode m_toggle_mode;
+	GyroTurnAxis m_turn_axis;
 	double m_yaw_sensitivity;
 	double m_pitch_sensitivity;
 
@@ -60,9 +85,9 @@ private:
 	int m_dir = 1;
 
 	// accumulated rotation in degrees
-	v2f32 m_vector = v2f32(0.0, 0.0);
+	v3f m_gyro_samples = v3f(0.0, 0.0, 0.0);
 	// number of samples accumulated
-	int m_samples = 0;
+	int m_gyro_samples_count = 0;
 };
 
 extern GyroControls *g_gyrocontrols;

--- a/src/gui/gyrocontrols.h
+++ b/src/gui/gyrocontrols.h
@@ -14,6 +14,14 @@ class IrrlichtDevice;
 using namespace core;
 using namespace gui;
 
+enum GyroToggleMode : u8
+{
+	GYRO_ENABLE,
+	GYRO_DISABLE,
+	GYRO_INVERT
+};
+extern const struct EnumString es_TouchInteractionStyle[];
+
 class GyroControls
 {
 public:
@@ -21,16 +29,19 @@ public:
 	~GyroControls();
 	DISABLE_CLASS_COPY(GyroControls);
 
+	void readSettings();
+	void initActive();
+
 	bool OnEvent(const SEvent &event);
-	bool isActive(const bool toggle);
+	void toggle();
 
 	v2f32 getVector()
 	{
-		if (samples == 0)
+		if (m_samples == 0)
 			return v2f32(0.0, 0.0);
-		v2f32 v = vec / samples;
-		vec = v2f32(0.0, 0.0);
-		samples = 0;
+		v2f32 v = m_vector / m_samples;
+		m_vector = v2f32(0.0, 0.0);
+		m_samples = 0;
 		return v;
 	}
 
@@ -38,9 +49,20 @@ private:
 	IrrlichtDevice *m_device = nullptr;
 	IEventReceiver *m_receiver = nullptr;
 
+	static void settingChangedCallback(const std::string &name, void *data);
+
+	// cached settings
+	GyroToggleMode m_toggle_mode;
+	double m_yaw_sensitivity;
+	double m_pitch_sensitivity;
+
+	bool m_active = false;
+	int m_dir = 1;
+
 	// accumulated rotation in degrees
-	v2f32 vec = v2f32(0.0, 0.0);
-	int samples = 0;
+	v2f32 m_vector = v2f32(0.0, 0.0);
+	// number of samples accumulated
+	int m_samples = 0;
 };
 
 extern GyroControls *g_gyrocontrols;

--- a/src/gui/gyrocontrols.h
+++ b/src/gui/gyrocontrols.h
@@ -22,6 +22,7 @@ public:
 	DISABLE_CLASS_COPY(GyroControls);
 
 	bool OnEvent(const SEvent &event);
+	bool isActive(const bool toggle);
 
 	v2f32 getVector()
 	{

--- a/src/gui/gyrocontrols.h
+++ b/src/gui/gyrocontrols.h
@@ -1,0 +1,45 @@
+
+#pragma once
+
+#include "irrlichttypes_bloated.h"
+#include "IEventReceiver.h"
+
+#include "util/basic_macros.h"
+#include "client/keycode.h"
+
+#include <array>
+
+class IrrlichtDevice;
+
+using namespace core;
+using namespace gui;
+
+class GyroControls
+{
+public:
+	GyroControls(IrrlichtDevice *device);
+	~GyroControls();
+	DISABLE_CLASS_COPY(GyroControls);
+
+	bool OnEvent(const SEvent &event);
+
+	v2f32 getVector()
+	{
+		if (samples == 0)
+			return v2f32(0.0, 0.0);
+		v2f32 v = vec / samples;
+		vec = v2f32(0.0, 0.0);
+		samples = 0;
+		return v;
+	}
+
+private:
+	IrrlichtDevice *m_device = nullptr;
+	IEventReceiver *m_receiver = nullptr;
+
+	// accumulated rotation in degrees
+	v2f32 vec = v2f32(0.0, 0.0);
+	int samples = 0;
+};
+
+extern GyroControls *g_gyrocontrols;


### PR DESCRIPTION
Related: #17219, #17288
Part of #4153

This PR implements gyro aiming for modern gamepads featuring a gyroscope, allowing for precise camera control.

- How does the PR work?
It hooks up SDL_EVENT_GAMEPAD_SENSOR_UPDATE and uses its data to directly modify camera angles, similar to mouse movement or touchscreen swipes.

- Does it resolve any reported issue?
No, but it provides a prequisite for https://github.com/luanti-org/luanti/issues/4153.

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
2.2 Input handling

## To do

This PR is a Work in Progress

These are what I consider must-haves for a good implementation of gyro aim
- [x] enable gyro if availabe
- [x] Handle gyro events
- [x] hook gyro events up to camera rotation
- [x] Sensitivity settings
  - [x] real-world sensitivity scale, also see https://github.com/luanti-org/luanti/issues/17288
- [ ] calibration
- [ ] deadzone/precision speed threshold
- [x] gyro toggle bind
- [x] gyro toggle options (enable, disable, invert)
- [ ] local gyro space options (yaw, roll, yaw+roll)
- [ ] enable/disable gyro setting
  - [ ] make other settings dependent on it 

These I personally consider less important, might be better for follow-up PRs
- [ ] Handle accelerometer events
- [ ] Accelerometer-based gyro space options
  - [ ] Player Space
  - [ ] World Space
- [ ] acceleration
- [ ] autocalibration

## How to test

Right now gyro is always enabled so just build and run with an appropriate gamepad.

I'm intentionally creating this draft very early as I'm still getting used to Luanti's code base so if there's anything majorly wrong with how I'm putting things together please let me know :smile: 