### PR TITLE
Correctly convert node pos to block pos in findSunlight

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -707,7 +707,8 @@ u8 ServerEnvironment::findSunlight(v3s16 pos) const
 			MapNode node = m_map->getNode(neighborPos, &is_position_ok);
 			if (!is_position_ok) {
 				// This happens very rarely because the map at currentPos is loaded
-				m_map->emergeBlock(neighborPos, false);
+				v3s16 blockPos = getNodeBlockPos(neighborPos);
+				m_map->emergeBlock(blockPos, false);
 				node = m_map->getNode(neighborPos, &is_position_ok);
 				if (!is_position_ok)
 					continue; // not generated

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -707,8 +707,8 @@ u8 ServerEnvironment::findSunlight(v3s16 pos) const
 			MapNode node = m_map->getNode(neighborPos, &is_position_ok);
 			if (!is_position_ok) {
 				// This happens very rarely because the map at currentPos is loaded
-				v3s16 blockPos = getNodeBlockPos(neighborPos);
-				m_map->emergeBlock(blockPos, false);
+				v3s16 blockpos = getNodeBlockPos(neighborPos);
+				m_map->emergeBlock(blockpos, false);
 				node = m_map->getNode(neighborPos, &is_position_ok);
 				if (!is_position_ok)
 					continue; // not generated


### PR DESCRIPTION
Fix `findSunlight` using the neighbor's node pos as block pos when attempting to load unloaded blocks. 

This also fixes the crashes reported in #17275 without doing anything about the `InvalidPositionException` thrown when loading blocks outside the map limit, because `findSunlight` will no longer try to load blocks with map limit exceeding block positions.

The following mod code sets up a test scenario on first run and exercises the traversal into an unloaded block causing the erroneous block loading fixed in this PR on the second (and subsequent) run:

```lua
core.after(0, function()
	local min = vector.new(0, 1936, 0)
	local max = min:offset(15, 31, 15)
	local check = min:offset(8, 15, 8)
	core.load_area(check)
	local check_node = core.get_node(check)
	local max_node = core.get_node_or_nil(max)
	if check_node.name == "air" and check_node.param1 == 238 and not max_node then
		core.log("Testing findSunlight traversal into unloaded block...")
	elseif check_node.name ~= "ignore" then
		core.log(dump(core.get_node(check)))
		core.log(dump(core.get_node(max)))
		error("Setup failed?!")
	else
		local vm = VoxelManip(min, max)
		local data, light, param2 = {}, {}, {}
		for i = 1, 8192 do
			data[i] = core.CONTENT_IGNORE
			light[i] = 0
			param2[i] = 0
		end
		local i = VoxelArea(min, max):indexp(check)
		data[i] = core.CONTENT_AIR
		light[i] = 14*16 + 14
		data[i+16] = core.CONTENT_AIR
		light[i+16] = 11
		vm:set_data(data)
		vm:set_light_data(light)
		vm:set_param2_data(param2)
		vm:write_to_map(false)
		vm:close()
		core.log("Setup done, Testing findSunlight in fully loaded area...")
	end
	core.log("get_natural_light: 10 == " .. core.get_natural_light(check, 0.5))
	error("Test finished")
end)
```

Bonus test: forging a block at block pos `(8, 1952, 8)` into the map db after inital setup is finished will cause the exception from the linked issue.