### PR TITLE
Add gamepad support to AppStream metadata

### DIFF
--- a/misc/org.luanti.luanti.metainfo.xml
+++ b/misc/org.luanti.luanti.metainfo.xml
@@ -25,6 +25,7 @@
         <control>pointing</control>
         <control>keyboard</control>
         <control>touch</control>
+        <control>gamepad</control>
         <internet>offline-only</internet>
     </supports>
 


### PR DESCRIPTION
Following https://github.com/luanti-org/luanti/pull/17219 (tested and works great with my DualSense, nice job)

Add gamepad as a supported input method in the [AppStream metadata](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control)

## To do

This PR is Ready for Review.

## How to test

See if it matches the spec I guess.