### PR TITLE
Add lua API for setting sunlight/moonlight/lightsource color

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -44,7 +44,7 @@ CENTROID_ VARYING_ float nightRatio;
 
 VARYING_ highp vec3 eyeVec;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
+uniform vec3 artificialLight;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -31,7 +31,7 @@ flat VARYING_ uint varTexLayer;
 VARYING_ highp vec3 eyeVec;
 VARYING_ float nightRatio;
 // Color of the light emitted by the light sources.
-const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
+uniform vec3 artificialLight;
 VARYING_ float vIDiff;
 
 #ifdef USE_SKINNING

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9566,9 +9566,19 @@ child will follow movement and rotation of that bone.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `sunlight_color`: overrides the color of sunlight (`ColorSpec` or `false`).
+      * `moonlight_color`: overrides the color of moonlight (`ColorSpec` or `false`).
+      * `lightsource_color`: overrides the color of light emitted by light
+        sources, e.g. torches (`ColorSpec` or `false`).
+        * All three default to the engine's built-in colors. Omitting any leaves the value unchanged.
+          Passing `false` resets an individual color to its engine default.
+        * `sunlight_color` and `moonlight_color` are still blended by time of
+          day.
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.
+    * `sunlight_color`, `moonlight_color` and `lightsource_color` are only
+      present if overridden.
 * `respawn()`: Respawns the player using the same mechanism as the death screen,
   including calling `on_respawnplayer` callbacks.
 * `get_flags()`: returns a table of player flags (the following boolean fields):

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -230,6 +230,7 @@ void ClientEnvironment::step(float dtime)
 
 	// Update lighting on local player (used for wield item)
 	u32 day_night_ratio = getDayNightRatio();
+	lplayer->updateCustomLighting(dtime);
 	{
 		// Get node at head
 
@@ -242,7 +243,11 @@ void ClientEnvironment::step(float dtime)
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
 		lplayer->light_color = encode_light(light, 0); // this transfers light.alpha
-		final_color_blend(&lplayer->light_color, light, day_night_ratio);
+		video::SColorf dayLight;
+		get_sunlight_color(&dayLight, day_night_ratio,
+				lplayer->m_moonlight_color, lplayer->m_sunlight_color);
+		final_color_blend(&lplayer->light_color, lplayer->light_color, dayLight,
+				lplayer->m_lightsource_color);
 	}
 
 	/*

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -77,6 +77,7 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	int m_crack_texture_scale_i = 0;
 	CachedPixelShaderSetting<float> m_crack_texture_scale{"crackTextureScale"};
 	CachedPixelShaderSetting<float, 3> m_day_light{"dayLight"};
+	CachedVertexShaderSetting<float, 3> m_artificial_light_vertex{"artificialLight"};
 	CachedPixelShaderSetting<float, 3> m_minimap_yaw{"yawVec"};
 	CachedPixelShaderSetting<float, 3> m_camera_offset_pixel{"cameraOffset"};
 	CachedVertexShaderSetting<float, 3> m_camera_offset_vertex{"cameraOffset"};
@@ -148,9 +149,13 @@ public:
 	void onSetUniforms(video::IMaterialRendererServices *services) override
 	{
 		u32 daynight_ratio = (float)m_client->getEnv().getDayNightRatio();
+		const LocalPlayer *lp = m_client->getEnv().getLocalPlayer();
+		const auto &lighting = lp->getLighting();
 		video::SColorf sunlight;
-		get_sunlight_color(&sunlight, daynight_ratio);
+		get_sunlight_color(&sunlight, daynight_ratio,
+				lp->m_moonlight_color, lp->m_sunlight_color);
 		m_day_light.set(sunlight, services);
+		m_artificial_light_vertex.set(lp->m_lightsource_color, services);
 
 		u32 animation_timer = m_client->getEnv().getFrameTime() % 1000000;
 		float animation_timer_f = (float)animation_timer / 100000.f;
@@ -185,8 +190,6 @@ public:
 			tmp = m_crack_texture_scale_i;
 			m_crack_texture_scale.set(&tmp, services);
 		}
-
-		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 
 		const AutoExposure &exposure_params = lighting.exposure;
 		std::array<float, 7> exposure_buffer = {
@@ -2891,8 +2894,12 @@ PointedThing Game::updatePointedThing(
 		}
 
 		u32 daynight_ratio = client->getEnv().getDayNightRatio();
+		const LocalPlayer *lp = client->getEnv().getLocalPlayer();
+		video::SColorf dayLight;
+		get_sunlight_color(&dayLight, daynight_ratio,
+				lp->m_moonlight_color, lp->m_sunlight_color);
 		video::SColor c;
-		final_color_blend(&c, light_level, daynight_ratio);
+		final_color_blend(&c, encode_light(light_level, 0), dayLight, lp->m_lightsource_color);
 
 		// Modify final color a bit with time
 		u32 timer = client->getEnv().getFrameTime() % 5000;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -3,6 +3,8 @@
 // Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "localplayer.h"
+#include "client/mapblock_mesh.h"
+#include "util/numeric.h"
 #include <cmath>
 #include "mtevent.h"
 #include "collision.h"
@@ -53,6 +55,13 @@ void PlayerSettings::settingsChangedCallback(const std::string &name, void *data
 	((PlayerSettings *)data)->readGlobalSettings();
 }
 
+static void damp_color(video::SColorf &current, const video::SColorf &target, float lambda)
+{
+	current.r = damp(current.r, target.r, lambda);
+	current.g = damp(current.g, target.g, lambda);
+	current.b = damp(current.b, target.b, lambda);
+}
+
 /*
 	LocalPlayer
 */
@@ -63,6 +72,9 @@ LocalPlayer::LocalPlayer(Client *client, const std::string &name):
 {
 	m_player_settings.readGlobalSettings();
 	m_player_settings.registerSettingsCallback();
+	m_sunlight_color    = DEFAULT_SUNLIGHT_COLOR;
+	m_moonlight_color   = DEFAULT_MOONLIGHT_COLOR;
+	m_lightsource_color = DEFAULT_LIGHTSOURCE_COLOR;
 }
 
 LocalPlayer::~LocalPlayer()
@@ -1244,4 +1256,21 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 		m_autojump = true;
 		m_autojump_time = 0.1f;
 	}
+}
+
+void LocalPlayer::updateCustomLighting(float dtime)
+{
+	float DECAY_RATE = 10.0f;
+
+	video::SColorf target_sun = m_lighting.has_sunlight_color ?
+			video::SColorf(m_lighting.sunlight_color) : DEFAULT_SUNLIGHT_COLOR;
+	video::SColorf target_moon = m_lighting.has_moonlight_color ?
+			video::SColorf(m_lighting.moonlight_color) : DEFAULT_MOONLIGHT_COLOR;
+	video::SColorf target_src = m_lighting.has_lightsource_color ?
+			video::SColorf(m_lighting.lightsource_color) : DEFAULT_LIGHTSOURCE_COLOR;
+
+	float lambda = DECAY_RATE * dtime;
+	damp_color(m_sunlight_color,    target_sun,  lambda);
+	damp_color(m_moonlight_color,   target_moon, lambda);
+	damp_color(m_lightsource_color, target_src,  lambda);
 }

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -162,6 +162,14 @@ public:
 	}
 
 	inline Lighting& getLighting() { return m_lighting; }
+	// const version for read-only access, needed for const access
+	inline const Lighting& getLighting() const { return m_lighting; }
+	// smooths the transition when a mod sets new lighting
+	void updateCustomLighting(float dtime);
+	// calculated sun/moon/light colors from mod set + smoothing
+	video::SColorf m_sunlight_color;
+	video::SColorf m_moonlight_color;
+	video::SColorf m_lightsource_color;
 
 	inline PlayerSettings &getPlayerSettings() { return m_player_settings; }
 
@@ -219,4 +227,5 @@ private:
 
 	PlayerSettings m_player_settings;
 	Lighting m_lighting;
+
 };

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -278,13 +278,34 @@ u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData 
 	return getSmoothLightCombined(p, dirs, data);
 }
 
+// Default color endpoints for the day-night blend, extracted from the original final_color_blend()
+const video::SColorf DEFAULT_SUNLIGHT_COLOR(0.96f, 0.96f, 1.058f);
+const video::SColorf DEFAULT_MOONLIGHT_COLOR(-0.04f, -0.04f, 0.078f);
+const video::SColorf DEFAULT_LIGHTSOURCE_COLOR(1.04f, 1.04f, 1.04f);
+
+static video::SColorf lerp_skylight_color(
+		const video::SColorf &moonlight, const video::SColorf &sunlight,
+		u32 daynight_ratio)
+{
+	f32 t = daynight_ratio / 1000.0f;
+	video::SColorf result;
+	result.r = moonlight.r + (sunlight.r - moonlight.r) * t;
+	result.g = moonlight.g + (sunlight.g - moonlight.g) * t;
+	result.b = moonlight.b + (sunlight.b - moonlight.b) * t;
+	return result;
+}
+
 void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio)
 {
-	f32 rg = daynight_ratio / 1000.0f - 0.04f;
-	f32 b = (0.98f * daynight_ratio) / 1000.0f + 0.078f;
-	sunlight->r = rg;
-	sunlight->g = rg;
-	sunlight->b = b;
+	*sunlight = lerp_skylight_color(DEFAULT_MOONLIGHT_COLOR,
+			DEFAULT_SUNLIGHT_COLOR, daynight_ratio);
+}
+
+
+void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio,
+		const video::SColorf &moonlight, const video::SColorf &sunlightColor)
+{
+	*sunlight = lerp_skylight_color(moonlight, sunlightColor, daynight_ratio);
 }
 
 void final_color_blend(video::SColor *result,
@@ -296,17 +317,23 @@ void final_color_blend(video::SColor *result,
 		encode_light(light, 0), dayLight);
 }
 
+
 void final_color_blend(video::SColor *result,
 		const video::SColor &data, const video::SColorf &dayLight)
 {
-	static const video::SColorf artificialColor(1.04f, 1.04f, 1.04f);
+	final_color_blend(result, data, dayLight, DEFAULT_LIGHTSOURCE_COLOR);
+}
 
+void final_color_blend(video::SColor *result,
+		const video::SColor &data, const video::SColorf &dayLight,
+		const video::SColorf &lightsourceColor)
+{
 	video::SColorf c(data);
 	f32 n = 1 - c.a;
 
-	f32 r = c.r * (c.a * dayLight.r + n * artificialColor.r) * 2.0f;
-	f32 g = c.g * (c.a * dayLight.g + n * artificialColor.g) * 2.0f;
-	f32 b = c.b * (c.a * dayLight.b + n * artificialColor.b) * 2.0f;
+	f32 r = c.r * (c.a * dayLight.r + n * lightsourceColor.r) * 2.0f;
+	f32 g = c.g * (c.a * dayLight.g + n * lightsourceColor.g) * 2.0f;
+	f32 b = c.b * (c.a * dayLight.b + n * lightsourceColor.b) * 2.0f;
 
 	// Emphase blue a bit in darker places
 	// Each entry of this array represents a range of 8 blue levels

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -12,6 +12,7 @@
 #include "util/numeric.h"
 #include "client/tile.h"
 #include "voxel.h"
+#include "lighting.h"
 #include <map>
 
 namespace video {
@@ -329,11 +330,18 @@ u16 getFaceLight(MapNode n, MapNode n2, const NodeDefManager *ndef);
 u16 getSmoothLightSolid(const v3s16 &p, const v3s16 &face_dir, const v3s16 &corner, MeshMakeData *data);
 u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData *data);
 
+extern const video::SColorf DEFAULT_SUNLIGHT_COLOR;
+extern const video::SColorf DEFAULT_MOONLIGHT_COLOR;
+extern const video::SColorf DEFAULT_LIGHTSOURCE_COLOR;
+
 /*!
  * Returns the sunlight's color from the current
  * day-night ratio.
  */
 void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio);
+
+void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio,
+		const video::SColorf &moonlight, const video::SColorf &sunlightColor);
 
 /*!
  * Gives the final  SColor shown on screen.
@@ -354,6 +362,18 @@ void final_color_blend(video::SColor *result,
  */
 void final_color_blend(video::SColor *result,
 		const video::SColor &data, const video::SColorf &dayLight);
+
+/*!
+ * Gives the final  SColor shown on screen.
+ *
+ * \param result output color
+ * \param data the half-baked vertex color
+ * \param dayLight color of the sunlight
+ * \param lightsourceColor color of artificial light
+ */
+void final_color_blend(video::SColor *result,
+		const video::SColor &data, const video::SColorf &dayLight,
+		const video::SColorf &lightsourceColor);
 
 // Retrieves the TileSpec of a face of a node
 // Adds MATERIAL_FLAG_CRACK if the node is cracked

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -53,4 +53,13 @@ struct Lighting
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
 	v3f shadow_direction;
+
+	// Overrides for the day/night sunlight gradient and artificial light tint.
+	// false means use the engine's built-in colors.
+	bool has_sunlight_color {false};
+	video::SColor sunlight_color {255, 255, 255, 255};
+	bool has_moonlight_color {false};
+	video::SColor moonlight_color {255, 255, 255, 255};
+	bool has_lightsource_color {false};
+	video::SColor lightsource_color {255, 255, 255, 255};
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1916,5 +1916,12 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 			break;
 		// >= 5.16.0-dev
 		*pkt >> lighting.shadow_direction;
+
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.17.0-dev
+		*pkt >> lighting.has_sunlight_color >> lighting.sunlight_color;
+		*pkt >> lighting.has_moonlight_color >> lighting.moonlight_color;
+		*pkt >> lighting.has_lightsource_color >> lighting.lightsource_color;
 	} while (0);
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2728,6 +2728,27 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
 		}
 		lua_pop(L, 1); // bloom
+
+		lua_getfield(L, 2, "sunlight_color");
+		if (lua_isboolean(L, -1) && !lua_toboolean(L, -1))
+			lighting.has_sunlight_color = false;
+		else if (!lua_isnil(L, -1))
+			lighting.has_sunlight_color = read_color(L, -1, &lighting.sunlight_color);
+		lua_pop(L, 1); // sunlight_color
+
+		lua_getfield(L, 2, "moonlight_color");
+		if (lua_isboolean(L, -1) && !lua_toboolean(L, -1))
+			lighting.has_moonlight_color = false;
+		else if (!lua_isnil(L, -1))
+			lighting.has_moonlight_color = read_color(L, -1, &lighting.moonlight_color);
+		lua_pop(L, 1); // moonlight_color
+
+		lua_getfield(L, 2, "lightsource_color");
+		if (lua_isboolean(L, -1) && !lua_toboolean(L, -1))
+			lighting.has_lightsource_color = false;
+		else if (!lua_isnil(L, -1))
+			lighting.has_lightsource_color = read_color(L, -1, &lighting.lightsource_color);
+		lua_pop(L, 1); // lightsource_color
 }
 
 	getServer(L)->setLighting(player, lighting);
@@ -2782,6 +2803,18 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.bloom_radius);
 	lua_setfield(L, -2, "radius");
 	lua_setfield(L, -2, "bloom");
+	if (lighting.has_sunlight_color) {
+		push_ARGB8(L, lighting.sunlight_color);
+		lua_setfield(L, -2, "sunlight_color");
+	}
+	if (lighting.has_moonlight_color) {
+		push_ARGB8(L, lighting.moonlight_color);
+		lua_setfield(L, -2, "moonlight_color");
+	}
+	if (lighting.has_lightsource_color) {
+		push_ARGB8(L, lighting.lightsource_color);
+		lua_setfield(L, -2, "lightsource_color");
+	}
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2055,6 +2055,10 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.shadow_direction;
 
+	pkt << lighting.has_sunlight_color << lighting.sunlight_color;
+	pkt << lighting.has_moonlight_color << lighting.moonlight_color;
+	pkt << lighting.has_lightsource_color << lighting.lightsource_color;
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

### Goal of the PR
- Allow the previously hardcoded sunlight, moonlight and artificial light colors to be changed via Lua, per player

### How does the PR work?
- Extend existing per-player `set_lighting(light_def)` by adding 3 new values to `light_def` table:
  - `sunlight_color` - the color used to light nodes with natural light during day
  - `moonlight_color` - the color used to light nodes at night
  - `lightsource_color` - the color of artifical lights
- Also returns the above 3 values in the `get_lighting()` table, but only if they have been overridden
- The specified colors simply replace previous hardcoded values (values are still in code as DEFAULTs)
- Blending between day/night and natural/artifical lights remains as it was, only moved to functions
- Add a small smooth transition when setting color to player, so the lighting change happens gradually over the course of about 0.1 sec (independent of frame-rate)

### Does it resolve any reported issue?
- https://github.com/luanti-org/luanti/issues/8890

### Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- not as far as I know

### If not a bug fix, why is this PR needed? What usecases does it solve?
- As described by the linked issue above, it allows customizing the mood and lights from lua, allowing things like location based lighting, or time-based lighting (up to mods to decide how to use it)

### If you have used an LLM/AI to help with code or assets, you must disclose this.
I have used Claude code to do some boilerplate networking things. Every line of code has been looked at manually, and claude code was given very specific instructions of what to touch.

## To do
This PR is Ready for Review.

## How to test
<details>

<summary>Lua mod code used in video below</summary>

```lua
local function set_color_cmd(field)
	return function(playername, param)
		local player = minetest.get_player_by_name(playername)
		if param:match("^%s*$") then
			player:set_lighting({ [field] = false })
			return true, field .. " reset to default"
		end
		local hex = param:match("^%s*(%x%x%x%x%x%x)%s*$")
		if not hex then
			return false, "use hex"
		end
		player:set_lighting({ [field] = "#" .. hex })
		return true, field .. " set to #" .. hex
	end
end

minetest.register_chatcommand("set_sc", {
	params = "<RRGGBB>",
	description = "Set sunlight_color for yourself",
	func = set_color_cmd("sunlight_color"),
})

minetest.register_chatcommand("set_mc", {
	params = "<RRGGBB>",
	description = "Set moonlight_color for yourself",
	func = set_color_cmd("moonlight_color"),
})

minetest.register_chatcommand("set_lc", {
	params = "<RRGGBB>",
	description = "Set lightsource_color for yourself",
	func = set_color_cmd("lightsource_color"),
})
```

</details>


### Video

https://github.com/user-attachments/assets/1528b449-a4f3-456d-9e19-d185ba9dd5d6

