### PR TITLE
Don't cull upper face of waving liquids below solid nodes

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -455,39 +455,39 @@ void MapblockMeshGenerator::drawSolidNode()
 		// a gap where the face was culled. Also keep backface culling off so the
 		// face is visible from below e.g. looking up from underwater.
 		// Submerged solids surrounded by liquid or other solid nodes on all sides are excluded.
-		bool wavy_liquid_top = face == 0
+		bool liquid_needs_top_face = face == 0
 			&& cur_node.f->drawtype == NDT_LIQUID
 			&& cur_node.f->waving == 3
 			&& data->m_enable_waving_water;
-		if (wavy_liquid_top) {
-			wavy_liquid_top = false;
+		if (liquid_needs_top_face) {
+			liquid_needs_top_face = false;
 			static const v3s16 h_dirs[4] = {
 				v3s16(1,0,0), v3s16(-1,0,0), v3s16(0,0,1), v3s16(0,0,-1)
 			};
 			for (const v3s16 &d : h_dirs) {
 				const ContentFeatures &f_side = nodedef->get(data->m_vmanip.getNodeNoEx(p2 + d));
 
-				bool side_is_open = !(f_side.visuals->solidness || f_side.visuals->visual_solidness);
+				bool side_is_translucent = !(f_side.visuals->solidness || f_side.visuals->visual_solidness);
 				bool side_is_same_flowing_liquid =
 					f_side.drawtype == NDT_FLOWINGLIQUID && cur_node.f->sameLiquidRender(f_side);
 
-				// an open block to the side (that isn't the same liquid) means we should show the
-				// water surface to not expose an air gap below the solid block above us
-				if (side_is_open && !side_is_same_flowing_liquid) {
-					wavy_liquid_top = true;
+				// Draw the top face as soon there's a translucent node diagonally above to
+				// avoid visual gaps in the liquid surface
+				if (side_is_translucent && !side_is_same_flowing_liquid) {
+					liquid_needs_top_face = true;
 					break;
 				}
 			}
 		}
 		if (n2 != CONTENT_AIR) {
 			const ContentFeatures &f2 = nodedef->get(n2);
-			if (f2.visuals->solidness == 2 && !wavy_liquid_top)
+			if (f2.visuals->solidness == 2 && !liquid_needs_top_face)
 				continue;
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
 				backface_culling =
-					!wavy_liquid_top && (f2.visuals->solidness || f2.visuals->visual_solidness);
+					!liquid_needs_top_face && (f2.visuals->solidness || f2.visuals->visual_solidness);
 			}
 		}
 		faces |= 1 << face;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -450,14 +450,44 @@ void MapblockMeshGenerator::drawSolidNode()
 			continue;
 		if (n2 == CONTENT_IGNORE)
 			continue;
+		// For a waving liquid source, keep the top face even when a solid node
+		// is directly above: wave animation can pull the surface down and expose
+		// a gap where the face was culled. Also keep backface culling off so the
+		// face is visible from below e.g. looking up from underwater.
+		// Submerged solids surrounded by liquid or other solid nodes on all sides are excluded.
+		bool wavy_liquid_top = face == 0
+			&& cur_node.f->drawtype == NDT_LIQUID
+			&& cur_node.f->waving == 3
+			&& data->m_enable_waving_water;
+		if (wavy_liquid_top) {
+			wavy_liquid_top = false;
+			static const v3s16 h_dirs[4] = {
+				v3s16(1,0,0), v3s16(-1,0,0), v3s16(0,0,1), v3s16(0,0,-1)
+			};
+			for (const v3s16 &d : h_dirs) {
+				const ContentFeatures &f_side = nodedef->get(data->m_vmanip.getNodeNoEx(p2 + d));
+
+				bool side_is_open = !(f_side.visuals->solidness || f_side.visuals->visual_solidness);
+				bool side_is_same_flowing_liquid =
+					f_side.drawtype == NDT_FLOWINGLIQUID && cur_node.f->sameLiquidRender(f_side);
+
+				// an open block to the side (that isn't the same liquid) means we should show the
+				// water surface to not expose an air gap below the solid block above us
+				if (side_is_open && !side_is_same_flowing_liquid) {
+					wavy_liquid_top = true;
+					break;
+				}
+			}
+		}
 		if (n2 != CONTENT_AIR) {
 			const ContentFeatures &f2 = nodedef->get(n2);
-			if (f2.visuals->solidness == 2)
+			if (f2.visuals->solidness == 2 && !wavy_liquid_top)
 				continue;
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
-				backface_culling = f2.visuals->solidness || f2.visuals->visual_solidness;
+				backface_culling =
+					!wavy_liquid_top && (f2.visuals->solidness || f2.visuals->visual_solidness);
 			}
 		}
 		faces |= 1 << face;

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -48,6 +48,7 @@ struct MeshMakeData
 	bool m_generate_minimap = false;
 	bool m_smooth_lighting = false;
 	bool m_enable_water_reflections = false;
+	bool m_enable_waving_water = false;
 
 	const NodeDefManager *m_nodedef;
 

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -91,6 +91,7 @@ MeshUpdateQueue::MeshUpdateQueue(Client *client):
 {
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
 	m_cache_enable_water_reflections = g_settings->getBool("enable_water_reflections");
+	m_cache_enable_waving_water = g_settings->getBool("enable_waving_water");
 }
 
 MeshUpdateQueue::~MeshUpdateQueue()
@@ -239,6 +240,7 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	data->m_generate_minimap = !!m_client->getMinimap();
 	data->m_smooth_lighting = m_cache_smooth_lighting;
 	data->m_enable_water_reflections = m_cache_enable_water_reflections;
+	data->m_enable_waving_water = m_cache_enable_waving_water;
 }
 
 /*

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -106,6 +106,7 @@ private:
 	// TODO: Add callback to update these when g_settings changes, and update all meshes
 	bool m_cache_smooth_lighting;
 	bool m_cache_enable_water_reflections;
+	bool m_cache_enable_waving_water;
 
 	void fillDataFromMapBlocks(QueuedMeshUpdate *q);
 };


### PR DESCRIPTION
## Goal of the PR
Fix a visual bug that's been bothering me

## How does the PR work?
When the client has the waving liquid setting enabled and a waving liquid is below a solid node:
- Check if solid node has any other node types (Except solid or flowing liquid) that might generate a surface
- If so, generate a surface

The result is that this PR solves the waving water gap under solid nodes on the border, while maintaining no 'air pockets' underwater. This approach uses local-only checks, not a global scan so its one flaw is that for a huge area of solid nodes that are hovering right above the water, the waving water will be added around the border nodes, but not under all nodes of the large area.

This is strictly an improvement over current appearance however, as that was always the case anyway.

## Does it resolve any reported issue?
https://github.com/luanti-org/luanti/issues/3075 - also obvious visual bug see screenshots below

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
No

## To do

This PR is Ready for Review.

## How to test
- Put solid node above a waving liquid (e.g. water_source)

## Recordings

### Before

https://github.com/user-attachments/assets/c7d13568-1ebd-4380-8fdc-44b832337e90

### After

https://github.com/user-attachments/assets/1a486df9-0c09-4424-878d-d4a00ea142a1

