### PR TITLE
Fix selected item count changing when swap is disallowed

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3910,6 +3910,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 						if (m_selected_swap.name == stack.name &&
 								m_selected_swap.count == stack.count) {
 							m_selected_swap.clear();
+							// After a sucessful swap, make sure the whole stack is selected.
 							m_selected_amount = stack.count;
 						}
 					} else {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3910,6 +3910,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 						if (m_selected_swap.name == stack.name &&
 								m_selected_swap.count == stack.count)
 							m_selected_swap.clear();
+							m_selected_amount = stack.count;
 					} else {
 						m_selected_amount = std::min(m_selected_amount, stack.count);
 					}
@@ -4828,7 +4829,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			// they are swapped
 			if (leftover.count == stack_from.count && leftover.name == stack_from.name) {
 				if (m_selected_swap.empty()) {
-					m_selected_amount = stack_to.count;
 					m_selected_dragging = false;
 
 					// WARNING: BLACK MAGIC, BUT IN A REDUCED SET

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3908,9 +3908,10 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 					ItemStack stack = list->getItem(m_selected_item->i);
 					if (!m_selected_swap.empty()) {
 						if (m_selected_swap.name == stack.name &&
-								m_selected_swap.count == stack.count)
+								m_selected_swap.count == stack.count) {
 							m_selected_swap.clear();
 							m_selected_amount = stack.count;
+						}
 					} else {
 						m_selected_amount = std::min(m_selected_amount, stack.count);
 					}


### PR DESCRIPTION
A small change to fix a small bug when an attempt to swap items is disallowed.

Minimal code to test:
```lua
local inv = core.create_detached_inventory("test", {
	allow_take = function() return 0 end
})
inv:set_size("main", 8)
local fs = "size[8,6]list[current_player;main;0,2;8,4;]"..
	"list[detached:test;main;0,0;8,1;]listring[]"
core.register_chatcommand("test", {
    func = function(name)
		core.show_formspec(name, "test", fs)
    end
})
```

Steps:
 1. Put some items in your inventory and run the command.
 2. Move a small stack of items to the other inventory.
 3. Pick up a larger stack and try to swap it with other stack.

What currently happens: The selected count of the selected stack changes to the count of the other stack.
What should happen, with the fix in this PR: Nothing; the selected stack doesn't change.