### PR TITLE
Make frame clamping more robust

### DIFF
--- a/irr/include/AnimSpec.h
+++ b/irr/include/AnimSpec.h
@@ -31,6 +31,9 @@ struct TrackAnimSpec {
 
 	/// Set the frame range between frame1 and frame2, sorted and clamped
 	void setFrameRange(f32 frame1, f32 frame2);
+
+	/// Clamp min/max/cur frame to model track max frame
+	void clamp(f32 model_max_frame);
 };
 
 /// Specification for multiple animation tracks

--- a/irr/include/AnimSpec.h
+++ b/irr/include/AnimSpec.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "irrTypes.h"
+#include <algorithm>
 #include <unordered_map>
 #include <variant>
 #include <string>
@@ -30,7 +31,11 @@ struct TrackAnimSpec {
 	void advance(f32 dtime_s);
 
 	/// Set the frame range between frame1 and frame2, sorted and clamped
-	void setFrameRange(f32 frame1, f32 frame2);
+	void setFrameRange(f32 frame1, f32 frame2)
+	{
+		min_frame = std::max(0.0f, std::min(frame1, frame2));
+		max_frame = std::max(0.0f, std::max(frame1, frame2));
+	}
 
 	/// Clamp min/max/cur frame to model track max frame
 	void clamp(f32 model_max_frame);

--- a/irr/src/AnimSpec.cpp
+++ b/irr/src/AnimSpec.cpp
@@ -22,12 +22,6 @@ void TrackAnimSpec::advance(f32 dtime_s)
 	}
 }
 
-void TrackAnimSpec::setFrameRange(f32 frame1, f32 frame2)
-{
-	min_frame = std::max(0.0f, std::min(frame1, frame2));
-	max_frame = std::max(0.0f, std::max(frame1, frame2));
-}
-
 void TrackAnimSpec::clamp(f32 model_max_frame)
 {
 	max_frame = std::min(max_frame, model_max_frame);

--- a/irr/src/AnimSpec.cpp
+++ b/irr/src/AnimSpec.cpp
@@ -28,6 +28,13 @@ void TrackAnimSpec::setFrameRange(f32 frame1, f32 frame2)
 	max_frame = std::max(0.0f, std::max(frame1, frame2));
 }
 
+void TrackAnimSpec::clamp(f32 model_max_frame)
+{
+	max_frame = std::min(max_frame, model_max_frame);
+	min_frame = std::min(max_frame, min_frame);
+	cur_frame = std::clamp(cur_frame, min_frame, max_frame);
+}
+
 void AnimSpec::advance(f32 dtime_s)
 {
 	for (auto &[_, track] : tracks) {

--- a/irr/src/SkinnedMesh.cpp
+++ b/irr/src/SkinnedMesh.cpp
@@ -89,7 +89,7 @@ std::vector<VariantTransform> SkinnedMesh::animateMesh(
 	std::vector<VariantTransform> result(AllJoints.size());
 	for (const auto &progress : progresses) {
 		const auto &anim = animations.at(progress.track_nr);
-		assert(progress.frame >= 0 && progress.frame <= anim.end_frame);
+		const auto frame = std::clamp(progress.frame, 0.0f, anim.end_frame);
 		for (const auto &joint_keys : anim.joint_keys) {
 			const auto joint_id = joint_keys.joint_id;
 			if (animated_joints[joint_id])
@@ -105,7 +105,7 @@ std::vector<VariantTransform> SkinnedMesh::animateMesh(
 			// .gltf does not allow animation of nodes using matrix transforms.
 			// Note that a decomposition into a TRS transform need not exist!
 
-			joint_keys.keys.updateTransform(progress.frame, trs);
+			joint_keys.keys.updateTransform(frame, trs);
 			if (progress.blend < 1.0f && old_transforms[joint_id].has_value()) {
 				// Blend with old transform
 				const auto &old_transform = *old_transforms[joint_id];

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1068,7 +1068,10 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		removeFromScene(false);
 		addToScene(m_client->tsrc(), m_smgr);
 
-		if (m_animated_meshnode) {
+		if (m_animated_meshnode && m_animated_meshnode->getMesh()) {
+			for (auto &[track_nr, track] : m_animation.tracks) {
+				track.clamp(m_animated_meshnode->getMesh()->getMaxFrameNumber(track_nr));
+			}
 			m_animated_meshnode->getAnimation() = m_animation; // Restore animation
 		}
 
@@ -1548,11 +1551,8 @@ void GenericCAO::applyTrackAnimation(scene::TrackId &&track_id, scene::TrackAnim
 		return;
 
 	if (m_animated_meshnode) {
-		anim.max_frame = std::min(anim.max_frame,
-				m_animated_meshnode->getMesh()->getMaxFrameNumber(*track_nr));
+		anim.clamp(m_animated_meshnode->getMesh()->getMaxFrameNumber(*track_nr));
 	}
-
-	anim.cur_frame = std::clamp(anim.cur_frame, anim.min_frame, anim.max_frame);
 
 	if (!m_is_local_player) {
 		m_animation.tracks[*track_nr] = anim;

--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -154,8 +154,7 @@ void GUIScene::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &sty
 void GUIScene::setFrameLoop(f32 begin, f32 end)
 {
 	auto &anim = m_mesh->getAnimation().tracks[0];
-	anim.min_frame = begin;
-	anim.max_frame = end;
+	anim.setFrameRange(begin, end);
 	anim.cur_frame = anim.fps >= 0 ? begin : end;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -424,8 +424,7 @@ int ObjectRef::l_set_animation(lua_State *L)
 	bool frame_loop   = readParam<bool>(L, 5, true);
 
 	scene::TrackAnimSpec anim;
-	anim.min_frame = frame_range.X;
-	anim.max_frame = frame_range.Y;
+	anim.setFrameRange(frame_range.X, frame_range.Y);
 	anim.fps = frame_speed;
 	anim.blend_duration = frame_blend;
 	anim.loop = frame_loop;
@@ -496,6 +495,8 @@ static void read_track_anim_spec(lua_State *L, int tidx,
 	anim.min_frame = getfloatfield_default(L, tidx, "min_frame", 0.0f);
 	anim.max_frame = getfloatfield_default(L, tidx, "max_frame",
 			std::numeric_limits<f32>::infinity());
+	if (anim.min_frame > anim.max_frame)
+		throw LuaError("expected min_frame <= max_frame");
 	anim.fps = getfloatfield_default(L, tidx, "speed", 1.0f);
 	anim.cur_frame = getfloatfield_default(L, tidx, "start_frame",
 			anim.fps >= 0 ? anim.min_frame : anim.max_frame);


### PR DESCRIPTION
Replaced the assertion with a clamp. The clamp shouldn't happen and the assertion happens to work, but is fragile especially considering possible rounding errors. (Could be fixed but not worth the trouble.)

Use setFrameRange() in a few more places.

Most importantly, correctly clamp min frame when clamping to model max frame number. Otherwise the std::clamp may crash, or if it doesn't, depending on the STL, cur_frame ends up out of bounds causing exactly the (now removed) assertion to fail.

## How to test

This makes the petz:rat on YourLand not crash your client anymore.

