### PR TITLE
Add HUD animation Lua API

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -56,6 +56,7 @@ core.features = {
 	get_modnames_load_order = true,
 	set_camera_resettable = true,
 	hud_hideable_field = true,
+	hud_animate = true,
 	compress_raw_deflate = true,
 	get_all_craft_recipes_fuel = true,
 }

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9329,6 +9329,14 @@ You **must not** mix names and track numbers to refer to the same animation.
   element.
     * `stat` supports the same keys as in the hud definition table except for
       `"type"` (or the deprecated `"hud_elem_type"`).
+* `hud_animate(id, animation definition)`: animate properties of a HUD element by keyframes.
+    * `id` is the HUD element ID returned by `hud_add`.
+    * See [HUD animation definition](#hud-animation-definition) for the format.
+    * Animations are applied client-side, server sends the definition
+      to the client which applies them locally.
+    * Multiple properties can be animated simultaneously in one anim def, but only one anim def can exist per element at a time. Calling this function on an element that's already animating will replace the existing animation set.
+    * Pass an empty table `{}` to cancel any animation on an element
+    * While an animation is active, it overwrites the animated properties each frame. Any `hud_change` calls on those properties will have no visible effect until the animation finishes or is cancelled.
 * `hud_get(id)`: gets the HUD element definition structure of the specified ID
 * `hud_get_all()`:
     * Returns a table in the form `{ [id] = HUD definition, [id] = ... }`.
@@ -12068,6 +12076,48 @@ Used by `ObjectRef:hud_add`. Returned by `ObjectRef:hud_get`.
     style = 0, -- integer [u32]
 
     hideable = true, -- bool
+
+    opacity = 1,-- float
+    -- value between 0 and 1, where 0 is invisible, and 1 is fully opaque. Default 1
+}
+```
+
+HUD animation definition
+-------------------------
+
+Used by `ObjectRef:hud_animate`.
+
+Each field in the table corresponds to an animatable HUD element property.
+Multiple properties can be animated at the same time by listing them in the same animation definition table. Any property not listed will be untouched by the animation.
+
+```lua
+{
+    pos_x = { -- pos_x is used as example, each available property has the same definition table
+        keyframes = { {0.1, 0.5}, {0.9, 0.5}, {0.1} },
+        -- List of {value, duration} pairs.
+        -- Duration is the time in seconds to transition FROM this keyframe TO the next one.
+        -- Last keyframe's duration is the time to transition back to the
+        -- first keyframe when looping. If not looping, or upon finishing finite loops,
+        -- the animation holds at the last keyframe's value
+
+        easing = "linear",
+        -- method of Interpolation to use between keyframes.
+        -- "linear" (default), "easein", "easeout", "easeinout"
+        -- these use quadratic easing functions under the hood
+
+        loop = 0,
+        -- Number of times to repeat the animation.
+        -- 0 = play once (default), -1 = loop forever, N = repeat N times
+    },
+
+    -- Animatable properties - multiple can be specified in one table to animate them simultaneously
+    -- Each property is animated independently, with its own elapsed time and loop count,
+    -- So you can specify different properties with their different durations and loop counts, and they will simply drift out of sync.
+    -- pos_x, pos_y : HUD element position
+    -- scale_x, scale_y : HUD element scale, a multiplier
+    -- offset_x, offset_y  : HUD element offset, in pixels
+    -- size_x, size_y : HUD element size, in pixels
+    -- opacity : HUD element opacity, clamped 0 to 1
 }
 ```
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -195,6 +195,7 @@ public:
 	void handleCommand_HudChange(NetworkPacket* pkt);
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
+	void handleCommand_HudAnimate(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
 	void handleCommand_HudSetSun(NetworkPacket* pkt);
 	void handleCommand_HudSetMoon(NetworkPacket* pkt);

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -37,6 +37,7 @@ enum ClientEventType : u8
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
 	CE_CLOUD_PARAMS,
 	CE_UPDATE_CAMERA,
+	CE_HUDANIMATE,
 	CLIENTEVENT_MAX,
 };
 
@@ -53,6 +54,7 @@ struct ClientEventHudAdd
 	v2f size;
 	s16 z_index;
 	bool hideable;
+	f32 opacity;
 };
 
 struct ClientEventHudChange
@@ -64,6 +66,12 @@ struct ClientEventHudChange
 	u32 data;
 	v3f v3fdata;
 	v2s32 v2s32data;
+};
+
+struct ClientEventHudAnimate
+{
+	u32 server_id;
+	HudElementAnimations animations;
 };
 
 struct ClientEvent
@@ -108,6 +116,7 @@ struct ClientEvent
 			u32 id;
 		} hudrm;
 		ClientEventHudChange *hudchange;
+		ClientEventHudAnimate *hudanimate;
 		SkyboxParams *set_sky;
 		struct
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -56,6 +56,8 @@
 	#include "client/sound/sound_openal.h"
 #endif
 
+const static float PENDING_HUD_ANIM_TIMEOUT_SEC = 10.0f;
+
 typedef s32 SamplerLayer_t;
 
 
@@ -2184,6 +2186,7 @@ const ClientEventHandler Game::clientEventHandler[CLIENTEVENT_MAX] = {
 	{&Game::handleClientEvent_OverrideDayNightRatio},
 	{&Game::handleClientEvent_CloudParams},
 	{&Game::handleClientEvent_UpdateCamera},
+	{&Game::handleClientEvent_HudAnimate},
 };
 
 void Game::handleClientEvent_None(ClientEvent *event, CameraOrientation *cam)
@@ -2300,7 +2303,19 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
 	e->hideable  = event->hudadd->hideable;
+	e->opacity   = event->hudadd->opacity;
 	m_hud_server_to_client[server_id] = player->hud.add(std::move(e));
+
+	// check for pending aims that may have arrived out of order
+	auto pending = m_pending_hud_animations.find(server_id);
+	if (pending != m_pending_hud_animations.end()) {
+		HudElement *elem = player->hud.get(m_hud_server_to_client[server_id]);
+		if (pending->second.animations.properties.empty())
+			elem->animations.reset();
+		else
+			elem->animations = std::move(pending->second.animations);
+		m_pending_hud_animations.erase(pending);
+	}
 
 	delete event->hudadd;
 }
@@ -2313,6 +2328,7 @@ void Game::handleClientEvent_HudRemove(ClientEvent *event, CameraOrientation *ca
 	if (i != m_hud_server_to_client.end()) {
 		player->hud.remove(i->second);
 		m_hud_server_to_client.erase(i);
+		m_pending_hud_animations.erase(event->hudrm.id);
 	}
 
 }
@@ -2369,6 +2385,8 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 		CASE_SET(HUD_STAT_HIDEABLE, hideable, data);
 
+		CASE_SET(HUD_STAT_OPACITY, opacity, v2fdata.X);
+
 		case HudElementStat_END:
 			break;
 	}
@@ -2376,6 +2394,27 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 #undef CASE_SET
 
 	delete event->hudchange;
+}
+
+void Game::handleClientEvent_HudAnimate(ClientEvent *event, CameraOrientation *cam)
+{
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+	auto i = m_hud_server_to_client.find(event->hudanimate->server_id);
+	if (i != m_hud_server_to_client.end()) {
+		HudElement *e = player->hud.get(i->second);
+		if (e) {
+			if (event->hudanimate->animations.properties.empty())
+				e->animations.reset();
+			else
+				e->animations = std::move(event->hudanimate->animations);
+		}
+	} else {
+		m_pending_hud_animations[event->hudanimate->server_id] =
+			{std::move(event->hudanimate->animations), 0.0f};
+	}
+
+	delete event->hudanimate;
 }
 
 void Game::handleClientEvent_SetSky(ClientEvent *event, CameraOrientation *cam)
@@ -3466,6 +3505,20 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		Update particles
 	*/
 	client->getParticleManager()->step(dtime);
+
+	/*
+	    Update rendering engine
+	*/
+	m_rendering_engine->step(dtime);
+
+	// cleanup any too-old pending anims to avoid keeping them forever
+	for (auto it = m_pending_hud_animations.begin(); it != m_pending_hud_animations.end();) {
+		it->second.age += dtime;
+		if (it->second.age > PENDING_HUD_ANIM_TIMEOUT_SEC)
+			it = m_pending_hud_animations.erase(it);
+		else
+			++it;
+	}
 
 	/*
 		Damage camera tilt

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -292,6 +292,7 @@ private:
 		CameraOrientation *cam);
 	void handleClientEvent_CloudParams(ClientEvent *event, CameraOrientation *cam);
 	void handleClientEvent_UpdateCamera(ClientEvent *event, CameraOrientation *cam);
+	void handleClientEvent_HudAnimate(ClientEvent *event, CameraOrientation *cam);
 
 	void updateChat(f32 dtime);
 
@@ -339,6 +340,12 @@ private:
 
 	// Map server hud ids to client hud ids
 	std::unordered_map<u32, u32> m_hud_server_to_client;
+	// list of pending anims that may have arrived out of order
+	struct PendingHudAnimation {
+		HudElementAnimations animations;
+		f32 age = 0.0f;
+	};
+	std::unordered_map<u32, PendingHudAnimation> m_pending_hud_animations;
 
 	GameRunData runData;
 	Flags m_flags;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -408,6 +408,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 				u8 alpha = (num >> 24) & 0xFF;
 				if (alpha == 0)
 					alpha = 0xFF; // Backwards compatibility
+				alpha = rangelim((u32)(alpha * e->opacity), 0, 255);
 
 				video::SColor color = video::SColor(alpha,
 						(num >> 16) & 0xFF,
@@ -440,7 +441,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 			case HUD_ELEM_STATBAR: {
 				v2s32 offs(e->offset.X, e->offset.Y);
 				drawStatbar(pos, HUD_CORNER_UPPER, e->dir, e->text, e->text2,
-					e->number, e->item, offs, e->size);
+					e->number, e->item, offs, e->size, e->opacity);
 				break; }
 			case HUD_ELEM_INVENTORY: {
 				InventoryList *inv = inventory->getList(e->text);
@@ -454,7 +455,8 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 					break;
 
 				pos += v2s32(e->offset.X, e->offset.Y);
-				video::SColor color(255, (e->number >> 16) & 0xFF,
+				u8 wp_alpha = rangelim((u32)(255 * e->opacity), 0, 255);
+				video::SColor color(wp_alpha, (e->number >> 16) & 0xFF,
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
@@ -490,7 +492,8 @@ void Hud::drawLuaElements(const v3s16 &camera_offset, bool only_unhidable)
 				if (!texture)
 					continue;
 
-				const video::SColor color(255, 255, 255, 255);
+				u8 img_alpha = rangelim((u32)(e->opacity * 255.0f), 0, 255);
+				const video::SColor color(img_alpha, 255, 255, 255);
 				const video::SColor colors[] = {color, color, color, color};
 				core::dimension2di imgsize(texture->getOriginalSize());
 				v2s32 dstsize(imgsize.Width * e->scale.X * m_scale_factor,
@@ -659,9 +662,11 @@ void Hud::drawCompassRotate(HudElement *e, video::ITexture *texture,
 
 void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 		const std::string &texture, const std::string &bgtexture,
-		s32 count, s32 maxcount, v2s32 offset, v2f size)
+		s32 count, s32 maxcount, v2s32 offset, v2f size,
+		f32 opacity)
 {
-	const video::SColor color(255, 255, 255, 255);
+	u8 a = rangelim((u32)(255 * opacity), 0, 255);
+	const video::SColor color(a, 255, 255, 255);
 	const video::SColor colors[] = {color, color, color, color};
 
 	video::ITexture *stat_texture = tsrc->getTexture(texture);

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -102,7 +102,8 @@ private:
 	bool calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos);
 	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir,
 			const std::string &texture, const std::string& bgtexture,
-			s32 count, s32 maxcount, v2s32 offset, v2f size = v2f());
+			s32 count, s32 maxcount, v2s32 offset, v2f size = v2f(),
+			f32 opacity = 1.0f);
 
 	void drawItems(v2s32 screen_pos, v2s32 screen_offset, s32 itemcount, v2f alignment,
 			s32 inv_offset, InventoryList *mainlist, u16 selectitem,

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -7,6 +7,10 @@
 
 #include "pipeline.h"
 #include "client/shadows/dynamicshadowsrender.h"
+#include "client/client.h"
+#include "client/localplayer.h"
+#include "hud_element.h"
+#include "util/numeric.h"
 
 RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud,
 		std::unique_ptr<ShadowRenderer> _shadow_renderer,
@@ -18,6 +22,111 @@ RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud
 }
 
 RenderingCore::~RenderingCore() = default;
+
+static f32 apply_easing(HudAnimEasing easing, f32 t)
+{
+	switch (easing) {
+		case HUD_ANIM_EASING_EASE_IN:     return ease_in(t);
+		case HUD_ANIM_EASING_EASE_OUT:    return ease_out(t);
+		case HUD_ANIM_EASING_EASE_IN_OUT: return ease_in_out(t);
+		default:                          return t;
+	}
+}
+
+static f32 evaluate_property(HudAnimProperty &prop, f32 dtime)
+{
+	if (prop.finished || prop.keyframes.size() < 2)
+		return prop.keyframes.empty() ? 0.0f : prop.keyframes[0].value;
+
+	f32 cycle_duration = 0.0f;
+	for (size_t i = 0; i < prop.keyframes.size() - 1; i++)
+		cycle_duration += prop.keyframes[i].duration;
+
+	bool loops = (prop.loop == -1 || prop.loop > 0);
+	if (loops)
+		cycle_duration += prop.keyframes.back().duration;
+
+	if (cycle_duration <= 0.0f)
+		return prop.keyframes[0].value;
+
+	prop.elapsed += dtime;
+
+	while (prop.elapsed >= cycle_duration) {
+		if (!loops) {
+			prop.finished = true;
+			return prop.keyframes.back().value;
+		}
+
+		prop.elapsed -= cycle_duration;
+		prop.loops_completed++;
+
+		if (prop.loop > 0 && prop.loops_completed >= prop.loop) {
+			prop.finished = true;
+			return prop.keyframes.back().value;
+		}
+	}
+
+	f32 t_acc = 0.0f;
+	for (size_t i = 0; i < prop.keyframes.size(); i++) {
+		f32 seg_dur = prop.keyframes[i].duration;
+		if (seg_dur <= 0.0f)
+			continue;
+
+		if (prop.elapsed < t_acc + seg_dur) {
+			f32 local_t = (prop.elapsed - t_acc) / seg_dur;
+			local_t = apply_easing(prop.easing, local_t);
+
+			size_t next = (i + 1) % prop.keyframes.size();
+			f32 a = prop.keyframes[i].value;
+			f32 b = prop.keyframes[next].value;
+			return a + (b - a) * local_t;
+		}
+		t_acc += seg_dur;
+	}
+
+	return prop.keyframes.back().value;
+}
+
+static void apply_anim_value(HudElement *e, u8 stat, f32 value)
+{
+	switch (static_cast<HudAnimationStat>(stat)) {
+		case HUD_ANIM_POS_X:    e->pos.X = value;    break;
+		case HUD_ANIM_POS_Y:    e->pos.Y = value;    break;
+		case HUD_ANIM_SCALE_X:  e->scale.X = value;  break;
+		case HUD_ANIM_SCALE_Y:  e->scale.Y = value;  break;
+		case HUD_ANIM_OFFSET_X: e->offset.X = value;  break;
+		case HUD_ANIM_OFFSET_Y: e->offset.Y = value;  break;
+		case HUD_ANIM_SIZE_X:   e->size.X = value;   break;
+		case HUD_ANIM_SIZE_Y:   e->size.Y = value;   break;
+		case HUD_ANIM_OPACITY:  e->opacity = rangelim(value, 0.0f, 1.0f); break;
+		default: break;
+	}
+}
+
+void RenderingCore::step(float dtime)
+{
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (!player)
+		return;
+
+	for (const auto &e : player->hud.getElements()) {
+		if (!e || !e->animations)
+			continue;
+
+		bool all_finished = true;
+		for (auto &[stat, prop] : e->animations->properties) {
+			if (prop.finished)
+				continue;
+
+			f32 value = evaluate_property(prop, dtime);
+			apply_anim_value(e.get(), stat, value);
+			all_finished = false;
+		}
+
+		if (all_finished)
+			e->animations.reset();
+	}
+}
 
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud,
 		bool _draw_wield_tool, bool _draw_crosshair)

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -41,6 +41,8 @@ public:
 	RenderingCore &operator=(const RenderingCore &) = delete;
 	RenderingCore &operator=(RenderingCore &&) = delete;
 
+	void step(float dtime);
+
 	void draw(video::SColor _skycolor, bool _show_hud,
 			bool _draw_wield_tool, bool _draw_crosshair);
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -289,6 +289,12 @@ bool RenderingEngine::setWindowIcon()
 	return m_device->setWindowIcon(img.get());
 }
 
+void RenderingEngine::step(float dtime)
+{
+	if (core)
+		core->step(dtime);
+}
+
 /*
 	Draws a screen with a single text on it.
 	Text will be removed when the screen is drawn the next time.

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -123,6 +123,8 @@ public:
 		return m_device->getGUIEnvironment();
 	}
 
+	void step(float dtime);
+
 	// If "indef_pos" is given, the value of "percent" is ignored and an indefinite
 	// progress bar is drawn.
 	void draw_load_screen(const std::wstring &text,

--- a/src/hud_element.cpp
+++ b/src/hud_element.cpp
@@ -37,6 +37,7 @@ const struct EnumString es_HudElementStat[] =
 	{HUD_STAT_TEXT2,   "text2"},
 	{HUD_STAT_STYLE,   "style"},
 	{HUD_STAT_HIDEABLE, "hideable"},
+	{HUD_STAT_OPACITY, "opacity"},
 	{0, NULL},
 };
 

--- a/src/hud_element.h
+++ b/src/hud_element.h
@@ -7,6 +7,9 @@
 
 #include "irrlichttypes_bloated.h"
 #include <string>
+#include <vector>
+#include <unordered_map>
+#include <optional>
 #include "util/enum_string.h"
 
 #define HUD_DIR_LEFT_RIGHT 0
@@ -72,6 +75,7 @@ enum HudElementStat : u8 {
 	HUD_STAT_TEXT2,
 	HUD_STAT_STYLE,
 	HUD_STAT_HIDEABLE,
+	HUD_STAT_OPACITY,
 	HudElementStat_END // Dummy for validity check
 };
 
@@ -80,6 +84,46 @@ enum HudCompassDir {
 	HUD_COMPASS_ROTATE_REVERSE,
 	HUD_COMPASS_TRANSLATE,
 	HUD_COMPASS_TRANSLATE_REVERSE,
+};
+
+enum HudAnimationStat : u8 {
+	HUD_ANIM_POS_X = 0,
+	HUD_ANIM_POS_Y,
+	HUD_ANIM_SCALE_X,
+	HUD_ANIM_SCALE_Y,
+	HUD_ANIM_OFFSET_X,
+	HUD_ANIM_OFFSET_Y,
+	HUD_ANIM_SIZE_X,
+	HUD_ANIM_SIZE_Y,
+	HUD_ANIM_OPACITY,
+	HUD_ANIM_STAT_COUNT,
+};
+
+enum HudAnimEasing : u8 {
+	HUD_ANIM_EASING_LINEAR = 0,
+	HUD_ANIM_EASING_EASE_IN,
+	HUD_ANIM_EASING_EASE_OUT,
+	HUD_ANIM_EASING_EASE_IN_OUT,
+};
+
+struct HudAnimKeyframe {
+	f32 value;
+	f32 duration;
+};
+
+struct HudAnimProperty {
+	std::vector<HudAnimKeyframe> keyframes;
+	HudAnimEasing easing = HUD_ANIM_EASING_LINEAR;
+	s32 loop = 0; // 0=once, -1=infinite, N=repeat N times
+
+	// client-side runtime state
+	f32 elapsed = 0.0f;
+	s32 loops_completed = 0;
+	bool finished = false;
+};
+
+struct HudElementAnimations {
+	std::unordered_map<u8, HudAnimProperty> properties;
 };
 
 struct HudElement {
@@ -99,6 +143,8 @@ struct HudElement {
 	std::string text2;
 	u32 style;
 	bool hideable = true;
+	f32 opacity = 1.0f;
+	std::optional<HudElementAnimations> animations;
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -112,6 +112,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_MINIMAP_MODES",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MinimapModes }, // 0x62,
 	{ "TOCLIENT_SET_LIGHTING",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SetLighting }, // 0x63,
 	{ "TOCLIENT_SPAWN_PARTICLE_BATCH",     TOCLIENT_STATE_CONNECTED, &Client::handleCommand_SpawnParticleBatch }, // 0x64,
+	{ "TOCLIENT_HUDANIMATE",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudAnimate }, // 0x65
 };
 
 const static ServerCommandFactory null_command_factory = { nullptr, 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1176,6 +1176,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	std::string text2;
 	u32 style = 0;
 	u8 flags = 1;
+	f32 opacity = 1.0f;
 
 	*pkt >> server_id >> type >> pos >> name >> scale >> text >> number >> item
 		>> dir >> align >> offset;
@@ -1210,6 +1211,10 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 		// >= 5.17.0-dev
 		*pkt >> flags;
 
+		if (!pkt->hasRemainingBytes())
+			break;
+		*pkt >> opacity;
+
 	} while (0);
 
 	ClientEvent *event = new ClientEvent();
@@ -1232,6 +1237,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd->text2     = text2;
 	event->hudadd->style     = style;
 	event->hudadd->hideable  = flags % 2;
+	event->hudadd->opacity   = opacity;
 	m_client_event_queue.push(event);
 }
 
@@ -1288,6 +1294,12 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 				v2fdata = v2f::from(old_format);
 			}
 			break;
+		case HUD_STAT_OPACITY: {
+			f32 fdata;
+			*pkt >> fdata;
+			v2fdata.X = fdata;
+			break;
+		}
 		default:
 			*pkt >> intdata;
 			break;
@@ -1302,6 +1314,43 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	event->hudchange->v3fdata   = v3fdata;
 	event->hudchange->sdata     = sdata;
 	event->hudchange->data      = intdata;
+	m_client_event_queue.push(event);
+}
+
+void Client::handleCommand_HudAnimate(NetworkPacket* pkt)
+{
+	u32 server_id;
+	u8 num_properties;
+
+	*pkt >> server_id >> num_properties;
+
+	auto *event_data = new ClientEventHudAnimate();
+	event_data->server_id = server_id;
+
+	for (u8 i = 0; i < num_properties; i++) {
+		u8 stat;
+		u8 easing;
+		s32 loop;
+		u16 num_keyframes;
+
+		*pkt >> stat >> easing >> loop >> num_keyframes;
+
+		HudAnimProperty prop;
+		prop.easing = (easing <= HUD_ANIM_EASING_EASE_IN_OUT)
+			? static_cast<HudAnimEasing>(easing) : HUD_ANIM_EASING_LINEAR;
+		prop.loop = loop;
+		prop.keyframes.resize(num_keyframes);
+
+		for (u16 k = 0; k < num_keyframes; k++) {
+			*pkt >> prop.keyframes[k].value >> prop.keyframes[k].duration;
+		}
+
+		event_data->animations.properties[stat] = std::move(prop);
+	}
+
+	ClientEvent *event = new ClientEvent();
+	event->type = CE_HUDANIMATE;
+	event->hudanimate = event_data;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -710,7 +710,21 @@ enum ToClientCommand : u16
 			u8[len] serialized ParticleParameters
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x65,
+	TOCLIENT_HUDANIMATE = 0x65,
+	/*
+		u32 id
+		u8 num_properties (0 = cancel)
+		for each property:
+			u8 stat (HudAnimationStat)
+			u8 easing (HudAnimEasing)
+			s32 loop
+			u16 num_keyframes
+			for each keyframe:
+				f32 value
+				f32 duration
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x66,
 };
 
 enum ToServerCommand : u16

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -213,4 +213,5 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_MINIMAP_MODES",            0, true }, // 0x62
 	{ "TOCLIENT_SET_LIGHTING",             0, true }, // 0x63
 	{ "TOCLIENT_SPAWN_PARTICLE_BATCH",     0, true }, // 0x64
+	{ "TOCLIENT_HUDANIMATE",               0, true }, // 0x65
 };

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2423,6 +2423,8 @@ void read_hud_element(lua_State *L, HudElement *elem)
 
 	elem->hideable = getboolfield_default(L, 2, "hideable", true);
 
+	elem->opacity = getfloatfield_default(L, 2, "opacity", 1.0f);
+
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2f()))
 		log_deprecated(L,"Deprecated usage of statbar without size!");
@@ -2491,6 +2493,9 @@ void push_hud_element(lua_State *L, HudElement *elem)
 
 	lua_pushboolean(L, elem->hideable);
 	lua_setfield(L, -2, "hideable");
+
+	lua_pushnumber(L, elem->opacity);
+	lua_setfield(L, -2, "opacity");
 }
 
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value)
@@ -2564,12 +2569,97 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 			elem->hideable = lua_isnoneornil(L, 4) ? true : lua_toboolean(L, 4);
 			*value = &elem->hideable;
 			break;
+		case HUD_STAT_OPACITY:
+			elem->opacity = lua_isnoneornil(L, 4) ? 1.0f : luaL_checknumber(L, 4);
+			*value = &elem->opacity;
+			break;
 		case HudElementStat_END:
 			return false;
 			break;
 	}
 
 	return true;
+}
+
+/******************************************************************************/
+
+static const struct {
+	const char *name;
+	HudAnimationStat stat;
+} hud_anim_property_names[] = {
+	{"pos_x",    HUD_ANIM_POS_X},
+	{"pos_y",    HUD_ANIM_POS_Y},
+	{"scale_x",  HUD_ANIM_SCALE_X},
+	{"scale_y",  HUD_ANIM_SCALE_Y},
+	{"offset_x", HUD_ANIM_OFFSET_X},
+	{"offset_y", HUD_ANIM_OFFSET_Y},
+	{"size_x",   HUD_ANIM_SIZE_X},
+	{"size_y",   HUD_ANIM_SIZE_Y},
+	{"opacity",  HUD_ANIM_OPACITY},
+};
+
+void read_hud_animation(lua_State *L, int index, HudElementAnimations &anims)
+{
+	for (const auto &pn : hud_anim_property_names) {
+		lua_getfield(L, index, pn.name);
+		if (!lua_istable(L, -1)) {
+			lua_pop(L, 1);
+			continue;
+		}
+
+		int prop_table = lua_gettop(L);
+		HudAnimProperty prop;
+
+		// Read easing
+		lua_getfield(L, prop_table, "easing");
+		if (lua_isstring(L, -1)) {
+			std::string easing = lua_tostring(L, -1);
+			if (easing == "easein")
+				prop.easing = HUD_ANIM_EASING_EASE_IN;
+			else if (easing == "easeout")
+				prop.easing = HUD_ANIM_EASING_EASE_OUT;
+			else if (easing == "easeinout")
+				prop.easing = HUD_ANIM_EASING_EASE_IN_OUT;
+		}
+		lua_pop(L, 1);
+
+		// Read loop
+		lua_getfield(L, prop_table, "loop");
+		if (lua_isnumber(L, -1))
+			prop.loop = lua_tonumber(L, -1);
+		lua_pop(L, 1);
+
+		// Read keyframes
+		lua_getfield(L, prop_table, "keyframes");
+		if (lua_istable(L, -1)) {
+			int kf_table = lua_gettop(L);
+			size_t num_kf = lua_objlen(L, kf_table);
+			prop.keyframes.reserve(num_kf);
+
+			for (size_t i = 1; i <= num_kf; i++) {
+				lua_rawgeti(L, kf_table, i);
+				if (lua_istable(L, -1)) {
+					HudAnimKeyframe kf;
+					lua_rawgeti(L, -1, 1);
+					kf.value = lua_tonumber(L, -1);
+					lua_pop(L, 1);
+
+					lua_rawgeti(L, -1, 2);
+					kf.duration = lua_isnumber(L, -1) ? lua_tonumber(L, -1) : 0.0f;
+					lua_pop(L, 1);
+
+					prop.keyframes.push_back(kf);
+				}
+				lua_pop(L, 1);
+			}
+		}
+		lua_pop(L, 1);
+
+		if (!prop.keyframes.empty())
+			anims.properties[static_cast<u8>(pn.stat)] = std::move(prop);
+
+		lua_pop(L, 1);
+	}
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -172,6 +172,8 @@ void push_hud_element(lua_State *L, HudElement *elem);
 
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value);
 
+void read_hud_animation(lua_State *L, int index, HudElementAnimations &anims);
+
 void push_collision_move_result(lua_State *L, const CollisionMoveResult &res);
 
 void push_mod_spec(lua_State *L, const ModSpec &spec, bool include_unsatisfied);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2031,6 +2031,31 @@ int ObjectRef::l_hud_change(lua_State *L)
 	return 1;
 }
 
+// hud_animate(self, id, animation_def)
+int ObjectRef::l_hud_animate(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr)
+		return 0;
+
+	u32 id = luaL_checkint(L, 2);
+
+	HudElement *elem = player->hud.get(id);
+	if (elem == nullptr)
+		return 0;
+
+	HudElementAnimations anims;
+	if (lua_istable(L, 3))
+		read_hud_animation(L, 3, anims);
+
+	getServer(L)->hudAnimate(player, id, anims);
+
+	lua_pushboolean(L, true);
+	return 1;
+}
+
 // hud_get(self, id)
 int ObjectRef::l_hud_get(lua_State *L)
 {
@@ -3109,6 +3134,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_add),
 	luamethod(ObjectRef, hud_remove),
 	luamethod(ObjectRef, hud_change),
+	luamethod(ObjectRef, hud_animate),
 	luamethod(ObjectRef, hud_get),
 	luamethod(ObjectRef, hud_get_all),
 	luamethod(ObjectRef, hud_set_flags),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -311,6 +311,9 @@ private:
 	// hud_change(self, id, stat, data)
 	static int l_hud_change(lua_State *L);
 
+	// hud_animate(self, id, animation_def)
+	static int l_hud_animate(lua_State *L);
+
 	// hud_get_next_id(self)
 	static u32 hud_get_next_id(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1889,7 +1889,8 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 	/// Bits 1 ... 8: unused (set to 0)
 	u8 flags = form->hideable ? 1 : 0;
 
-	pkt << form->z_index << form->text2 << form->style << flags;
+	pkt << form->z_index << form->text2 << form->style << flags
+		<< form->opacity;
 
 	Send(&pkt);
 }
@@ -1932,9 +1933,28 @@ void Server::SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void 
 		case HUD_STAT_HIDEABLE:
 			pkt << u32{*(bool *) value};
 			break;
+		case HUD_STAT_OPACITY:
+			pkt << *(f32 *) value;
+			break;
 		default: // all other types
 			pkt << *(u32 *) value;
 			break;
+	}
+
+	Send(&pkt);
+}
+
+void Server::SendHUDAnimate(session_t peer_id, u32 id, const HudElementAnimations &anims)
+{
+	NetworkPacket pkt(TOCLIENT_HUDANIMATE, 0, peer_id);
+
+	pkt << id << (u8)anims.properties.size();
+
+	for (const auto &[stat, prop] : anims.properties) {
+		pkt << stat << (u8)prop.easing << prop.loop << (u16)prop.keyframes.size();
+		for (const auto &kf : prop.keyframes) {
+			pkt << kf.value << kf.duration;
+		}
 	}
 
 	Send(&pkt);
@@ -3566,6 +3586,15 @@ bool Server::hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *
 		return false;
 
 	SendHUDChange(player->getPeerId(), id, stat, data);
+	return true;
+}
+
+bool Server::hudAnimate(RemotePlayer *player, u32 id, const HudElementAnimations &anims)
+{
+	if (!player)
+		return false;
+
+	SendHUDAnimate(player->getPeerId(), id, anims);
 	return true;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -373,6 +373,7 @@ public:
 	u32 hudAdd(RemotePlayer *player, std::unique_ptr<HudElement> element);
 	bool hudRemove(RemotePlayer *player, u32 id);
 	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
+	bool hudAnimate(RemotePlayer *player, u32 id, const HudElementAnimations &anims);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount);
 	void hudSetHotbarImage(RemotePlayer *player, const std::string &name);
@@ -553,6 +554,7 @@ private:
 	void SendHUDAdd(session_t peer_id, u32 id, HudElement *form);
 	void SendHUDRemove(session_t peer_id, u32 id);
 	void SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void *value);
+	void SendHUDAnimate(session_t peer_id, u32 id, const HudElementAnimations &anims);
 	void SendHUDSetFlags(session_t peer_id, u32 flags, u32 mask);
 	void SendHUDSetParam(session_t peer_id, u16 param, std::string_view value);
 	void SendSetSky(session_t peer_id, const SkyboxParams &params);

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -412,6 +412,22 @@ inline f32 damp(f32 a, f32 b, f32 lambda) {
 	return core::lerp(a, b, 1.0f - std::exp(-lambda));
 }
 
+// Easing functions: remap t in [0,1] to a quadratic eased curve
+inline f32 ease_in(f32 t)
+{
+	return t * t;
+}
+
+inline f32 ease_out(f32 t)
+{
+	return t * (2.0f - t);
+}
+
+inline f32 ease_in_out(f32 t)
+{
+	return (t < 0.5f) ? 2.0f * t * t : -1.0f + (4.0f - 2.0f * t) * t;
+}
+
 constexpr inline bool is_power_of_two(u32 n)
 {
 	return n != 0 && (n & (n - 1)) == 0;


### PR DESCRIPTION
###  Goal of the PR:
Add smooth client-side keyframe animations for HUD elements via a new `player:hud_animate(id, def)` Lua API, along with adding new opacity field for HUD elements that can also be animated.

### How does the PR work?
- Adds a new `TOCLIENT_HUDANIMATE` network packet (0x65) that sends animation definitions from server to client
- The server-side Lua API parses per-property animation tables (keyframes, easing, loop count) and serializes them
- The client receives the definition, stores it on the HudElement, and interpolates values each frame in RenderingCore::step()
- Supports 9 animatable properties: pos_x/y, scale_x/y, offset_x/y, size_x/y, opacity and four easing funcs: linear, ease-in, ease-out, ease-in-out (all quadratic)
- Also adds opacity as a HUD element field (0-1), supported for image, text, statbar, and waypoint elements
- Old clients safely ignore the new packet, so no backwards compat issues

### Does it resolve any reported issue?
No.

### Does this relate to a goal in the roadmap?
- Section 2.3 (UI Improvements) mentions a unified API for HUDs and GUIs. This PR extends the HUD API with animation capabilities

### If not a bug fix, why is this PR needed? What usecases does it solve?
The only way to animate any hud element currently is continuous calls to pos/scale/etc, and it won't be smooth.
This PR enables smooth client-side animations defined once and interpolated per-frame. Use cases include:

- Fading notifications in/out
- Pulsing or bouncing indicators, eg. health or hunger meters
- Sliding HUD elements on/off screen
- Shaking effects that decay
- Any combination of the above running simultaneously on the same element

LLM/AI disclosure:
- Some code (around networking stuff mostly) was co-authored with Claude (Anthropic). All changes were hand-reviewed by me, and tested in-game.

## To do

This PR is Ready for Review.

## How to test

<details>

<summary>LUA mod code to test this</summary>

```lua
-- HUD animation test
local hud_anim_test_ids = {}

local function find_health_hud_id(player)
  local all = player:hud_get_all()
  for id, def in pairs(all) do
    if def.text == "heart.png" and def.type == "statbar" then
      return id
    end
  end
  return nil
end

core.register_chatcommand("hudanimstop", {
  description = "Stop HUD animation test",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player or not hud_anim_test_ids[name] then
      return false, "No animation running"
    end
    player:hud_animate(hud_anim_test_ids[name], {})
    player:hud_remove(hud_anim_test_ids[name])
    hud_anim_test_ids[name] = nil

    local hp_id = find_health_hud_id(player)
    if hp_id then
      player:hud_animate(hp_id, {})
    end

    return true, "All animations stopped"
  end,
})

core.register_chatcommand("hudanim1", {
  description = "Test HUD animation",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    -- remove previous test element
    if hud_anim_test_ids[name] then
      player:hud_remove(hud_anim_test_ids[name])
    end

    local id = player:hud_add({
      type = "image",
      position = {x = 0.5, y = 0.5},
      offset = {x = 0, y = 0},
      text = "heart.png",
      scale = {x = 2, y = 2},
      alignment = {x = 0, y = 0},
      opacity = 1.0,
    })
    hud_anim_test_ids[name] = id

    player:hud_animate(id, {
      pos_x = {
        keyframes = { {0.2, 1.0}, {0.8, 1.0}, {0.2, 1.0} },
        easing = "easeinout",
        loop = -1,
      },
      opacity = {
        keyframes = { {1.0, 0.5}, {0.2, 0.5}, {1.0, 0.5} },
        easing = "easeinout",
        loop = -1,
      },
    })

    return true, "HUD animation started"
  end,
})

-- hudanim2: fade in and out (opacity only, no movement)
core.register_chatcommand("hudanim2", {
  description = "Test HUD animation - fade pulse",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    if hud_anim_test_ids[name] then
      player:hud_remove(hud_anim_test_ids[name])
    end

    local id = player:hud_add({
      type = "image",
      position = {x = 0.5, y = 0.3},
      offset = {x = 0, y = 0},
      text = "heart.png",
      scale = {x = 3, y = 3},
      alignment = {x = 0, y = 0},
      opacity = 1.0,
    })
    hud_anim_test_ids[name] = id

    player:hud_animate(id, {
      opacity = {
        keyframes = { {1.0, 0.8}, {0.0, 0.8}, {1.0, 0.8} },
        easing = "easeinout",
        loop = -1,
      },
    })
    return true, "Fade pulse started"
  end,
})

-- hudanim3: shake that dies down (play once, no loop)
core.register_chatcommand("hudanim3", {
  description = "Test HUD animation - decaying shake",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    if hud_anim_test_ids[name] then
      player:hud_remove(hud_anim_test_ids[name])
    end

    local id = player:hud_add({
      type = "image",
      position = {x = 0.5, y = 0.5},
      offset = {x = 0, y = 0},
      text = "heart.png",
      scale = {x = 2, y = 2},
      alignment = {x = 0, y = 0},
    })
    hud_anim_test_ids[name] = id

    player:hud_animate(id, {
      offset_x = {
        keyframes = {
          {20, 0.05}, {-20, 0.05},
          {15, 0.05}, {-15, 0.05},
          {10, 0.05}, {-10, 0.05},
          {5, 0.05},  {-5, 0.05},
          {2, 0.05},  {-2, 0.05},
          {0},
        },
        easing = "linear",
        loop = 0,
      },
    })
    return true, "Decaying shake started"
  end,
})

-- hudanim4: circular-ish motion (pos_x and pos_y with offset phase)
core.register_chatcommand("hudanim4", {
  description = "Test HUD animation - orbit motion",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    if hud_anim_test_ids[name] then
      player:hud_remove(hud_anim_test_ids[name])
    end

    local id = player:hud_add({
      type = "image",
      position = {x = 0.5, y = 0.5},
      offset = {x = 0, y = 0},
      text = "heart.png",
      scale = {x = 2, y = 2},
      alignment = {x = 0, y = 0},
    })
    hud_anim_test_ids[name] = id

    -- approximate circle with 4 keyframes
    player:hud_animate(id, {
      pos_x = {
        keyframes = { {0.6, 0.5}, {0.5, 0.5}, {0.4, 0.5}, {0.5, 0.5}, {0.6, 0.5} },
        easing = "easeinout",
        loop = -1,
      },
      pos_y = {
        keyframes = { {0.5, 0.5}, {0.4, 0.5}, {0.5, 0.5}, {0.6, 0.5}, {0.5, 0.5} },
        easing = "easeinout",
        loop = -1,
      },
    })
    return true, "Orbit motion started"
  end,
})

-- hudanim5: loop 3 times then stop
core.register_chatcommand("hudanim5", {
  description = "Test HUD animation - 3x loop then stop",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    if hud_anim_test_ids[name] then
      player:hud_remove(hud_anim_test_ids[name])
    end

    local id = player:hud_add({
      type = "image",
      position = {x = 0.5, y = 0.5},
      offset = {x = 0, y = 0},
      text = "heart.png",
      scale = {x = 2, y = 2},
      alignment = {x = 0, y = 0},
      opacity = 1.0,
    })
    hud_anim_test_ids[name] = id

    player:hud_animate(id, {
      pos_x = {
        keyframes = { {0.3, 0.4}, {0.7, 0.4}, {0.3, 0.4} },
        easing = "easeout",
        loop = 3,
      },
      opacity = {
        keyframes = { {1.0, 0.4}, {0.3, 0.4}, {1.0, 0.4} },
        easing = "easein",
        loop = 3,
      },
    })
    return true, "3x loop animation started"
  end,
})

-- hudanim6: fade the actual health bar
core.register_chatcommand("hudanim6", {
  description = "Test HUD animation - health bar fade",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    local id = find_health_hud_id(player)
    if not id then return false, "Health bar not found" end

    player:hud_animate(id, {
      opacity = {
        keyframes = { {1.0, 1.0}, {0.1, 1.0}, {1.0, 1.0} },
        easing = "easeinout",
        loop = -1,
      },
    })
    return true, "Health bar fade started (id=" .. id .. ")"
  end,
})

-- hudanim7: bounce the actual health bar
core.register_chatcommand("hudanim7", {
  description = "Test HUD animation - health bar bounce",
  func = function(name, param)
    local player = core.get_player_by_name(name)
    if not player then return false end

    local id = find_health_hud_id(player)
    if not id then return false, "Health bar not found" end

    player:hud_animate(id, {
      offset_y = {
        keyframes = { {-91, 0.3}, {-101, 0.3}, {-91, 0.3} },
        easing = "easeout",
        loop = -1,
      },
      opacity = {
        keyframes = { {1.0, 0.3}, {0.4, 0.3}, {1.0, 0.3} },
        easing = "easeinout",
        loop = -1,
      },
    })
    return true, "Health bar bounce started (id=" .. id .. ")"
  end,
})

```

</details>

### Video of above mod code running

https://github.com/user-attachments/assets/f606ae1a-2bce-4926-b053-ac79f0835b7d

