### PR TITLE
[no squash] Fixes related to node waving

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -153,12 +153,13 @@ void main(void)
 #endif
 	varTexCoord = inTexCoord0.st;
 
-	float disp_x;
-	float disp_z;
+	vec4 wpos = mWorld * inVertexPosition;
 // OpenGL < 4.3 does not support continued preprocessor lines
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
-	vec4 pos2 = mWorld * inVertexPosition;
-	float tOffset = (pos2.x + pos2.y) * 0.001 + pos2.z * 0.002;
+	float disp_x;
+	float disp_z;
+
+	float tOffset = (wpos.x + wpos.y) * 0.001 + wpos.z * 0.002;
 	disp_x = (smoothTriangleWave(animationTimer * 23.0 + tOffset) +
 		smoothTriangleWave(animationTimer * 11.0 + tOffset)) * 0.4;
 	disp_z = (smoothTriangleWave(animationTimer * 31.0 + tOffset) +
@@ -171,7 +172,7 @@ void main(void)
 	// Generate waves with Perlin-type noise.
 	// The constants are calibrated such that they roughly
 	// correspond to the old sine waves.
-	vec3 wavePos = (mWorld * pos).xyz + cameraOffset;
+	vec3 wavePos = wpos.xyz + cameraOffset;
 	// The waves are slightly compressed along the z-axis to get
 	// wave-fronts along the x-axis.
 	wavePos.x /= WATER_WAVE_LENGTH * 3.0;
@@ -189,6 +190,11 @@ void main(void)
 		pos.z += disp_z;
 	}
 #endif
+#if MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES || MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS
+	// Prevent z-fighting of oversized plants
+	pos.z += fract(wpos.y * 0.1) * 0.1;
+#endif
+
 	worldPosition = (mWorld * pos).xyz;
 	gl_Position = mWorldViewProj * pos;
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10630,8 +10630,7 @@ Used by `core.register_node`, `core.register_craftitem`, and
     after_use = function(itemstack, user, node, digparams),
     -- Called after a tool is used to dig a node and will replace the default
     -- tool wear-out handling.
-    -- Shall return the leftover itemstack or nil to not
-    -- modify the dropped item.
+    -- Shall return the leftover itemstack or nil to not modify the item (tool).
     -- The user may be any ObjectRef or nil.
     -- default: nil
 
@@ -10885,15 +10884,19 @@ Used by `core.register_node`.
     legacy_wallmounted = false,
 
     waving = 0,
-    -- Valid for drawtypes:
-    -- mesh, nodebox, plantlike, allfaces_optional, liquid, flowingliquid.
-    -- 1 - wave node like plants (node top moves side-to-side, bottom is fixed)
-    -- 2 - wave node like leaves (whole node moves side-to-side)
-    -- 3 - wave node like liquids (whole node moves up and down)
+    -- Describes whether the node shall be animated (position transformation).
+    -- Supported for drawtypes:
+    --   mesh, nodebox, plantlike, allfaces_optional, liquid, flowingliquid.
+    -- Values:
+    --   0: Not waving.
+    --   1: Node top moves side-to-side, bottom is fixed. (plants)
+    --   2: Whole node moves side-to-side. (leaves)
+    --   3: Whole node moves up and down. (liquids)
+    -- Note: Each wave effect depends on its client-side setting `enable_waving_*`.
     -- Not all models will properly wave.
-    -- plantlike drawtype can only wave like plants.
-    -- allfaces_optional drawtype can only wave like leaves.
-    -- liquid, flowingliquid drawtypes can only wave like liquids.
+    -- When `waving > 0`, plantlike always behaves like `1` and allfaces_optional
+    --   always behaves like `2`. This behavior may be removed in the future.
+    -- The drawtypes "liquid" and "flowingliquid" only accept value 3 (and 0).
 
     sounds = {
         -- Definition of node sounds to be played at various events.


### PR DESCRIPTION
Fixes an issue where nodes with `visual_scale > 1` *without* shader animations suffer from z-fighting.

Fixes #16606

## To do

This PR is Ready for Review.


## How to test

1. Install the `ethereal` mod
2. Join a Minetest Game world
3. Note how the leaves jitter (master) and don't (PR).
