### PR TITLE
ensure RemoteClient::GetNextBlocks can always make progress

### DIFF
--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -229,7 +229,7 @@ void RemoteClient::GetNextBlocks (
 	// At large distances there are (many) more blocks per loop,
 	// so limit loops even more.
 	// note that the loop will advance by at most max_d_increment_at_time+1
-	const s16 max_d_increment_at_time = d_start < d_cull_opt * 2 ? 2 : 0;
+	const s16 max_d_increment_at_time = d_start < d_cull_opt * 2 ? 2 : 1;
 	if (d_max > d_start + max_d_increment_at_time)
 		d_max = d_start + max_d_increment_at_time;
 


### PR DESCRIPTION
I noticed a strange behavior where sometimes `RemoteClient::GetNextBlocks` just does not make any progress anymore. Most obvious with very far zooms.
Tracked it down to a subtle interaction between restarting the loop and setting the next starting point.
See how `m_nearest_unsent_d` is set at the end of `GetNextBlocks`. If nothing was loaded at a distance, we won't progress to the next layer. Related: 904978070531b7592448bb9e996abc825f3f3058

This just makes sure that the loop make at least one layer progress. Could set to `d+1` near the end of the function, but this seemed most natural.

## To do

This PR is a Ready for Review.

## How to test

Set a very large viewing_range, zoom in, make sure the map continues to load. There are other scenarios to cause this. For example load in all blocks at a viewing range, then increase the viewing_range; if absolutely *all* blocks at the closer range have been loaded, it won't progress to the next layer.

(Easier to see with #17285, since without it loading is soo slow at very large zoomed distances anyway.)