### PR TITLE
Use ceiling division for clock resolution

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1153,7 +1153,9 @@ int ScriptApiSecurity::sl_os_setlocale(lua_State *L)
 int ScriptApiSecurity::sl_os_clock(lua_State *L)
 {
 	auto t = clock();
-	t = t - t % (SSCSM_CLOCK_RESOLUTION_US * CLOCKS_PER_SEC / 1'000'000);
+	const clock_t clock_resolution =
+		(SSCSM_CLOCK_RESOLUTION_US * CLOCKS_PER_SEC + 1'000'000 - 1) / 1'000'000;
+	t = t - t % clock_resolution;
 	lua_pushnumber(L, static_cast<lua_Number>(t) / static_cast<lua_Number>(CLOCKS_PER_SEC));
 	return 1;
 }

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1153,7 +1153,7 @@ int ScriptApiSecurity::sl_os_setlocale(lua_State *L)
 int ScriptApiSecurity::sl_os_clock(lua_State *L)
 {
 	auto t = clock();
-	const clock_t clock_resolution =
+	constexpr clock_t clock_resolution =
 		(SSCSM_CLOCK_RESOLUTION_US * CLOCKS_PER_SEC + 1'000'000 - 1) / 1'000'000;
 	t = t - t % clock_resolution;
 	lua_pushnumber(L, static_cast<lua_Number>(t) / static_cast<lua_Number>(CLOCKS_PER_SEC));


### PR DESCRIPTION
closes #17062 

Uses ceiling division to ensure divide by zero doesn't happen.
this is a bug fix

This PR is Ready for Review.

Tested by building and warning is not present.
