### PR TITLE
Fix text color and font not applying to field labels

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1486,17 +1486,23 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		Environment->setFocus(e);
 	}
 
+	auto style = getDefaultStyleForElement("pwdfield", name, "field");
+
 	if (label.length() >= 1) {
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+		gui::IGUIStaticText* t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
 			data->current_parent, 0);
+		if (t) {
+			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+			t->setOverrideFont(style.getFont());
+		}
 	}
 
 	e->setPasswordBox(true,L'*');
 
-	auto style = getDefaultStyleForElement("pwdfield", name, "field");
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	e->setDrawBorder(style.getBool(StyleSpec::BORDER, true));
 	e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
@@ -1523,8 +1529,14 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
 		// spec field id to 0, this stops submit searching for a value that isn't there
-		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+		gui::IGUIStaticText* t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
 				data->current_parent, 0);
+		if (t) {
+			auto style = getDefaultStyleForElement("field");
+			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+			t->setOverrideFont(style.getFont());
+		}
 		return;
 	}
 
@@ -1581,11 +1593,13 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		IGUIElement *t = gui::StaticText::add(Environment, spec.flabel.c_str(),
+		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(),
 				rect, false, true, data->current_parent, 0);
-
-		if (t)
+		if (t) {
 			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+			t->setOverrideFont(style.getFont());
+		}
 	}
 }
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -276,6 +276,16 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 	return v2s32(stof(v_geom[0]) * imgsize.X, stof(v_geom[1]) * imgsize.Y);
 }
 
+gui::IGUIStaticText* GUIFormSpecMenu::addLabel(const EnrichedString& text, const core::rect<s32>& rect,
+	gui::IGUIElement* parent, StyleSpec& style, bool wordWrap, s32 id)
+{
+	gui::IGUIStaticText* t = gui::StaticText::add(Environment, text, rect, false, wordWrap, parent, id);
+	t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+	t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+	t->setOverrideFont(style.getFont());
+	return t;
+}
+
 bool GUIFormSpecMenu::precheckElement(const std::string &name, const std::string &element,
 	size_t args_min, size_t args_max, std::vector<std::string> &parts)
 {
@@ -1492,13 +1502,7 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-			data->current_parent, 0);
-		if (t) {
-			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-			t->setOverrideFont(style.getFont());
-		}
+		addLabel(EnrichedString(spec.flabel.c_str()), rect, data->current_parent, style);
 	}
 
 	e->setPasswordBox(true,L'*');
@@ -1529,13 +1533,8 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
 		// spec field id to 0, this stops submit searching for a value that isn't there
-		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-				data->current_parent, 0);
-
 		auto style = getDefaultStyleForElement("field");
-		t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-		t->setOverrideFont(style.getFont());
+		addLabel(EnrichedString(spec.flabel.c_str()), rect, data->current_parent, style);
 		return;
 	}
 
@@ -1592,13 +1591,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(),
-				rect, false, true, data->current_parent, 0);
-		if (t) {
-			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-			t->setOverrideFont(style.getFont());
-		}
+		addLabel(EnrichedString(spec.flabel.c_str()), rect, data->current_parent, style);
 	}
 }
 
@@ -1813,15 +1806,9 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 			258 + m_fields.size(),
 			4
 		);
-		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
-				text, rect, false, false, data->current_parent,
-				spec.fid);
+		gui::IGUIStaticText *e = addLabel(text, rect, data->current_parent, style, false, spec.fid);
 		e->setTextAlignment(align_h, align_v);
 		e->setWordWrap(word_wrap);
-
-		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-		e->setOverrideFont(font);
 
 		m_fields.push_back(spec);
 
@@ -1954,14 +1941,8 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		258 + m_fields.size()
 	);
 
-	gui::IGUIStaticText *e = gui::StaticText::add(Environment, vlabel,
-			rect, false, false, data->current_parent, spec.fid);
-
+	gui::IGUIStaticText* e = addLabel(vlabel, rect, data->current_parent, style, false, spec.fid);
 	e->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
-
-	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-	e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-	e->setOverrideFont(font);
 
 	m_fields.push_back(spec);
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -276,10 +276,10 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 	return v2s32(stof(v_geom[0]) * imgsize.X, stof(v_geom[1]) * imgsize.Y);
 }
 
-gui::IGUIStaticText* GUIFormSpecMenu::addLabel(const EnrichedString& text, const core::rect<s32>& rect,
-	gui::IGUIElement* parent, StyleSpec& style, bool wordWrap, s32 id)
+gui::IGUIStaticText* GUIFormSpecMenu::addLabel(const EnrichedString &text, const core::rect<s32> &rect,
+	gui::IGUIElement *parent, const StyleSpec &style, bool word_wrap, s32 id)
 {
-	gui::IGUIStaticText* t = gui::StaticText::add(Environment, text, rect, false, wordWrap, parent, id);
+	gui::IGUIStaticText* t = gui::StaticText::add(Environment, text, rect, false, word_wrap, parent, id);
 	t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 	t->setOverrideFont(style.getFont());

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1492,7 +1492,7 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		int font_height = g_fontengine->getTextHeight();
 		rect.UpperLeftCorner.Y -= font_height;
 		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		gui::IGUIStaticText* t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
 			data->current_parent, 0);
 		if (t) {
 			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
@@ -1529,14 +1529,13 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	bool is_editable = !spec.fname.empty();
 	if (!is_editable && !is_multiline) {
 		// spec field id to 0, this stops submit searching for a value that isn't there
-		gui::IGUIStaticText* t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+		gui::IGUIStaticText *t = gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
 				data->current_parent, 0);
-		if (t) {
-			auto style = getDefaultStyleForElement("field");
-			t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-			t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-			t->setOverrideFont(style.getFont());
-		}
+
+		auto style = getDefaultStyleForElement("field");
+		t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		t->setOverrideFont(style.getFont());
 		return;
 	}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -276,10 +276,10 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 	return v2s32(stof(v_geom[0]) * imgsize.X, stof(v_geom[1]) * imgsize.Y);
 }
 
-gui::IGUIStaticText* GUIFormSpecMenu::addLabel(const EnrichedString &text, const core::rect<s32> &rect,
+gui::IGUIStaticText *GUIFormSpecMenu::addLabel(const EnrichedString &text, const core::rect<s32> &rect,
 	gui::IGUIElement *parent, const StyleSpec &style, bool word_wrap, s32 id)
 {
-	gui::IGUIStaticText* t = gui::StaticText::add(Environment, text, rect, false, word_wrap, parent, id);
+	gui::IGUIStaticText *t = gui::StaticText::add(Environment, text, rect, false, word_wrap, parent, id);
 	t->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 	t->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
 	t->setOverrideFont(style.getFont());
@@ -1941,7 +1941,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		258 + m_fields.size()
 	);
 
-	gui::IGUIStaticText* e = addLabel(vlabel, rect, data->current_parent, style, false, spec.fid);
+	gui::IGUIStaticText *e = addLabel(vlabel, rect, data->current_parent, style, false, spec.fid);
 	e->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 
 	m_fields.push_back(spec);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -500,7 +500,7 @@ private:
 	void showTooltip(const std::wstring &text, const video::SColor &color,
 		const video::SColor &bgcolor);
 
-	gui::IGUIStaticText* addLabel(const EnrichedString &text, const core::rect<s32> &rect,
+	gui::IGUIStaticText *addLabel(const EnrichedString &text, const core::rect<s32> &rect,
 		gui::IGUIElement *parent, const StyleSpec &style, bool word_wrap = true, s32 id = 0);
 
 	/**

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -501,7 +501,7 @@ private:
 		const video::SColor &bgcolor);
 
 	gui::IGUIStaticText* addLabel(const EnrichedString &text, const core::rect<s32> &rect,
-		gui::IGUIElement* parent, StyleSpec &style, bool wordWrap = true, s32 id = 0);
+		gui::IGUIElement *parent, const StyleSpec &style, bool word_wrap = true, s32 id = 0);
 
 	/**
 	 * Auto-scrolls a scroll container to center the focused element.

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -18,6 +18,7 @@
 #include "guiScrollBar.h"
 #include "guiTable.h"
 #include "util/string.h"
+#include "util/enriched_string.h"
 #include "StyleSpec.h"
 #include <ICursorControl.h> // gui::ECURSOR_ICON
 #include <IGUIStaticText.h>
@@ -498,6 +499,9 @@ private:
 
 	void showTooltip(const std::wstring &text, const video::SColor &color,
 		const video::SColor &bgcolor);
+
+	gui::IGUIStaticText* addLabel(const EnrichedString &text, const core::rect<s32> &rect,
+		gui::IGUIElement* parent, StyleSpec &style, bool wordWrap = true, s32 id = 0);
 
 	/**
 	 * Auto-scrolls a scroll container to center the focused element.


### PR DESCRIPTION
Makes `textcolor` and `font` apply to `field` and `textarea` labels.

Code to test:
```lua
local fs = table.concat({
	"formspec_version[6]size[8,5.5]",
	"style[*;font=mono,bold;textcolor=#0F0]",
	"label[0.5,0.75;Label]",
	"field[0.5,1.5;3,0.75;field;Field;testing]",
	"field[0.5,2.75;3,0.75;;No Edit Field;testing]",
	"pwdfield[0.5,4;3,0.75;pwdfield;Password Field]",
	"textarea[4,0.75;3.5,2;textarea;Text Area;testing]",
	"textarea[4,3.5;3.5,2;;No Edit Text Area;testing]",
})
core.register_chatcommand("test", {
    func = function(name)
		core.show_formspec(name, "test", fs)
    end
})
```
Before:
<img width="500" height="344" alt="image" src="https://github.com/user-attachments/assets/ceb13b02-9f65-42d4-83ed-2122c077cb71" />
After:
<img width="500" height="344" alt="image" src="https://github.com/user-attachments/assets/329e23c1-0adb-459e-9655-8eb2db21be81" />
