### PR TITLE
SSCSM: Wire up item/node definitions

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -895,9 +895,13 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     paramtype2 = string,            -- ParamType2 of the node
     drawtype = string,              -- Drawtype of the node
     mesh = <string>,                -- Mesh name if existent
+    tiles = {tile definition, ...},         -- 6 base tiles
+    overlay_tiles = {tile definition, ...}, -- 6 overlay tiles, drawn over the base tiles
+    special_tiles = {tile definition, ...}, -- Special tiles, amount varies by drawtype
     minimap_color = <Color>,        -- Color of node on minimap *May not exist*
     visual_scale = number,          -- Visual scale of node
-    alpha = number,                 -- Alpha of the node. Only used for liquids
+    alpha = number,                 -- Raw AlphaMode enum ordinal (0=blend, 1=clip, 2=opaque)
+    use_texture_alpha = string,     -- "blend", "clip" or "opaque"
     color = <Color>,                -- Color of node *May not exist*
     palette_name = <string>,        -- Filename of palette *May not exist*
     palette = <{                    -- List of colors
@@ -941,6 +945,31 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     legacy_facedir_simple = bool,   -- Whether to use old facedir
     legacy_wallmounted = bool       -- Whether to use old wallmounted
     move_resistance = <number>,     -- How slow players can move through the node *May not exist*
+}
+```
+
+#### Tile Definition
+
+```lua
+{
+    name = string,                  -- Texture name
+    backface_culling = bool,        -- Whether the tile's backface is culled
+    tileable_horizontal = bool,     -- Whether the tile is horizontally tileable
+    tileable_vertical = bool,       -- Whether the tile is vertically tileable
+    color = <Color>,                -- Tile color *May not exist*
+    align_style = string,           -- "node", "world" or "user"
+    scale = number,                 -- Scale of the tile
+    animation = {                   -- Tile animation parameters
+        type = string,              -- "none", "vertical_frames" or "sheet_2d"
+        -- if type == "vertical_frames":
+        aspect_w = number,
+        aspect_h = number,
+        length = number,
+        -- if type == "sheet_2d":
+        frames_w = number,
+        frames_h = number,
+        frame_length = number,
+    },
 }
 ```
 

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -950,6 +950,8 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 
 #### Tile Definition
 
+`nil` if the tile is unset.
+
 ```lua
 {
     name = string,                  -- Texture name
@@ -959,8 +961,8 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     color = <Color>,                -- Tile color *May not exist*
     align_style = string,           -- "node", "world" or "user"
     scale = number,                 -- Scale of the tile
-    animation = {                   -- Tile animation parameters
-        type = string,              -- "none", "vertical_frames" or "sheet_2d"
+    animation = {                   -- Tile animation parameters *May not exist*
+        type = string,              -- "vertical_frames" or "sheet_2d"
         -- if type == "vertical_frames":
         aspect_w = number,
         aspect_h = number,

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -988,6 +988,7 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     color = Color,                  -- Color for item
     wield_scale = Vector,           -- Wieldmesh scale
     stack_max = number,             -- Number of items stackable together
+    range = number,                 -- Range of node/object pointing that overrides the default
     usable = bool,                  -- Has on_use callback defined
     liquids_pointable = bool,       -- Whether you can point at liquids with the item
     tool_capabilities = <table>,    -- If the item is a tool, tool capabilities of the item

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -895,9 +895,9 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     paramtype2 = string,            -- ParamType2 of the node
     drawtype = string,              -- Drawtype of the node
     mesh = <string>,                -- Mesh name if existent
-    tiles = {tile definition, ...},         -- 6 base tiles
-    overlay_tiles = {tile definition, ...}, -- 6 overlay tiles, drawn over the base tiles
-    special_tiles = {tile definition, ...}, -- Special tiles, amount varies by drawtype
+    tiles = {tile definition, ...},         -- 6 base tiles, entries may be nil
+    overlay_tiles = {tile definition, ...}, -- 6 overlay tiles, drawn over the base tiles, entries may be nil
+    special_tiles = {tile definition, ...}, -- Special tiles, amount varies by drawtype, entries may be nil
     minimap_color = <Color>,        -- Color of node on minimap *May not exist*
     visual_scale = number,          -- Visual scale of node
     alpha = number,                 -- Raw AlphaMode enum ordinal (0=blend, 1=clip, 2=opaque)
@@ -988,7 +988,7 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     color = Color,                  -- Color for item
     wield_scale = Vector,           -- Wieldmesh scale
     stack_max = number,             -- Number of items stackable together
-    range = number,                 -- Range of node/object pointing that overrides the default
+    range = number,                 -- Range of node/object pointing
     usable = bool,                  -- Has on_use callback defined
     liquids_pointable = bool,       -- Whether you can point at liquids with the item
     tool_capabilities = <table>,    -- If the item is a tool, tool capabilities of the item

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -59,6 +59,18 @@ Functions that take or return paths always use virtual paths.
 * `core.get_name_from_content_id(id)`
 
 
+### Global tables
+
+#### Registered definition tables
+
+* `core.registered_items`
+* `core.registered_nodes`
+* `core.registered_tools`
+* `core.registered_craftitems`
+* `core.registered_aliases`
+  * TODO still empty
+
+
 ### Util API
 
 * `core.log([level,] text)`

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -197,40 +197,10 @@ Client::Client(
 		m_sscsm_controller->runEvent(this, std::move(event2));
 	}
 
-	{
-		//FIXME: network packets
-		//FIXME: check that *client_builtin* is not overridden
-
-		std::string enable_sscsm = g_settings->get("enable_sscsm");
-		if (enable_sscsm == "singleplayer") { //FIXME: enum
-			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
-
-			// some simple test code
-			event1->files.emplace_back("sscsm_test0:init.lua",
-					R"=+=(
-print("sscsm_test0: loading")
-
---print(dump(_G))
---print(debug.traceback())
-
-do
-	local pos = vector.zero()
-	local function print_nodes()
-		print(string.format("node at %s: %s", pos, dump(core.get_node_or_nil(pos))))
-		pos = pos:offset(1, 0, 0)
-		core.after(1, print_nodes)
-	end
-	core.after(0, print_nodes)
-end
-					)=+=");
-
-			m_sscsm_controller->runEvent(this, std::move(event1));
-
-			auto event2 = std::make_unique<SSCSMEventLoadMods>();
-			event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
-			m_sscsm_controller->runEvent(this, std::move(event2));
-		}
-	}
+	//FIXME: network packets
+	//FIXME: check that *client_builtin* is not overridden
+	// The sscsm_test0 preview mod is loaded from afterContentReceived(),
+	// once itemdefs/nodedefs actually exist to populate core.registered_*.
 }
 
 void Client::migrateModStorage()
@@ -1955,6 +1925,47 @@ void Client::afterContentReceived()
 	// Start mesh update thread after setting up content definitions
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_manager->start();
+
+	{
+		std::string enable_sscsm = g_settings->get("enable_sscsm");
+		if (enable_sscsm == "singleplayer") { //FIXME: enum
+			m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAddItemdefs>());
+
+			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+
+			// some simple test code
+			event1->files.emplace_back("sscsm_test0:init.lua",
+					R"=+=(
+print("sscsm_test0: loading")
+
+--print(dump(_G))
+--print(debug.traceback())
+
+do
+	local pos = vector.zero()
+	local function print_nodes()
+		print(string.format("node at %s: %s", pos, dump(core.get_node_or_nil(pos))))
+		pos = pos:offset(1, 0, 0)
+		core.after(1, print_nodes)
+	end
+	core.after(0, print_nodes)
+end
+
+do
+	local n = 0
+	for _ in pairs(core.registered_nodes) do n = n + 1 end
+	print("sscsm_test0: registered_nodes count: " .. n)
+end
+print("sscsm_test0: air def: " .. dump(core.registered_nodes["air"]))
+					)=+=");
+
+			m_sscsm_controller->runEvent(this, std::move(event1));
+
+			auto event2 = std::make_unique<SSCSMEventLoadMods>();
+			event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
+			m_sscsm_controller->runEvent(this, std::move(event2));
+		}
+	}
 
 	m_state = LC_Ready;
 	sendReady();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -199,7 +199,7 @@ Client::Client(
 
 	//FIXME: network packets
 	//FIXME: check that *client_builtin* is not overridden
-	// The sscsm_test0 preview mod is loaded from afterContentReceived(),
+	// The sscsm_test0 preview mod is loaded from loadSSCSM(),
 	// once itemdefs/nodedefs actually exist to populate core.registered_*.
 }
 
@@ -1934,12 +1934,28 @@ void Client::afterContentReceived()
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_manager->start();
 
-	if (sscsm_enabled) {
-		auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+	m_state = LC_Ready;
+	sendReady();
 
-		// some simple test code
-		event1->files.emplace_back("sscsm_test0:init.lua",
-				R"=+=(
+	if (m_mods_loaded)
+		m_script->on_client_ready(m_env.getLocalPlayer());
+
+	m_rendering_engine->draw_load_screen(wstrgettext("Done!"), guienv, m_tsrc, 0, 100);
+	infostream<<"Client::afterContentReceived() done"<<std::endl;
+}
+
+void Client::loadSSCSM()
+{
+	std::string enable_sscsm = g_settings->get("enable_sscsm");
+	bool sscsm_enabled = enable_sscsm == "singleplayer"; //FIXME: enum
+	if (!sscsm_enabled)
+		return;
+
+	auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+
+	// some simple test code
+	event1->files.emplace_back("sscsm_test0:init.lua",
+			R"=+=(
 print("sscsm_test0: loading")
 
 --print(dump(_G))
@@ -1963,21 +1979,11 @@ end
 print("sscsm_test0: air def: " .. dump(core.registered_nodes["air"]))
 				)=+=");
 
-		m_sscsm_controller->runEvent(this, std::move(event1));
+	m_sscsm_controller->runEvent(this, std::move(event1));
 
-		auto event2 = std::make_unique<SSCSMEventLoadMods>();
-		event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
-		m_sscsm_controller->runEvent(this, std::move(event2));
-	}
-
-	m_state = LC_Ready;
-	sendReady();
-
-	if (m_mods_loaded)
-		m_script->on_client_ready(m_env.getLocalPlayer());
-
-	m_rendering_engine->draw_load_screen(wstrgettext("Done!"), guienv, m_tsrc, 0, 100);
-	infostream<<"Client::afterContentReceived() done"<<std::endl;
+	auto event2 = std::make_unique<SSCSMEventLoadMods>();
+	event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
+	m_sscsm_controller->runEvent(this, std::move(event2));
 }
 
 float Client::getRTT()

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1915,6 +1915,14 @@ void Client::afterContentReceived()
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 
+	std::string enable_sscsm = g_settings->get("enable_sscsm");
+	bool sscsm_enabled = enable_sscsm == "singleplayer"; //FIXME: enum
+
+	// Must run before fillNodeVisuals(), which sets ContentFeatures::visuals
+	// and may resolve drawtypes based on this client's local render settings.
+	if (sscsm_enabled)
+		m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAddItemdefs>());
+
 	// Update node textures and assign shaders to each tile
 	infostream<<"- Updating node textures"<<std::endl;
 	TextureUpdateArgs tu_args;
@@ -1926,16 +1934,12 @@ void Client::afterContentReceived()
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_manager->start();
 
-	{
-		std::string enable_sscsm = g_settings->get("enable_sscsm");
-		if (enable_sscsm == "singleplayer") { //FIXME: enum
-			m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAddItemdefs>());
+	if (sscsm_enabled) {
+		auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
 
-			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
-
-			// some simple test code
-			event1->files.emplace_back("sscsm_test0:init.lua",
-					R"=+=(
+		// some simple test code
+		event1->files.emplace_back("sscsm_test0:init.lua",
+				R"=+=(
 print("sscsm_test0: loading")
 
 --print(dump(_G))
@@ -1957,14 +1961,13 @@ do
 	print("sscsm_test0: registered_nodes count: " .. n)
 end
 print("sscsm_test0: air def: " .. dump(core.registered_nodes["air"]))
-					)=+=");
+				)=+=");
 
-			m_sscsm_controller->runEvent(this, std::move(event1));
+		m_sscsm_controller->runEvent(this, std::move(event1));
 
-			auto event2 = std::make_unique<SSCSMEventLoadMods>();
-			event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
-			m_sscsm_controller->runEvent(this, std::move(event2));
-		}
+		auto event2 = std::make_unique<SSCSMEventLoadMods>();
+		event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
+		m_sscsm_controller->runEvent(this, std::move(event2));
 	}
 
 	m_state = LC_Ready;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1915,13 +1915,9 @@ void Client::afterContentReceived()
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 
-	std::string enable_sscsm = g_settings->get("enable_sscsm");
-	bool sscsm_enabled = enable_sscsm == "singleplayer"; //FIXME: enum
-
 	// Must run before fillNodeVisuals(), which sets ContentFeatures::visuals
 	// and may resolve drawtypes based on this client's local render settings.
-	if (sscsm_enabled)
-		m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
+	m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
 
 	// Update node textures and assign shaders to each tile
 	infostream<<"- Updating node textures"<<std::endl;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1921,7 +1921,7 @@ void Client::afterContentReceived()
 	// Must run before fillNodeVisuals(), which sets ContentFeatures::visuals
 	// and may resolve drawtypes based on this client's local render settings.
 	if (sscsm_enabled)
-		m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAddItemdefs>());
+		m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
 
 	// Update node textures and assign shaders to each tile
 	infostream<<"- Updating node textures"<<std::endl;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1915,16 +1915,16 @@ void Client::afterContentReceived()
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 
-	// Must run before fillNodeVisuals(), which sets ContentFeatures::visuals
-	// and may resolve drawtypes based on this client's local render settings.
-	m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
-
 	// Update node textures and assign shaders to each tile
 	infostream<<"- Updating node textures"<<std::endl;
 	TextureUpdateArgs tu_args;
 	tu_args.last_time_ms = porting::getTimeMs();
 	tu_args.text_base = wstrgettext("Initializing nodes");
 	NodeVisuals::fillNodeVisuals(m_nodedef, this, &tu_args);
+
+	// Runs after fillNodeVisuals(), which is where ContentFeatures::visuals and thus
+	// minimap_color, and palette - the two values we care for in SSCSM, get populated
+	m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
 
 	// Start mesh update thread after setting up content definitions
 	infostream<<"- Starting mesh update thread"<<std::endl;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -349,6 +349,7 @@ public:
 
 	void drawLoadScreen(const std::wstring &text, float dtime, int percent);
 	void afterContentReceived();
+	void loadSSCSM();
 	void showUpdateProgressTexture(void *args, float progress);
 
 	float getRTT();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -879,6 +879,7 @@ bool Game::createClient(const GameStartData &start_data)
 
 	// Update cached textures, meshes and materials
 	client->afterContentReceived();
+	client->loadSSCSM();
 
 	/* Camera
 	 */

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -879,6 +879,7 @@ bool Game::createClient(const GameStartData &start_data)
 
 	// Update cached textures, meshes and materials
 	client->afterContentReceived();
+	// Load received SSCSMs
 	client->loadSSCSM();
 
 	/* Camera

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -429,6 +429,14 @@ public:
 		}
 	}
 
+	virtual void getDefinitions(std::vector<ItemDefinition> &result) const
+	{
+		result.clear();
+		result.reserve(m_item_definitions.size());
+		for (const auto &item_definition : m_item_definitions)
+			result.push_back(*item_definition.second);
+	}
+
 	virtual bool isKnown(const std::string &name_) const
 	{
 		const std::string &name = getAlias(name_);

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -155,6 +155,8 @@ public:
 	virtual const std::string &getAlias(const std::string &name) const=0;
 	// Get set of all defined item names and aliases
 	virtual void getAll(std::set<std::string> &result) const=0;
+	// Get all item definitions (aliases not resolved)
+	virtual void getDefinitions(std::vector<ItemDefinition> &result) const=0;
 	// Check if item is known
 	virtual bool isKnown(const std::string &name) const=0;
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -316,6 +316,24 @@ ContentFeatures::~ContentFeatures()
 #endif
 }
 
+#if CHECK_CLIENT_BUILD()
+ContentFeaturesSSCSM ContentFeatures::copyWithoutVisuals() const
+{
+	ContentFeaturesSSCSM result;
+	result.cf = *this;
+	// Null this out before anything else runs, so the shallow copy
+	// above never gets a chance to double-delete visuals.
+	result.cf.visuals = nullptr;
+	result.had_visuals = visuals != nullptr;
+	if (visuals) {
+		result.minimap_color = visuals->minimap_color;
+		if (visuals->palette)
+			result.palette = *visuals->palette;
+	}
+	return result;
+}
+#endif
+
 void ContentFeatures::reset()
 {
 	/*

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -26,6 +26,7 @@ class TestSchematic;
 #endif
 #if CHECK_CLIENT_BUILD()
 struct NodeVisuals;
+struct ContentFeaturesSSCSM;
 #endif
 
 enum ContentParamType : u8
@@ -488,11 +489,30 @@ struct ContentFeatures
 		return itemgroup_get(groups, group);
 	}
 
+#if CHECK_CLIENT_BUILD()
+	// Copies everything except visuals, which is GPU/mesh state that isn't
+	// safe to copy. Named explicitly since it's not a full copy.
+	ContentFeaturesSSCSM copyWithoutVisuals() const;
+#endif
+
 private:
 	void setAlphaFromLegacy(u8 legacy_alpha);
 
 	u8 getAlphaForLegacy() const;
 };
+
+#if CHECK_CLIENT_BUILD()
+// Result of ContentFeatures::copyWithoutVisuals(). cf.visuals is always
+// nullptr; minimap_color/palette are carried alongside instead.
+struct ContentFeaturesSSCSM
+{
+	ContentFeatures cf;
+	// Whether cf.visuals was set at copy time; if false, ignore the fields below.
+	bool had_visuals = false;
+	video::SColor minimap_color;
+	std::vector<video::SColor> palette;
+};
+#endif
 
 /*!
  * @brief This class is for getting the actual properties of nodes from their

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -744,6 +744,10 @@ static void push_tile_animation_params(lua_State *L, const TileAnimationParams &
 /******************************************************************************/
 void push_tile_definition(lua_State *L, const TileDef &def)
 {
+	if (def.name.empty()) {
+		lua_pushnil(L);
+		return;
+	}
 	lua_newtable(L);
 	lua_pushstring(L, def.name.c_str());
 	lua_setfield(L, -2, "name");
@@ -763,8 +767,10 @@ void push_tile_definition(lua_State *L, const TileDef &def)
 	lua_setfield(L, -2, "align_style");
 	lua_pushnumber(L, def.scale);
 	lua_setfield(L, -2, "scale");
-	push_tile_animation_params(L, def.animation);
-	lua_setfield(L, -2, "animation");
+	if (def.animation.type != TAT_NONE) {
+		push_tile_animation_params(L, def.animation);
+		lua_setfield(L, -2, "animation");
+	}
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -282,6 +282,78 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "touch_interaction");
 }
 
+void push_item_definition_for_sscsm(lua_State *L, const ItemDefinition &i)
+{
+	const char *type = enum_to_string(es_ItemType, i.type);
+
+	lua_newtable(L);
+	lua_pushstring(L, i.name.c_str());
+	lua_setfield(L, -2, "name");
+	lua_pushstring(L, type);
+	lua_setfield(L, -2, "type");
+	lua_pushstring(L, i.description.c_str());
+	lua_setfield(L, -2, "description");
+	if (!i.short_description.empty()) {
+		lua_pushstring(L, i.short_description.c_str());
+		lua_setfield(L, -2, "short_description");
+	}
+	push_groups(L, i.groups);
+	lua_setfield(L, -2, "groups");
+	push_item_image_definition(L, i.inventory_image);
+	lua_setfield(L, -2, "inventory_image");
+	push_item_image_definition(L, i.inventory_overlay);
+	lua_setfield(L, -2, "inventory_overlay");
+	push_item_image_definition(L, i.wield_image);
+	lua_setfield(L, -2, "wield_image");
+	push_item_image_definition(L, i.wield_overlay);
+	lua_setfield(L, -2, "wield_overlay");
+	push_v3f(L, i.wield_scale);
+	lua_setfield(L, -2, "wield_scale");
+	lua_pushstring(L, i.palette_image.c_str());
+	lua_setfield(L, -2, "palette_image");
+	push_ARGB8(L, i.color);
+	lua_setfield(L, -2, "color");
+	lua_pushinteger(L, i.stack_max);
+	lua_setfield(L, -2, "stack_max");
+	lua_pushnumber(L, i.range);
+	lua_setfield(L, -2, "range");
+	lua_pushboolean(L, i.liquids_pointable);
+	lua_setfield(L, -2, "liquids_pointable");
+	if (i.pointabilities) {
+		push_pointabilities(L, *i.pointabilities);
+		lua_setfield(L, -2, "pointabilities");
+	}
+	if (i.tool_capabilities) {
+		push_tool_capabilities(L, *i.tool_capabilities);
+		lua_setfield(L, -2, "tool_capabilities");
+	}
+	if (i.wear_bar_params.has_value()) {
+		push_wear_bar_params(L, *i.wear_bar_params);
+		lua_setfield(L, -2, "wear_color");
+	}
+	lua_pushstring(L, i.node_placement_prediction.c_str());
+	lua_setfield(L, -2, "node_placement_prediction");
+	{
+		lua_createtable(L, 0, 3);
+		const TouchInteraction &inter = i.touch_interaction;
+		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_nothing));
+		lua_setfield(L, -2,"pointed_nothing");
+		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_node));
+		lua_setfield(L, -2,"pointed_node");
+		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_object));
+		lua_setfield(L, -2,"pointed_object");
+		lua_setfield(L, -2, "touch_interaction");
+	}
+	lua_pushboolean(L, i.usable);
+	lua_setfield(L, -2, "usable");
+	push_simplesoundspec(L, i.sound_place);
+	lua_setfield(L, -2, "sound_place");
+	push_simplesoundspec(L, i.sound_place_failed);
+	lua_setfield(L, -2, "sound_place_failed");
+	lua_pushboolean(L, i.wallmounted_rotate_vertical);
+	lua_setfield(L, -2, "wallmounted_rotate_vertical");
+}
+
 /******************************************************************************/
 const std::array<const char *, 36> object_property_keys = {
 	"hp_max",
@@ -1090,6 +1162,135 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 			lua_setfield(L, -2, "palette");
 		}
 #endif
+	}
+	lua_pushnumber(L, c.waving);
+	lua_setfield(L, -2, "waving");
+	lua_pushnumber(L, c.connect_sides);
+	lua_setfield(L, -2, "connect_sides");
+
+	lua_createtable(L, c.connects_to.size(), 0);
+	u16 i = 1;
+	for (const std::string &it : c.connects_to) {
+		lua_pushlstring(L, it.c_str(), it.size());
+		lua_rawseti(L, -2, i++);
+	}
+	lua_setfield(L, -2, "connects_to");
+
+	push_ARGB8(L, c.post_effect_color);
+	lua_setfield(L, -2, "post_effect_color");
+	lua_pushboolean(L, c.post_effect_color_shaded);
+	lua_setfield(L, -2, "post_effect_color_shaded");
+	lua_pushnumber(L, c.leveled);
+	lua_setfield(L, -2, "leveled");
+	lua_pushnumber(L, c.leveled_max);
+	lua_setfield(L, -2, "leveled_max");
+	lua_pushboolean(L, c.sunlight_propagates);
+	lua_setfield(L, -2, "sunlight_propagates");
+	lua_pushnumber(L, c.light_source);
+	lua_setfield(L, -2, "light_source");
+	lua_pushboolean(L, c.is_ground_content);
+	lua_setfield(L, -2, "is_ground_content");
+	lua_pushboolean(L, c.walkable);
+	lua_setfield(L, -2, "walkable");
+	push_pointability_type(L, c.pointable);
+	lua_setfield(L, -2, "pointable");
+	lua_pushboolean(L, c.diggable);
+	lua_setfield(L, -2, "diggable");
+	lua_pushboolean(L, c.climbable);
+	lua_setfield(L, -2, "climbable");
+	lua_pushboolean(L, c.buildable_to);
+	lua_setfield(L, -2, "buildable_to");
+	lua_pushboolean(L, c.rightclickable);
+	lua_setfield(L, -2, "rightclickable");
+	lua_pushnumber(L, c.damage_per_second);
+	lua_setfield(L, -2, "damage_per_second");
+	if (c.isLiquid()) {
+		lua_pushstring(L, liquid_type.c_str());
+		lua_setfield(L, -2, "liquid_type");
+		lua_pushstring(L, c.liquid_alternative_flowing.c_str());
+		lua_setfield(L, -2, "liquid_alternative_flowing");
+		lua_pushstring(L, c.liquid_alternative_source.c_str());
+		lua_setfield(L, -2, "liquid_alternative_source");
+		lua_pushnumber(L, c.liquid_viscosity);
+		lua_setfield(L, -2, "liquid_viscosity");
+		lua_pushboolean(L, c.liquid_renewable);
+		lua_setfield(L, -2, "liquid_renewable");
+		lua_pushnumber(L, c.liquid_range);
+		lua_setfield(L, -2, "liquid_range");
+	}
+	lua_pushnumber(L, c.drowning);
+	lua_setfield(L, -2, "drowning");
+	lua_pushboolean(L, c.floodable);
+	lua_setfield(L, -2, "floodable");
+	push_nodebox(L, c.node_box);
+	lua_setfield(L, -2, "node_box");
+	push_nodebox(L, c.selection_box);
+	lua_setfield(L, -2, "selection_box");
+	push_nodebox(L, c.collision_box);
+	lua_setfield(L, -2, "collision_box");
+	lua_newtable(L);
+	push_simplesoundspec(L, c.sound_footstep);
+	lua_setfield(L, -2, "sound_footstep");
+	push_simplesoundspec(L, c.sound_dig);
+	lua_setfield(L, -2, "sound_dig");
+	push_simplesoundspec(L, c.sound_dug);
+	lua_setfield(L, -2, "sound_dug");
+	lua_setfield(L, -2, "sounds");
+	lua_pushboolean(L, c.legacy_facedir_simple);
+	lua_setfield(L, -2, "legacy_facedir_simple");
+	lua_pushboolean(L, c.legacy_wallmounted);
+	lua_setfield(L, -2, "legacy_wallmounted");
+	lua_pushstring(L, c.node_dig_prediction.c_str());
+	lua_setfield(L, -2, "node_dig_prediction");
+	lua_pushnumber(L, c.move_resistance);
+	lua_setfield(L, -2, "move_resistance");
+	lua_pushboolean(L, c.liquid_move_physics);
+	lua_setfield(L, -2, "liquid_move_physics");
+}
+
+void push_content_features_for_sscsm(lua_State *L, const ContentFeatures &c)
+{
+	std::string paramtype = enum_to_string(ScriptApiNode::es_ContentParamType, c.param_type);
+	std::string paramtype2 = enum_to_string(ScriptApiNode::es_ContentParamType2, c.param_type_2);
+	std::string drawtype = enum_to_string(ScriptApiNode::es_DrawType, c.drawtype);
+	std::string liquid_type = enum_to_string(ScriptApiNode::es_LiquidType, c.liquid_type);
+
+	/* Missing "tiles" because TODO. */
+
+	lua_newtable(L);
+	lua_pushboolean(L, c.has_on_construct);
+	lua_setfield(L, -2, "has_on_construct");
+	lua_pushboolean(L, c.has_on_destruct);
+	lua_setfield(L, -2, "has_on_destruct");
+	lua_pushboolean(L, c.has_after_destruct);
+	lua_setfield(L, -2, "has_after_destruct");
+	lua_pushstring(L, c.name.c_str());
+	lua_setfield(L, -2, "name");
+	push_groups(L, c.groups);
+	lua_setfield(L, -2, "groups");
+	lua_pushstring(L, paramtype.c_str());
+	lua_setfield(L, -2, "paramtype");
+	lua_pushstring(L, paramtype2.c_str());
+	lua_setfield(L, -2, "paramtype2");
+	lua_pushstring(L, drawtype.c_str());
+	lua_setfield(L, -2, "drawtype");
+	if (!c.mesh.empty()) {
+		lua_pushstring(L, c.mesh.c_str());
+		lua_setfield(L, -2, "mesh");
+	}
+	// NOTE: c.visuals is filled in by fillNodeVisuals() on the main/render
+	// thread and must not be dereferenced here: this function runs on the
+	// SSCSM environment thread, so minimap_color/palette are left out for now.
+	lua_pushnumber(L, c.visual_scale);
+	lua_setfield(L, -2, "visual_scale");
+	lua_pushnumber(L, c.alpha);
+	lua_setfield(L, -2, "alpha");
+	if (!c.palette_name.empty()) {
+		push_ARGB8(L, c.color);
+		lua_setfield(L, -2, "color");
+
+		lua_pushstring(L, c.palette_name.c_str());
+		lua_setfield(L, -2, "palette_name");
 	}
 	lua_pushnumber(L, c.waving);
 	lua_setfield(L, -2, "waving");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -719,6 +719,55 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype, bool special)
 }
 
 /******************************************************************************/
+static void push_tile_animation_params(lua_State *L, const TileAnimationParams &anim)
+{
+	lua_newtable(L);
+	lua_pushstring(L, enum_to_string(es_TileAnimationType, anim.type));
+	lua_setfield(L, -2, "type");
+	if (anim.type == TAT_VERTICAL_FRAMES) {
+		lua_pushnumber(L, anim.vertical_frames.aspect_w);
+		lua_setfield(L, -2, "aspect_w");
+		lua_pushnumber(L, anim.vertical_frames.aspect_h);
+		lua_setfield(L, -2, "aspect_h");
+		lua_pushnumber(L, anim.vertical_frames.length);
+		lua_setfield(L, -2, "length");
+	} else if (anim.type == TAT_SHEET_2D) {
+		lua_pushnumber(L, anim.sheet_2d.frames_w);
+		lua_setfield(L, -2, "frames_w");
+		lua_pushnumber(L, anim.sheet_2d.frames_h);
+		lua_setfield(L, -2, "frames_h");
+		lua_pushnumber(L, anim.sheet_2d.frame_length);
+		lua_setfield(L, -2, "frame_length");
+	}
+}
+
+/******************************************************************************/
+void push_tile_definition(lua_State *L, const TileDef &def)
+{
+	lua_newtable(L);
+	lua_pushstring(L, def.name.c_str());
+	lua_setfield(L, -2, "name");
+	lua_pushboolean(L, def.backface_culling);
+	lua_setfield(L, -2, "backface_culling");
+	lua_pushboolean(L, def.tileable_horizontal);
+	lua_setfield(L, -2, "tileable_horizontal");
+	lua_pushboolean(L, def.tileable_vertical);
+	lua_setfield(L, -2, "tileable_vertical");
+	if (def.has_color) {
+		push_ARGB8(L, def.color);
+		lua_setfield(L, -2, "color");
+	}
+	const char *align_style = def.align_style == ALIGN_STYLE_WORLD ? "world" :
+			def.align_style == ALIGN_STYLE_USER_DEFINED ? "user" : "node";
+	lua_pushstring(L, align_style);
+	lua_setfield(L, -2, "align_style");
+	lua_pushnumber(L, def.scale);
+	lua_setfield(L, -2, "scale");
+	push_tile_animation_params(L, def.animation);
+	lua_setfield(L, -2, "animation");
+}
+
+/******************************************************************************/
 void read_content_features(lua_State *L, ContentFeatures &f, int index)
 {
 	if(index < 0)
@@ -1046,8 +1095,6 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	std::string drawtype(enum_to_string(ScriptApiNode::es_DrawType, c.drawtype));
 	std::string liquid_type(enum_to_string(ScriptApiNode::es_LiquidType, c.liquid_type));
 
-	/* Missing "tiles" because I don't see a usecase (at least not yet). */
-
 	lua_newtable(L);
 	lua_pushboolean(L, c.has_on_construct);
 	lua_setfield(L, -2, "has_on_construct");
@@ -1069,6 +1116,19 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 		lua_pushstring(L, c.mesh.c_str());
 		lua_setfield(L, -2, "mesh");
 	}
+
+	const auto push_tiles = [&](const char *name, const TileDef *tiledefs, size_t count) {
+		lua_createtable(L, count, 0);
+		for (size_t i = 0; i < count; i++) {
+			push_tile_definition(L, tiledefs[i]);
+			lua_rawseti(L, -2, i + 1);
+		}
+		lua_setfield(L, -2, name);
+	};
+	push_tiles("tiles", c.tiledef, 6);
+	push_tiles("overlay_tiles", c.tiledef_overlay, 6);
+	push_tiles("special_tiles", c.tiledef_special, CF_SPECIAL_COUNT);
+
 #if CHECK_CLIENT_BUILD()
 	if (c.visuals) {
 		push_ARGB8(L, c.visuals->minimap_color); // I know this is not set-able w/ register_node,
@@ -1079,6 +1139,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "visual_scale");
 	lua_pushnumber(L, c.alpha);
 	lua_setfield(L, -2, "alpha");
+	lua_pushstring(L, enum_to_string(ScriptApiNode::es_TextureAlphaMode, c.alpha));
+	lua_setfield(L, -2, "use_texture_alpha");
 	if (!c.palette_name.empty()) {
 		push_ARGB8(L, c.color);
 		lua_setfield(L, -2, "color");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -244,6 +244,8 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "wield_scale");
 	lua_pushinteger(L, i.stack_max);
 	lua_setfield(L, -2, "stack_max");
+	lua_pushnumber(L, i.range);
+	lua_setfield(L, -2, "range");
 	lua_pushboolean(L, i.usable);
 	lua_setfield(L, -2, "usable");
 	lua_pushboolean(L, i.liquids_pointable);
@@ -280,78 +282,6 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_object));
 	lua_setfield(L, -2,"pointed_object");
 	lua_setfield(L, -2, "touch_interaction");
-}
-
-void push_item_definition_for_sscsm(lua_State *L, const ItemDefinition &i)
-{
-	const char *type = enum_to_string(es_ItemType, i.type);
-
-	lua_newtable(L);
-	lua_pushstring(L, i.name.c_str());
-	lua_setfield(L, -2, "name");
-	lua_pushstring(L, type);
-	lua_setfield(L, -2, "type");
-	lua_pushstring(L, i.description.c_str());
-	lua_setfield(L, -2, "description");
-	if (!i.short_description.empty()) {
-		lua_pushstring(L, i.short_description.c_str());
-		lua_setfield(L, -2, "short_description");
-	}
-	push_groups(L, i.groups);
-	lua_setfield(L, -2, "groups");
-	push_item_image_definition(L, i.inventory_image);
-	lua_setfield(L, -2, "inventory_image");
-	push_item_image_definition(L, i.inventory_overlay);
-	lua_setfield(L, -2, "inventory_overlay");
-	push_item_image_definition(L, i.wield_image);
-	lua_setfield(L, -2, "wield_image");
-	push_item_image_definition(L, i.wield_overlay);
-	lua_setfield(L, -2, "wield_overlay");
-	push_v3f(L, i.wield_scale);
-	lua_setfield(L, -2, "wield_scale");
-	lua_pushstring(L, i.palette_image.c_str());
-	lua_setfield(L, -2, "palette_image");
-	push_ARGB8(L, i.color);
-	lua_setfield(L, -2, "color");
-	lua_pushinteger(L, i.stack_max);
-	lua_setfield(L, -2, "stack_max");
-	lua_pushnumber(L, i.range);
-	lua_setfield(L, -2, "range");
-	lua_pushboolean(L, i.liquids_pointable);
-	lua_setfield(L, -2, "liquids_pointable");
-	if (i.pointabilities) {
-		push_pointabilities(L, *i.pointabilities);
-		lua_setfield(L, -2, "pointabilities");
-	}
-	if (i.tool_capabilities) {
-		push_tool_capabilities(L, *i.tool_capabilities);
-		lua_setfield(L, -2, "tool_capabilities");
-	}
-	if (i.wear_bar_params.has_value()) {
-		push_wear_bar_params(L, *i.wear_bar_params);
-		lua_setfield(L, -2, "wear_color");
-	}
-	lua_pushstring(L, i.node_placement_prediction.c_str());
-	lua_setfield(L, -2, "node_placement_prediction");
-	{
-		lua_createtable(L, 0, 3);
-		const TouchInteraction &inter = i.touch_interaction;
-		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_nothing));
-		lua_setfield(L, -2,"pointed_nothing");
-		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_node));
-		lua_setfield(L, -2,"pointed_node");
-		lua_pushstring(L, enum_to_string(es_TouchInteractionMode, inter.pointed_object));
-		lua_setfield(L, -2,"pointed_object");
-		lua_setfield(L, -2, "touch_interaction");
-	}
-	lua_pushboolean(L, i.usable);
-	lua_setfield(L, -2, "usable");
-	push_simplesoundspec(L, i.sound_place);
-	lua_setfield(L, -2, "sound_place");
-	push_simplesoundspec(L, i.sound_place_failed);
-	lua_setfield(L, -2, "sound_place_failed");
-	lua_pushboolean(L, i.wallmounted_rotate_vertical);
-	lua_setfield(L, -2, "wallmounted_rotate_vertical");
 }
 
 /******************************************************************************/
@@ -1162,135 +1092,6 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 			lua_setfield(L, -2, "palette");
 		}
 #endif
-	}
-	lua_pushnumber(L, c.waving);
-	lua_setfield(L, -2, "waving");
-	lua_pushnumber(L, c.connect_sides);
-	lua_setfield(L, -2, "connect_sides");
-
-	lua_createtable(L, c.connects_to.size(), 0);
-	u16 i = 1;
-	for (const std::string &it : c.connects_to) {
-		lua_pushlstring(L, it.c_str(), it.size());
-		lua_rawseti(L, -2, i++);
-	}
-	lua_setfield(L, -2, "connects_to");
-
-	push_ARGB8(L, c.post_effect_color);
-	lua_setfield(L, -2, "post_effect_color");
-	lua_pushboolean(L, c.post_effect_color_shaded);
-	lua_setfield(L, -2, "post_effect_color_shaded");
-	lua_pushnumber(L, c.leveled);
-	lua_setfield(L, -2, "leveled");
-	lua_pushnumber(L, c.leveled_max);
-	lua_setfield(L, -2, "leveled_max");
-	lua_pushboolean(L, c.sunlight_propagates);
-	lua_setfield(L, -2, "sunlight_propagates");
-	lua_pushnumber(L, c.light_source);
-	lua_setfield(L, -2, "light_source");
-	lua_pushboolean(L, c.is_ground_content);
-	lua_setfield(L, -2, "is_ground_content");
-	lua_pushboolean(L, c.walkable);
-	lua_setfield(L, -2, "walkable");
-	push_pointability_type(L, c.pointable);
-	lua_setfield(L, -2, "pointable");
-	lua_pushboolean(L, c.diggable);
-	lua_setfield(L, -2, "diggable");
-	lua_pushboolean(L, c.climbable);
-	lua_setfield(L, -2, "climbable");
-	lua_pushboolean(L, c.buildable_to);
-	lua_setfield(L, -2, "buildable_to");
-	lua_pushboolean(L, c.rightclickable);
-	lua_setfield(L, -2, "rightclickable");
-	lua_pushnumber(L, c.damage_per_second);
-	lua_setfield(L, -2, "damage_per_second");
-	if (c.isLiquid()) {
-		lua_pushstring(L, liquid_type.c_str());
-		lua_setfield(L, -2, "liquid_type");
-		lua_pushstring(L, c.liquid_alternative_flowing.c_str());
-		lua_setfield(L, -2, "liquid_alternative_flowing");
-		lua_pushstring(L, c.liquid_alternative_source.c_str());
-		lua_setfield(L, -2, "liquid_alternative_source");
-		lua_pushnumber(L, c.liquid_viscosity);
-		lua_setfield(L, -2, "liquid_viscosity");
-		lua_pushboolean(L, c.liquid_renewable);
-		lua_setfield(L, -2, "liquid_renewable");
-		lua_pushnumber(L, c.liquid_range);
-		lua_setfield(L, -2, "liquid_range");
-	}
-	lua_pushnumber(L, c.drowning);
-	lua_setfield(L, -2, "drowning");
-	lua_pushboolean(L, c.floodable);
-	lua_setfield(L, -2, "floodable");
-	push_nodebox(L, c.node_box);
-	lua_setfield(L, -2, "node_box");
-	push_nodebox(L, c.selection_box);
-	lua_setfield(L, -2, "selection_box");
-	push_nodebox(L, c.collision_box);
-	lua_setfield(L, -2, "collision_box");
-	lua_newtable(L);
-	push_simplesoundspec(L, c.sound_footstep);
-	lua_setfield(L, -2, "sound_footstep");
-	push_simplesoundspec(L, c.sound_dig);
-	lua_setfield(L, -2, "sound_dig");
-	push_simplesoundspec(L, c.sound_dug);
-	lua_setfield(L, -2, "sound_dug");
-	lua_setfield(L, -2, "sounds");
-	lua_pushboolean(L, c.legacy_facedir_simple);
-	lua_setfield(L, -2, "legacy_facedir_simple");
-	lua_pushboolean(L, c.legacy_wallmounted);
-	lua_setfield(L, -2, "legacy_wallmounted");
-	lua_pushstring(L, c.node_dig_prediction.c_str());
-	lua_setfield(L, -2, "node_dig_prediction");
-	lua_pushnumber(L, c.move_resistance);
-	lua_setfield(L, -2, "move_resistance");
-	lua_pushboolean(L, c.liquid_move_physics);
-	lua_setfield(L, -2, "liquid_move_physics");
-}
-
-void push_content_features_for_sscsm(lua_State *L, const ContentFeatures &c)
-{
-	std::string paramtype = enum_to_string(ScriptApiNode::es_ContentParamType, c.param_type);
-	std::string paramtype2 = enum_to_string(ScriptApiNode::es_ContentParamType2, c.param_type_2);
-	std::string drawtype = enum_to_string(ScriptApiNode::es_DrawType, c.drawtype);
-	std::string liquid_type = enum_to_string(ScriptApiNode::es_LiquidType, c.liquid_type);
-
-	/* Missing "tiles" because TODO. */
-
-	lua_newtable(L);
-	lua_pushboolean(L, c.has_on_construct);
-	lua_setfield(L, -2, "has_on_construct");
-	lua_pushboolean(L, c.has_on_destruct);
-	lua_setfield(L, -2, "has_on_destruct");
-	lua_pushboolean(L, c.has_after_destruct);
-	lua_setfield(L, -2, "has_after_destruct");
-	lua_pushstring(L, c.name.c_str());
-	lua_setfield(L, -2, "name");
-	push_groups(L, c.groups);
-	lua_setfield(L, -2, "groups");
-	lua_pushstring(L, paramtype.c_str());
-	lua_setfield(L, -2, "paramtype");
-	lua_pushstring(L, paramtype2.c_str());
-	lua_setfield(L, -2, "paramtype2");
-	lua_pushstring(L, drawtype.c_str());
-	lua_setfield(L, -2, "drawtype");
-	if (!c.mesh.empty()) {
-		lua_pushstring(L, c.mesh.c_str());
-		lua_setfield(L, -2, "mesh");
-	}
-	// NOTE: c.visuals is filled in by fillNodeVisuals() on the main/render
-	// thread and must not be dereferenced here: this function runs on the
-	// SSCSM environment thread, so minimap_color/palette are left out for now.
-	lua_pushnumber(L, c.visual_scale);
-	lua_setfield(L, -2, "visual_scale");
-	lua_pushnumber(L, c.alpha);
-	lua_setfield(L, -2, "alpha");
-	if (!c.palette_name.empty()) {
-		push_ARGB8(L, c.color);
-		lua_setfield(L, -2, "color");
-
-		lua_pushstring(L, c.palette_name.c_str());
-		lua_setfield(L, -2, "palette_name");
 	}
 	lua_pushnumber(L, c.waving);
 	lua_setfield(L, -2, "waving");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -38,6 +38,14 @@ struct EnumString es_TileAnimationType[] =
 	{0, nullptr},
 };
 
+struct EnumString es_AlignStyle[] =
+{
+	{ALIGN_STYLE_NODE, "node"},
+	{ALIGN_STYLE_WORLD, "world"},
+	{ALIGN_STYLE_USER_DEFINED, "user"},
+	{0, nullptr},
+};
+
 struct EnumString es_ItemType[] =
 {
 	{ITEM_NONE, "none"},
@@ -761,9 +769,7 @@ void push_tile_definition(lua_State *L, const TileDef &def)
 		push_ARGB8(L, def.color);
 		lua_setfield(L, -2, "color");
 	}
-	const char *align_style = def.align_style == ALIGN_STYLE_WORLD ? "world" :
-			def.align_style == ALIGN_STYLE_USER_DEFINED ? "user" : "node";
-	lua_pushstring(L, align_style);
+	lua_pushstring(L, enum_to_string(es_AlignStyle, def.align_style));
 	lua_setfield(L, -2, "align_style");
 	lua_pushnumber(L, def.scale);
 	lua_setfield(L, -2, "scale");

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1252,6 +1252,25 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "liquid_move_physics");
 }
 
+#if CHECK_CLIENT_BUILD()
+/******************************************************************************/
+void push_content_features_sscsm(lua_State *L, const ContentFeaturesSSCSM &c)
+{
+	push_content_features(L, c.cf);
+	// c.cf.visuals is always nullptr, see ContentFeaturesSSCSM
+	// push minimap_color and palette from the fields instead
+	int idx = lua_gettop(L);
+	if (c.had_visuals) {
+		push_ARGB8(L, c.minimap_color);
+		lua_setfield(L, idx, "minimap_color");
+		if (!c.cf.palette_name.empty()) {
+			push_palette(L, &c.palette);
+			lua_setfield(L, idx, "palette");
+		}
+	}
+}
+#endif
+
 /******************************************************************************/
 void push_nodebox(lua_State *L, const NodeBox &box)
 {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -750,7 +750,7 @@ static void push_tile_animation_params(lua_State *L, const TileAnimationParams &
 }
 
 /******************************************************************************/
-void push_tile_definition(lua_State *L, const TileDef &def)
+void push_tiledef(lua_State *L, const TileDef &def)
 {
 	if (def.name.empty()) {
 		lua_pushnil(L);
@@ -1132,7 +1132,7 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	const auto push_tiles = [&](const char *name, const TileDef *tiledefs, size_t count) {
 		lua_createtable(L, count, 0);
 		for (size_t i = 0; i < count; i++) {
-			push_tile_definition(L, tiledefs[i]);
+			push_tiledef(L, tiledefs[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, name);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -65,6 +65,7 @@ extern const std::array<const char *, 36> object_property_keys;
 
 void read_content_features(lua_State *L, ContentFeatures &f, int index);
 void push_content_features(lua_State *L, const ContentFeatures &c);
+void push_content_features_for_sscsm(lua_State *L, const ContentFeatures &c);
 
 void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);
@@ -101,6 +102,7 @@ void read_item_definition(lua_State *L, int index,
 		const ItemDefinition &default_def, ItemDefinition &def);
 void push_item_definition(lua_State *L, const ItemDefinition &i);
 void push_item_definition_full(lua_State *L, const ItemDefinition &i);
+void push_item_definition_for_sscsm(lua_State *L, const ItemDefinition &i);
 
 /// @param fallback set to true if reading from bare entity table (not initial_properties)
 void read_object_properties(lua_State *L, int index,

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -58,6 +58,7 @@ namespace Json { class Value; }
 namespace treegen { struct TreeDef; }
 
 extern struct EnumString es_TileAnimationType[];
+extern struct EnumString es_AlignStyle[];
 extern struct EnumString es_ItemType[];
 extern struct EnumString es_TouchInteractionMode[];
 

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -70,6 +70,7 @@ void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);
 
 TileDef read_tiledef(lua_State *L, int index, u8 drawtype, bool special);
+void push_tile_definition(lua_State *L, const TileDef &def);
 
 void read_simplesoundspec(lua_State *L, int index, SoundSpec &spec);
 NodeBox read_nodebox(lua_State *L, int index);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -65,7 +65,6 @@ extern const std::array<const char *, 36> object_property_keys;
 
 void read_content_features(lua_State *L, ContentFeatures &f, int index);
 void push_content_features(lua_State *L, const ContentFeatures &c);
-void push_content_features_for_sscsm(lua_State *L, const ContentFeatures &c);
 
 void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);
@@ -102,7 +101,6 @@ void read_item_definition(lua_State *L, int index,
 		const ItemDefinition &default_def, ItemDefinition &def);
 void push_item_definition(lua_State *L, const ItemDefinition &i);
 void push_item_definition_full(lua_State *L, const ItemDefinition &i);
-void push_item_definition_for_sscsm(lua_State *L, const ItemDefinition &i);
 
 /// @param fallback set to true if reading from bare entity table (not initial_properties)
 void read_object_properties(lua_State *L, int index,

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <vector>
 #include <array>
 
+#include "config.h"
 #include "irrlichttypes_bloated.h"
 #include "itemgroup.h"
 #include "util/pointabilities.h"
@@ -35,6 +36,9 @@ class ServerActiveObject;
 
 struct CollisionMoveResult;
 struct ContentFeatures;
+#if CHECK_CLIENT_BUILD()
+struct ContentFeaturesSSCSM;
+#endif
 struct DigParams;
 struct EnumString;
 struct FlagDesc;
@@ -66,6 +70,9 @@ extern const std::array<const char *, 36> object_property_keys;
 
 void read_content_features(lua_State *L, ContentFeatures &f, int index);
 void push_content_features(lua_State *L, const ContentFeatures &c);
+#if CHECK_CLIENT_BUILD()
+void push_content_features_sscsm(lua_State *L, const ContentFeaturesSSCSM &c);
+#endif
 
 void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -71,7 +71,7 @@ void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);
 
 TileDef read_tiledef(lua_State *L, int index, u8 drawtype, bool special);
-void push_tile_definition(lua_State *L, const TileDef &def);
+void push_tiledef(lua_State *L, const TileDef &def);
 
 void read_simplesoundspec(lua_State *L, int index, SoundSpec &spec);
 NodeBox read_nodebox(lua_State *L, int index);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -82,11 +82,13 @@ struct EnumString ScriptApiNode::es_NodeBoxType[] =
 		{0, NULL},
 	};
 
+// Should be ordered exactly like enum AlphaMode in nodedef.h
 struct EnumString ScriptApiNode::es_TextureAlphaMode[] =
 	{
-		{ALPHAMODE_OPAQUE, "opaque"},
-		{ALPHAMODE_CLIP, "clip"},
 		{ALPHAMODE_BLEND, "blend"},
+		{ALPHAMODE_CLIP, "clip"},
+		{ALPHAMODE_OPAQUE, "opaque"},
+		{ALPHAMODE_LEGACY_COMPAT, "opaque"},
 		{0, NULL},
 	};
 

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -6,6 +6,109 @@
 
 #include "s_internal.h"
 #include "script/sscsm/sscsm_environment.h"
+#include "script/sscsm/sscsm_requests.h"
+#include "script/common/c_content.h"
+#include "itemdef.h"
+
+void ScriptApiSSCSM::add_itemdefs()
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	infostream << "Adding itemdefs..." << std::endl;
+
+	auto answer = getSSCSMEnv()->doRequest(SSCSMRequestGetItemDefs{});
+
+	lua_newtable(L);
+	int idx_registered_items = lua_gettop(L);
+	lua_newtable(L);
+	int idx_registered_nodes = lua_gettop(L);
+	lua_newtable(L);
+	int idx_registered_tools = lua_gettop(L);
+	lua_newtable(L);
+	int idx_registered_craftitems = lua_gettop(L);
+	lua_newtable(L);
+	int idx_registered_aliases = lua_gettop(L);
+
+	for (const ItemDefinition &item_def : answer.items) {
+		lua_pushstring(L, item_def.name.c_str());
+		int idx_name = lua_gettop(L);
+		push_item_definition_for_sscsm(L, item_def);
+		int idx_def = lua_gettop(L);
+
+		// insert into core.registered_items
+		lua_pushvalue(L, idx_name);
+		lua_pushvalue(L, idx_def);
+		lua_settable(L, idx_registered_items);
+
+		// insert into core.registered_<itemtype>s
+		int idx_defs = idx_registered_items;
+		switch (item_def.type) {
+		case ITEM_NONE:
+			break;
+		case ITEM_NODE:
+			idx_defs = idx_registered_nodes;
+			break;
+		case ITEM_CRAFT:
+			idx_defs = idx_registered_craftitems;
+			break;
+		case ITEM_TOOL:
+			idx_defs = idx_registered_tools;
+			break;
+		default:
+			assert(false);
+			break;
+		}
+		if (idx_defs != idx_registered_items) {
+			lua_pushvalue(L, idx_name);
+			lua_pushvalue(L, idx_def);
+			lua_settable(L, idx_defs);
+		}
+
+		lua_pop(L, 2); // def, name
+	}
+
+	for (const ContentFeatures &node_def : answer.nodes) {
+		lua_pushstring(L, node_def.name.c_str());
+		lua_gettable(L, idx_registered_nodes);
+		if (lua_isnil(L, -1)) {
+			// registered as a node but not as an item (e.g. CONTENT_UNKNOWN);
+			// nothing to merge extra node fields into, skip it
+			lua_pop(L, 1);
+			continue;
+		}
+		int idx_existing = lua_gettop(L);
+
+		push_content_features_for_sscsm(L, node_def);
+		int idx_extra = lua_gettop(L);
+
+		// merge node-only fields into the existing item def table
+		lua_pushnil(L);
+		while (lua_next(L, idx_extra) != 0) {
+			lua_pushvalue(L, -2); // key
+			lua_insert(L, -2); // key, value
+			lua_settable(L, idx_existing);
+		}
+
+		lua_pop(L, 2); // idx_extra, idx_existing
+	}
+
+	//TODO: aliases, name-id mapping
+
+	lua_getglobal(L, "core");
+	lua_pushvalue(L, idx_registered_items);
+	lua_setfield(L, -2, "registered_items");
+	lua_pushvalue(L, idx_registered_nodes);
+	lua_setfield(L, -2, "registered_nodes");
+	lua_pushvalue(L, idx_registered_tools);
+	lua_setfield(L, -2, "registered_tools");
+	lua_pushvalue(L, idx_registered_craftitems);
+	lua_setfield(L, -2, "registered_craftitems");
+	lua_pushvalue(L, idx_registered_aliases);
+	lua_setfield(L, -2, "registered_aliases");
+	lua_pop(L, 1); // core
+
+	// SSCSM client builtin will complete the defs
+}
 
 void ScriptApiSSCSM::load_mods(const std::vector<std::pair<std::string, std::string>> &mods)
 {

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -32,7 +32,7 @@ void ScriptApiSSCSM::add_itemdefs()
 	for (const ItemDefinition &item_def : answer.items) {
 		lua_pushstring(L, item_def.name.c_str());
 		int idx_name = lua_gettop(L);
-		push_item_definition_for_sscsm(L, item_def);
+		push_item_definition_full(L, item_def);
 		int idx_def = lua_gettop(L);
 
 		// insert into core.registered_items
@@ -78,7 +78,7 @@ void ScriptApiSSCSM::add_itemdefs()
 		}
 		int idx_existing = lua_gettop(L);
 
-		push_content_features_for_sscsm(L, node_def);
+		push_content_features(L, node_def);
 		int idx_extra = lua_gettop(L);
 
 		// merge node-only fields into the existing item def table

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -10,7 +10,7 @@
 #include "script/common/c_content.h"
 #include "itemdef.h"
 
-void ScriptApiSSCSM::add_itemdefs()
+void ScriptApiSSCSM::after_content_received()
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -106,8 +106,6 @@ void ScriptApiSSCSM::add_itemdefs()
 	lua_pushvalue(L, idx_registered_aliases);
 	lua_setfield(L, -2, "registered_aliases");
 	lua_pop(L, 1); // core
-
-	// SSCSM client builtin will complete the defs
 }
 
 void ScriptApiSSCSM::load_mods(const std::vector<std::pair<std::string, std::string>> &mods)

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -79,16 +79,8 @@ void ScriptApiSSCSM::after_content_received()
 		}
 		int idx_existing = lua_gettop(L);
 
-		push_content_features(L, node_def.cf);
+		push_content_features_sscsm(L, node_def);
 		int idx_extra = lua_gettop(L);
-		if (node_def.had_visuals) {
-			push_ARGB8(L, node_def.minimap_color);
-			lua_setfield(L, idx_extra, "minimap_color");
-			if (!node_def.cf.palette_name.empty()) {
-				push_palette(L, &node_def.palette);
-				lua_setfield(L, idx_extra, "palette");
-			}
-		}
 
 		// merge node-only fields into the existing item def table
 		lua_pushnil(L);

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -8,6 +8,7 @@
 #include "script/sscsm/sscsm_environment.h"
 #include "script/sscsm/sscsm_requests.h"
 #include "script/common/c_content.h"
+#include "script/common/c_converter.h"
 #include "itemdef.h"
 
 void ScriptApiSSCSM::after_content_received()
@@ -67,8 +68,8 @@ void ScriptApiSSCSM::after_content_received()
 		lua_pop(L, 2); // def, name
 	}
 
-	for (const ContentFeatures &node_def : answer.nodes) {
-		lua_pushstring(L, node_def.name.c_str());
+	for (const ContentFeaturesSSCSM &node_def : answer.nodes) {
+		lua_pushstring(L, node_def.cf.name.c_str());
 		lua_gettable(L, idx_registered_nodes);
 		if (lua_isnil(L, -1)) {
 			// registered as a node but not as an item (e.g. CONTENT_UNKNOWN);
@@ -78,8 +79,16 @@ void ScriptApiSSCSM::after_content_received()
 		}
 		int idx_existing = lua_gettop(L);
 
-		push_content_features(L, node_def);
+		push_content_features(L, node_def.cf);
 		int idx_extra = lua_gettop(L);
+		if (node_def.had_visuals) {
+			push_ARGB8(L, node_def.minimap_color);
+			lua_setfield(L, idx_extra, "minimap_color");
+			if (!node_def.cf.palette_name.empty()) {
+				push_palette(L, &node_def.palette);
+				lua_setfield(L, idx_extra, "palette");
+			}
+		}
 
 		// merge node-only fields into the existing item def table
 		lua_pushnil(L);

--- a/src/script/cpp_api/s_sscsm.h
+++ b/src/script/cpp_api/s_sscsm.h
@@ -9,6 +9,8 @@
 class ScriptApiSSCSM : virtual public ScriptApiBase
 {
 public:
+	void add_itemdefs();
+
 	void load_mods(const std::vector<std::pair<std::string, std::string>> &mods);
 
 	void environment_step(float dtime);

--- a/src/script/cpp_api/s_sscsm.h
+++ b/src/script/cpp_api/s_sscsm.h
@@ -9,7 +9,7 @@
 class ScriptApiSSCSM : virtual public ScriptApiBase
 {
 public:
-	void add_itemdefs();
+	void after_content_received();
 
 	void load_mods(const std::vector<std::pair<std::string, std::string>> &mods);
 

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -28,6 +28,14 @@ struct SSCSMEventUpdateVFSFiles : public ISSCSMEvent
 	}
 };
 
+struct SSCSMEventAddItemdefs : public ISSCSMEvent
+{
+	void exec(SSCSMEnvironment *env) override
+	{
+		env->getScript()->add_itemdefs();
+	}
+};
+
 struct SSCSMEventLoadMods : public ISSCSMEvent
 {
 	// modnames and paths to init.lua file, in load order

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -28,11 +28,11 @@ struct SSCSMEventUpdateVFSFiles : public ISSCSMEvent
 	}
 };
 
-struct SSCSMEventAddItemdefs : public ISSCSMEvent
+struct SSCSMEventAfterContentReceived : public ISSCSMEvent
 {
 	void exec(SSCSMEnvironment *env) override
 	{
-		env->getScript()->add_itemdefs();
+		env->getScript()->after_content_received();
 	}
 };
 

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -126,6 +126,7 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 		client->idef()->getDefinitions(answer.items);
 
 		const NodeDefManager *ndef = client->ndef();
+		answer.nodes.reserve(ndef->size());
 		for (u32 c = 0; c < ndef->size(); c++) {
 			const ContentFeatures &cf = ndef->get(c);
 			answer.nodes.push_back(cf);

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -123,20 +123,12 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 	{
 		Answer answer{};
 
-		std::set<std::string> item_names;
-		client->idef()->getAll(item_names);
-		answer.items.reserve(item_names.size());
-		for (const std::string &name : item_names)
-			answer.items.push_back(client->idef()->get(name));
+		client->idef()->getDefinitions(answer.items);
 
 		const NodeDefManager *ndef = client->ndef();
 		for (u32 c = 0; c < ndef->size(); c++) {
 			const ContentFeatures &cf = ndef->get(c);
-			if (cf.name.empty())
-				continue; // unregistered/removed id
 			answer.nodes.push_back(cf);
-			// null visuals since they're not thread safe to copy
-			answer.nodes.back().visuals = nullptr;
 		}
 
 		return serializeSSCSMAnswer(std::move(answer));

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -10,6 +10,8 @@
 #include "map.h"
 #include "client/client.h"
 #include "log_internal.h"
+#include "itemdef.h"
+#include "nodedef.h"
 
 // Poll the next event (e.g. on_globalstep)
 struct SSCSMRequestPollNextEvent final : public ISSCSMRequest
@@ -102,6 +104,41 @@ struct SSCSMRequestGetNode final : public ISSCSMRequest
 		Answer answer{};
 		answer.node = node;
 		answer.is_pos_ok = is_pos_ok;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// Fetch all currently known item and node definitions, to populate
+// core.registered_items/_nodes/_tools/_craftitems on the SSCSM side.
+// TODO: aliases and the content-id name mapping are not sent yet.
+struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		std::vector<ItemDefinition> items;
+		std::vector<ContentFeatures> nodes;
+	};
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		Answer answer{};
+
+		std::set<std::string> item_names;
+		client->idef()->getAll(item_names);
+		answer.items.reserve(item_names.size());
+		for (const std::string &name : item_names)
+			answer.items.push_back(client->idef()->get(name));
+
+		const NodeDefManager *ndef = client->ndef();
+		for (u32 c = 0; c < ndef->size(); c++) {
+			const ContentFeatures &cf = ndef->get(c);
+			if (cf.name.empty())
+				continue; // unregistered/removed id
+			answer.nodes.push_back(cf);
+			// null visuals since they're not thread safe to copy
+			answer.nodes.back().visuals = nullptr;
+		}
+
 		return serializeSSCSMAnswer(std::move(answer));
 	}
 };

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -116,7 +116,7 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 	struct Answer final : public ISSCSMAnswer
 	{
 		std::vector<ItemDefinition> items;
-		std::vector<ContentFeatures> nodes;
+		std::vector<ContentFeaturesSSCSM> nodes;
 	};
 
 	SerializedSSCSMAnswer exec(Client *client) override
@@ -129,7 +129,7 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 		answer.nodes.reserve(ndef->size());
 		for (u32 c = 0; c < ndef->size(); c++) {
 			const ContentFeatures &cf = ndef->get(c);
-			answer.nodes.push_back(cf);
+			answer.nodes.push_back(cf.copyWithoutVisuals());
 		}
 
 		return serializeSSCSMAnswer(std::move(answer));


### PR DESCRIPTION
### Goal of the PR
Part of the SSCSM roadmap, completes the item/node definition wiring sketched in desour's repo the `sscsm_itemdefs` branch, where ScriptApiSSCSM::add_itemdefs() was a stub. This PR replaces that stub with a working implementation: SSCSM Lua code now sees correctly populated `core.registered_items`, `core.registered_nodes`, `core.registered_tools`, and `core.registered_craftitems` tables, built from the client's actual IItemDefManager/NodeDefManager data.

### How does the PR work?
- `SSCSMRequestGetItemDefs` (new): a request sent from the SSCSM environment thread to the main thread, which gathers every registered item and node def and copies them to the SSCSM thread. Each copied `ContentFeatures` gets its `visuals` pointer nulled right after copying, to avoid a double-free against the live NodeDefManager (was mentioned in a core review)
- `ScriptApiSSCSM::add_itemdefs()`: builds the five Lua tables from that data, merges node-only fields into the corresponding item table entry, and assigns them onto core.
- `push_item_definition_for_sscsm()` / `push_content_features_for_sscsm()`: SSCSM-side counterparts to the existing CPCSM logic
- `Client::afterContentReceived()`: dispatches the new `SSCSMEventAddItemdefs` event once item+node defs are actually available, moved the existing hardcoded `sscsm_test0` preview-mod loading here too 

### Does it resolve any reported issue?
n/a

### Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
SSCSM

### If not a bug fix, why is this PR needed? What usecases does it solve?
SSCSM

### If you have used an LLM/AI to help with code or assets, you must disclose this.
I used Claude code to fill in many of the boiler plate lua stack pushing, and for it to do a code review and catch issues (which is why i switched to u32 instead of u16 in the SSCSMRequestGetItemDefs request), and it caught some other minor bugfixes like using std::move in the right spots.

## To do

This PR is a Ready for Review.

Verify the limitations are fine for now:
- [ ] Aliases and the content-id/name mapping aren't sent yet (following desours orignal scope).
- [ ] A node without a matching `ITEM_NODE`-typed item definition doesn't get a `core.registered_nodes` entry, not sure if it should

## How to test

Enable singleplayer SSCSM, run game, check debug.txt for the sscsm_test0 output:
```
sscsm_test0: loading
sscsm_test0: registered_nodes count: 394
sscsm_test0: air def: { 
```
