### PR TITLE
[no sq] Fix more animation stuff

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9557,8 +9557,15 @@ You **must not** mix names and track numbers to refer to the same animation.
     * See also `core.time_to_day_night_ratio`,
 * `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
 * `set_local_animation(idle, walk, dig, walk_while_dig, frame_speed)`:
-  set animation for player model in third person view.
-    * Every animation equals to a `{x=starting frame, y=ending frame}` table.
+  Set local animations for player model in third person view.
+    * Applied immediately on the client based on in-game player state ("local").
+    * Local animations currently always use the first animation track.
+    * Local animations override server-sent animations on the first animation track if both use the same frame range.
+      (This is to not interrupt playing local animations.)
+    * Server-sent animations (`set_animation()`, `play_animation()`)
+      override local animations if they use a different frame range.
+    * Every animation is given as a `{x = start frame, y = end frame}` table.
+      You can use `{x = 0, y = 0}` for "no animation", deferring to server-sent animations.
     * `frame_speed` sets the animations frame speed. Default is 30.
 * `get_local_animation()`: returns idle, walk, dig, walk_while_dig tables and
   `frame_speed`.

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -701,11 +701,6 @@ void SelfType::MeshExtractor::loadAnimation(const std::size_t animIdx)
 	auto &irr_anim = m_irr_model.getAnimation(m_irr_model.addAnimation());
 	irr_anim.name = anim.name.value_or("");
 
-	for (const auto &chan : anim.channels) {
-		if (!chan.target.node.has_value())
-			throw std::runtime_error("no animated node");
-	}
-
 	std::vector<decltype(anim.channels)::const_iterator> chan_its(anim.channels.size());
 	std::iota(chan_its.begin(), chan_its.end(), anim.channels.cbegin());
 	// Group by target node
@@ -715,10 +710,17 @@ void SelfType::MeshExtractor::loadAnimation(const std::size_t animIdx)
 			});
 
 	for (auto it = chan_its.begin(); it != chan_its.end();) {
+		if (!(*it)->target.node) {
+			warn("animation channel targets no node, ignoring");
+			++it;
+			continue;
+		}
+
 		const std::size_t target_node = *((*it)->target.node);
 		const auto *joint = m_loaded_nodes.at(target_node);
 		if (std::holds_alternative<core::matrix4>(joint->transform)) {
 			warn("nodes using matrix transforms must not be animated");
+			++it;
 			continue;
 		}
 		SkinnedMesh::Keys keys;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1408,8 +1408,14 @@ void GenericCAO::setLocalPlayerAnimation(LocalPlayerAnimation local_anim, float 
 		return; // no change
 
 	v2f range = player->local_animations[static_cast<u8>(local_anim)];
-	if (range == v2f())
+	if (range == v2f()) {
+		if (m_local_player_animation) {
+			// Reset local player animation override
+			m_local_player_animation = false;
+			m_animated_meshnode->getAnimation() = m_animation;
+		}
 		return; // animation not defined, stick to current animation
+	}
 
 	scene::TrackAnimSpec anim;
 	anim.setFrameRange(range.X, range.Y);
@@ -1554,24 +1560,22 @@ void GenericCAO::applyTrackAnimation(scene::TrackId &&track_id, scene::TrackAnim
 		anim.clamp(m_animated_meshnode->getMesh()->getMaxFrameNumber(*track_nr));
 	}
 
+	// Update stored animation in either case.
+	// This becomes relevant if local animations are left unspecified,
+	// in which case the stored animation is reapplied.
+	m_animation.tracks[*track_nr] = anim;
 	if (!m_is_local_player) {
-		m_animation.tracks[*track_nr] = anim;
 		updateAnimation(*track_nr);
 	} else {
-		LocalPlayer *player = m_env->getLocalPlayer();
-		// update animation only if local animations present
-		// and received animation is unknown (except idle animation)
-		bool is_known = false;
-		for (const auto &local_anim : player->local_animations) {
-			if (track_nr == 0 && anim.max_frame == local_anim.Y)
-				is_known = true;
-		}
-		if (!is_known ||
-				(player->local_animations[1].Y + player->local_animations[2].Y < 1))
-		{
+		const auto &local_anims = m_env->getLocalPlayer()->local_animations;
+		bool is_known = track_nr == 0 && std::any_of(local_anims.begin(), local_anims.end(),
+				[&](v2f range) {
+					return anim.min_frame == range.X && anim.max_frame == range.Y;
+				});
+		// Apply the animation if it is not a known local animation
+		if (!is_known) {
 			updateAnimation(*track_nr);
 		}
-		// FIXME: ^ This code is trash. It's also broken.
 	}
 }
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1742,7 +1742,11 @@ void GenericCAO::processMessage(const std::string &data)
 		applyTrackAnimation(std::move(track_id), anim);
 	} else if (cmd == AO_CMD_SET_ANIMATION_SPEED) {
 		f32 new_fps = readF32(is);
-		const auto track_id = readTrackIdentifier(is);
+		scene::TrackId track_id = (u16) 0;
+		if (canRead(is)) {
+			// New animation API since 5.17.0
+			track_id = readTrackIdentifier(is);
+		}
 
 		auto track_nr_opt = resolveTrackId(track_id);
 		if (!track_nr_opt)
@@ -1755,6 +1759,7 @@ void GenericCAO::processMessage(const std::string &data)
 			m_animated_meshnode->getAnimation().tracks[track_nr].fps = new_fps;
 		}
 	} else if (cmd == AO_CMD_STOP_ANIMATION) {
+		// New animation API since 5.17.0
 		const auto track_id = readTrackIdentifier(is);
 
 		auto track_nr_opt = resolveTrackId(track_id);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1534,7 +1534,8 @@ std::optional<u16> GenericCAO::resolveTrackId(const scene::TrackId &track_id)
 	u16 track_nr = std::get<u16>(track_id);
 	u16 max_track_nr = mesh->getTrackCount();
 	if (track_nr >= max_track_nr) {
-		warningstream << "Track number " << track_nr << " out of bounds for mesh " << m_prop.mesh
+		// 1-indexed track number for consistency with Lua API
+		warningstream << "Track number " << (track_nr + 1) << " out of bounds for mesh " << m_prop.mesh
 			<< " (max: " << max_track_nr << ")" << std::endl;
 		return std::nullopt;
 	}

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -131,7 +131,7 @@ private:
 	scene::AnimSpec m_animation;
 	/// For the local player CAO, animations may be overridden by the client
 	/// based on the in-game state of the local player (e.g. walking, digging, idling).
-	/// See also localplayer.h (e.g. LocalPlayerAnimation, LocalPlayer::last_animation).
+	/// See also LocalPlayerAnimation (player.h), LocalPlayer::last_animation (localplayer.h).
 	bool m_local_player_animation = false;
 	/// Deferred set animation commands, to be run once the scene node exists
 	std::vector<std::pair<std::string, scene::TrackAnimSpec>> deferred_set_animation_cmds;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -17,15 +17,6 @@ class Map;
 struct CollisionInfo;
 struct CollisionMoveResult;
 
-// Note: Part of the protocol, do not reorder.
-enum class LocalPlayerAnimation : u8
-{
-	NO_ANIM,
-	WALK_ANIM,
-	DIG_ANIM,
-	WD_ANIM, // walking + digging
-};
-
 struct PlayerSettings
 {
 	bool free_move = false;

--- a/src/player.h
+++ b/src/player.h
@@ -157,6 +157,16 @@ enum CameraMode : int {
 
 extern const struct EnumString es_CameraMode[];
 
+// Note: Part of the protocol, do not reorder.
+enum class LocalPlayerAnimation : u8
+{
+	NO_ANIM,
+	WALK_ANIM,
+	DIG_ANIM,
+	WD_ANIM, // walking + digging
+	COUNT
+};
+
 class Player
 {
 public:
@@ -198,7 +208,7 @@ public:
 	f32 movement_liquid_sink;
 	f32 movement_gravity;
 
-	std::array<v2f, 4> local_animations;
+	std::array<v2f, (size_t) LocalPlayerAnimation::COUNT> local_animations;
 	float local_animation_speed;
 
 	std::string inventory_formspec;

--- a/src/player.h
+++ b/src/player.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <array>
 
 #define PLAYERNAME_SIZE 20
 
@@ -197,7 +198,7 @@ public:
 	f32 movement_liquid_sink;
 	f32 movement_gravity;
 
-	v2f local_animations[4];
+	std::array<v2f, 4> local_animations;
 	float local_animation_speed;
 
 	std::string inventory_formspec;


### PR DESCRIPTION
Regression from https://github.com/luanti-org/luanti/commit/f7518186932883513d82ba4e655268c54d1f9eea:
Server-sent animations that are not known as local animations should override local animations.
This did not happen because `m_animation.tracks[*track_nr] = anim;` was missing on that path.

I decided to properly specify how local animations should behave and implement that. This is not 1:1 faithful to the old logic, however the old logic was (1) not documented and (2) known garbage. The new logic should work fine with how `player_api` uses these APIs (and seems to at least in my testing), and is somewhat reasonable to me (but I'm open to suggestions!).

Open-ish question is how we want to treat `{x=0, y=0}` ranges more generally. The new API doesn't have any special treatment for them and as far as I can see there's nothing that prevents frame 0 from having a different pose from the rest pose in a glTF file. The old API (`set_animation()`) seems to have treated this case sort of as "no animation"? (In particular there is no "unset animation".)

## How to test

1. Clone the [emote](https://github.com/minetest-mods/emote) mod
2. Start MTG + emote
3. Issue `/sit` or `/lay` and view yourself in 3rd person. It should work.

