### PR TITLE
Fix -Wunused-result in porting.cpp

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -101,14 +101,15 @@ volatile std::sig_atomic_t *signal_handler_killstatus()
 static void signal_handler(int sig)
 {
 	if (!g_killed) {
+		volatile ssize_t ignore;
 		if (sig == SIGINT) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"Ctrl-C pressed, shutting down.\n"};
-			(void)write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			ignore = write(STDERR_FILENO, dbg_text, strlen(dbg_text));
 		} else if (sig == SIGTERM) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"got SIGTERM, shutting down.\n"};
-			(void)write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			ignore = write(STDERR_FILENO, dbg_text, strlen(dbg_text));
 		}
 		g_killed = true;
 	} else {

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -101,15 +101,15 @@ volatile std::sig_atomic_t *signal_handler_killstatus()
 static void signal_handler(int sig)
 {
 	if (!g_killed) {
-		volatile ssize_t ignore = 0;
 		if (sig == SIGINT) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"Ctrl-C pressed, shutting down.\n"};
-			ignore = write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			//nothing we can safely do in a signal handler
+			if (write(STDERR_FILENO, dbg_text, strlen(dbg_text)) < 0) {}
 		} else if (sig == SIGTERM) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"got SIGTERM, shutting down.\n"};
-			ignore = write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			if (write(STDERR_FILENO, dbg_text, strlen(dbg_text)) < 0) {}
 		}
 		g_killed = true;
 	} else {

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -98,9 +98,10 @@ volatile std::sig_atomic_t *signal_handler_killstatus()
 
 #if !defined(_WIN32) // POSIX
 
-//Stops compiler throwing unsued-result for a function
-template<typename ... Args>
-static void ignore(Args && ...)
+// Used to silence compiler warnings about unused function results.
+// Note that static_cast<void>(...) does not suffice for the [warn_unused_result] attribute.
+template<typename... Args>
+static void ignore(Args &&...)
 {
 }
 
@@ -108,13 +109,14 @@ static void signal_handler(int sig)
 {
 	if (!g_killed) {
 		if (sig == SIGINT) {
-			const char *dbg_text{"INFO: signal_handler(): "
-				"Ctrl-C pressed, shutting down.\n"};
-			//nothing we can safely do in a signal handler so ignore it
+			const char *dbg_text = "INFO: signal_handler(): "
+				"Ctrl-C pressed, shutting down.\n";
+			// Not much we can safely do in a signal handler so ignore failing writes
 			ignore(write(STDERR_FILENO, dbg_text, strlen(dbg_text)));
 		} else if (sig == SIGTERM) {
-			const char *dbg_text{"INFO: signal_handler(): "
-				"got SIGTERM, shutting down.\n"};
+			const char *dbg_text = "INFO: signal_handler(): "
+				"got SIGTERM, shutting down.\n";
+			// Not much we can safely do in a signal handler so ignore failing writes
 			ignore(write(STDERR_FILENO, dbg_text, strlen(dbg_text)));
 		}
 		g_killed = true;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -104,11 +104,11 @@ static void signal_handler(int sig)
 		if (sig == SIGINT) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"Ctrl-C pressed, shutting down.\n"};
-			write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			(void)write(STDERR_FILENO, dbg_text, strlen(dbg_text));
 		} else if (sig == SIGTERM) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"got SIGTERM, shutting down.\n"};
-			write(STDERR_FILENO, dbg_text, strlen(dbg_text));
+			(void)write(STDERR_FILENO, dbg_text, strlen(dbg_text));
 		}
 		g_killed = true;
 	} else {

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -98,18 +98,24 @@ volatile std::sig_atomic_t *signal_handler_killstatus()
 
 #if !defined(_WIN32) // POSIX
 
+//Stops compiler throwing unsued-result for a function
+template<typename ... Args>
+static void ignore(Args && ...)
+{
+}
+
 static void signal_handler(int sig)
 {
 	if (!g_killed) {
 		if (sig == SIGINT) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"Ctrl-C pressed, shutting down.\n"};
-			//nothing we can safely do in a signal handler
-			if (write(STDERR_FILENO, dbg_text, strlen(dbg_text)) < 0) {}
+			//nothing we can safely do in a signal handler so ignore it
+			ignore(write(STDERR_FILENO, dbg_text, strlen(dbg_text)));
 		} else if (sig == SIGTERM) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"got SIGTERM, shutting down.\n"};
-			if (write(STDERR_FILENO, dbg_text, strlen(dbg_text)) < 0) {}
+			ignore(write(STDERR_FILENO, dbg_text, strlen(dbg_text)));
 		}
 		g_killed = true;
 	} else {

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -101,7 +101,7 @@ volatile std::sig_atomic_t *signal_handler_killstatus()
 static void signal_handler(int sig)
 {
 	if (!g_killed) {
-		volatile ssize_t ignore;
+		volatile ssize_t ignore = 0;
 		if (sig == SIGINT) {
 			const char *dbg_text{"INFO: signal_handler(): "
 				"Ctrl-C pressed, shutting down.\n"};


### PR DESCRIPTION
Fix warning:

PR fixes a warning in porting.cpp caused by unused result in the signal_handler method when calling "write".
The fix was to encapsulate the write method in an if with no body so the result is technically used.



## To do

This PR is Ready for Review.



## How to test

Clone then perform a out of tree build using the instructions provided on Luanti README for compiling.
Included here for ease assuming you are on Linux.
```
cmake . -DRUN_IN_PLACE=TRUE
make -j$(nproc)
```

Do note that the warning would only show when following the instructions on the Luanti README. When performing an in-tree build in vscode the same warning would not show. I am not sure what the cause of this is.

Here is a screenshot of the warning it fixes:
<img width="1001" height="138" alt="Screenshot from 2026-07-04 15-31-58" src="https://github.com/user-attachments/assets/df7719c5-139d-4baf-8b55-742136aeaded" />

