### PR TITLE
Formspec: Fix model element flickering

### DIFF
--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -99,13 +99,9 @@ void GUIScene::draw()
 		m_cam->bindTargetAndRotation(true);
 	}
 
-	cameraLoop();
-
 	// Continuous rotation
 	if (m_inf_rot)
 		rotateCamera(v3f(0.f, -0.03f * (float)dtime_ms, 0.f));
-
-	m_smgr->drawAll();
 
 	if (m_initial_rotation && m_mesh) {
 		rotateCamera(v3f(m_custom_rot.X, m_custom_rot.Y, 0.f));
@@ -113,6 +109,9 @@ void GUIScene::draw()
 
 		m_initial_rotation = false;
 	}
+
+	cameraLoop();
+	m_smgr->drawAll();
 
 	m_driver->setViewPort(oldViewPort);
 }
@@ -176,6 +175,7 @@ inline void GUIScene::calcOptimalDistance()
 	f32 depth  = box.MaxEdge.Z - box.MinEdge.Z;
 	f32 max_width = width > depth ? width : depth;
 
+	m_cam->updateMatrices(); // Updates the frustum
 	const scene::SViewFrustum *f = m_cam->getViewFrustum();
 	f32 cam_far = m_cam->getFarValue();
 	f32 far_width = core::line3df(f->getFarLeftUp(), f->getFarRightUp()).getLength();


### PR DESCRIPTION
Fixes #17300

The problem was that `calcOptimalDistance()` did not update the camera properly, so the first `GUIScene::draw()` call (which is the only one that calls `calcOptimalDistance()`) draws a wrong model, or more correctly uses an outdated camera position.

I did not look at the MultiCraft solution beforehand, so there is no licensing problem.

The model animation reset on formspec update is a different problem.
This PR only fixes the problem of the first draw call being wrong. This also happens if you only show the formspec once and don't update it, but it's less noticeable.

## To do

Ready for Review.

## How to test

Use the i3 mod, see issue.