### PR TITLE
SSCSM: Add sscsm api for hud elements, mirroring csm api

### DIFF
--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -57,6 +57,13 @@ Functions that take or return paths always use virtual paths.
 * `core.get_node_or_nil(pos)`
 * `core.get_content_id(name)`
 * `core.get_name_from_content_id(id)`
+* `core.hud_add(form)`
+* `core.hud_remove(id)`
+* `core.hud_change(id, stat, data)`
+* `core.hud_get(id)`
+* `core.hud_get_all()`
+  * Shares an id space with client-provided CSM (CPCSM) HUD elements;
+    see `client_lua_api.md`.
 
 
 ### Util API

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -62,8 +62,8 @@ Functions that take or return paths always use virtual paths.
 * `core.hud_change(id, stat, data)`
 * `core.hud_get(id)`
 * `core.hud_get_all()`
-  * Shares an id space with client-provided CSM (CPCSM) HUD elements;
-    see `client_lua_api.md`.
+  * Shares an id space with server-added HUD elements, like the ones added
+    by a server-side mod via `core.hud_add`.
 
 
 ### Util API

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -222,6 +222,79 @@ do
 	end
 	core.after(0, print_nodes)
 end
+
+-- SSCSM hud_* round-trip self-check: add an element, read it back via
+-- hud_get/hud_get_all, and change one stat, logging PASS/FAIL for each step.
+do
+	-- deep-compares only the keys present in `a` (extra keys in `b` are fine);
+	-- numbers use an epsilon since HudElement stores floats that don't
+	-- round-trip exactly through Lua's doubles.
+	local function deep_equal(a, b)
+		if type(a) == "number" and type(b) == "number" then
+			return math.abs(a - b) < 0.0001
+		end
+		if type(a) ~= "table" then
+			return a == b
+		end
+		if type(b) ~= "table" then
+			return false
+		end
+		for k, v in pairs(a) do
+			if not deep_equal(v, b[k]) then
+				return false
+			end
+		end
+		return true
+	end
+
+	local function fields_match(a, b)
+		for k, v in pairs(a) do
+			if not deep_equal(v, b[k]) then
+				return false, k, v, b[k]
+			end
+		end
+		return true
+	end
+
+	local form = {
+		type = "text",
+		position = {x = 0.5, y = 0.1},
+		text = "sscsm_test0 hud",
+		number = 0xffffff,
+	}
+	local id = core.hud_add(form)
+	print(string.format("sscsm_test0: hud_add returned id=%s", tostring(id)))
+
+	local got = core.hud_get(id)
+	local ok, mismatch_key, expected, actual = fields_match(form, got or {})
+	print(string.format("sscsm_test0: hud_get round-trip %s%s",
+			ok and "PASS" or "FAIL",
+			ok and "" or (string.format(" (field: %s, expected: %s, got: %s)",
+					tostring(mismatch_key), dump(expected), dump(actual)))))
+	print(string.format("sscsm_test0: hud_get position (expected: %s, got: %s)",
+			dump(form.position), dump(got and got.position)))
+
+	local all = core.hud_get_all()
+	print(string.format("sscsm_test0: hud_get_all %s (id %s present: %s)",
+			(all ~= nil) and "PASS" or "FAIL", tostring(id), tostring(all[id] ~= nil)))
+
+	local changed = core.hud_change(id, "text", "sscsm_test0 hud changed")
+	local got2 = core.hud_get(id)
+	print(string.format("sscsm_test0: hud_change %s (expected: %s, got: %s)",
+			(changed and got2 and got2.text == "sscsm_test0 hud changed") and "PASS" or "FAIL",
+			dump("sscsm_test0 hud changed"), dump(got2 and got2.text)))
+
+	local removed = core.hud_remove(id)
+	print(string.format("sscsm_test0: hud_remove %s", removed and "PASS" or "FAIL"))
+
+	-- left on screen so hud_add can be visually confirmed
+	core.hud_add({
+		type = "text",
+		position = {x = 0.5, y = 0.2},
+		text = "sscsm_test0 persistent hud",
+		number = 0xffffff,
+	})
+end
 					)=+=");
 
 			m_sscsm_controller->runEvent(this, std::move(event1));

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -224,7 +224,7 @@ do
 end
 
 -- SSCSM hud_* round-trip self-check: add an element, read it back via
--- hud_get/hud_get_all, and change one stat, logging PASS/FAIL for each step.
+-- hud_get/hud_get_all, and change one stat.
 do
 	-- deep-compares only the keys present in `a` (extra keys in `b` are fine);
 	-- numbers use an epsilon since HudElement stores floats that don't
@@ -247,15 +247,6 @@ do
 		return true
 	end
 
-	local function fields_match(a, b)
-		for k, v in pairs(a) do
-			if not deep_equal(v, b[k]) then
-				return false, k, v, b[k]
-			end
-		end
-		return true
-	end
-
 	local form = {
 		type = "text",
 		position = {x = 0.5, y = 0.1},
@@ -263,29 +254,19 @@ do
 		number = 0xffffff,
 	}
 	local id = core.hud_add(form)
-	print(string.format("sscsm_test0: hud_add returned id=%s", tostring(id)))
 
 	local got = core.hud_get(id)
-	local ok, mismatch_key, expected, actual = fields_match(form, got or {})
-	print(string.format("sscsm_test0: hud_get round-trip %s%s",
-			ok and "PASS" or "FAIL",
-			ok and "" or (string.format(" (field: %s, expected: %s, got: %s)",
-					tostring(mismatch_key), dump(expected), dump(actual)))))
-	print(string.format("sscsm_test0: hud_get position (expected: %s, got: %s)",
-			dump(form.position), dump(got and got.position)))
+	assert(deep_equal(form, got or {}))
 
 	local all = core.hud_get_all()
-	print(string.format("sscsm_test0: hud_get_all %s (id %s present: %s)",
-			(all ~= nil) and "PASS" or "FAIL", tostring(id), tostring(all[id] ~= nil)))
+	assert(all and all[id] ~= nil)
 
 	local changed = core.hud_change(id, "text", "sscsm_test0 hud changed")
 	local got2 = core.hud_get(id)
-	print(string.format("sscsm_test0: hud_change %s (expected: %s, got: %s)",
-			(changed and got2 and got2.text == "sscsm_test0 hud changed") and "PASS" or "FAIL",
-			dump("sscsm_test0 hud changed"), dump(got2 and got2.text)))
+	assert(changed and got2 and got2.text == "sscsm_test0 hud changed")
 
 	local removed = core.hud_remove(id)
-	print(string.format("sscsm_test0: hud_remove %s", removed and "PASS" or "FAIL"))
+	assert(removed)
 
 	-- left on screen so hud_add can be visually confirmed
 	core.hud_add({

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2277,8 +2277,8 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 
 	u32 server_id = event->hudadd->server_id;
 	// ignore if we already have a HUD with that ID
-	auto i = m_hud_server_to_client.find(server_id);
-	if (i != m_hud_server_to_client.end()) {
+	auto i = player->hud_server_to_client.find(server_id);
+	if (i != player->hud_server_to_client.end()) {
 		delete event->hudadd;
 		return;
 	}
@@ -2300,7 +2300,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->text2     = event->hudadd->text2;
 	e->style     = event->hudadd->style;
 	e->hideable  = event->hudadd->hideable;
-	m_hud_server_to_client[server_id] = player->hud.add(std::move(e));
+	player->hud_server_to_client[server_id] = player->hud.add(std::move(e));
 
 	delete event->hudadd;
 }
@@ -2309,10 +2309,10 @@ void Game::handleClientEvent_HudRemove(ClientEvent *event, CameraOrientation *ca
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-	auto i = m_hud_server_to_client.find(event->hudrm.id);
-	if (i != m_hud_server_to_client.end()) {
+	auto i = player->hud_server_to_client.find(event->hudrm.id);
+	if (i != player->hud_server_to_client.end()) {
 		player->hud.remove(i->second);
-		m_hud_server_to_client.erase(i);
+		player->hud_server_to_client.erase(i);
 	}
 
 }
@@ -2323,8 +2323,8 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 	HudElement *e = nullptr;
 
-	auto i = m_hud_server_to_client.find(event->hudchange->id);
-	if (i != m_hud_server_to_client.end()) {
+	auto i = player->hud_server_to_client.find(event->hudchange->id);
+	if (i != player->hud_server_to_client.end()) {
 		e = player->hud.get(i->second);
 	}
 

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -337,9 +337,6 @@ private:
 	Minimap *mapper = nullptr;
 	GameFormSpec m_game_formspec;
 
-	// Map server hud ids to client hud ids
-	std::unordered_map<u32, u32> m_hud_server_to_client;
-
 	GameRunData runData;
 	Flags m_flags;
 

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -8,6 +8,7 @@
 #include "constants.h"
 #include "lighting.h"
 #include <string>
+#include <unordered_map>
 
 class Client;
 class ClientActiveObject;
@@ -107,6 +108,9 @@ public:
 	float hurt_tilt_strength = 0.0f;
 
 	PlayerHud csm_hud;
+
+	// Map server hud ids to client hud ids (for `hud` HUD elements)
+	std::unordered_map<u32, u32> hud_server_to_client;
 
 	GenericCAO *getCAO() const { return m_cao; }
 

--- a/src/hud_element.cpp
+++ b/src/hud_element.cpp
@@ -40,6 +40,29 @@ const struct EnumString es_HudElementStat[] =
 	{0, NULL},
 };
 
+void apply_hud_stat(HudElementStat stat, const HudElementStatValue &value, HudElement *elem)
+{
+	switch (stat) {
+		case HUD_STAT_POS:      elem->pos      = std::get<v2f>(value);         break;
+		case HUD_STAT_NAME:     elem->name     = std::get<std::string>(value); break;
+		case HUD_STAT_SCALE:    elem->scale    = std::get<v2f>(value);         break;
+		case HUD_STAT_TEXT:     elem->text     = std::get<std::string>(value); break;
+		case HUD_STAT_NUMBER:   elem->number   = std::get<u32>(value);         break;
+		case HUD_STAT_ITEM:     elem->item     = std::get<u32>(value);         break;
+		case HUD_STAT_DIR:      elem->dir      = std::get<u32>(value);         break;
+		case HUD_STAT_ALIGN:    elem->align    = std::get<v2f>(value);         break;
+		case HUD_STAT_OFFSET:   elem->offset   = std::get<v2f>(value);         break;
+		case HUD_STAT_WORLD_POS: elem->world_pos = std::get<v3f>(value);       break;
+		case HUD_STAT_SIZE:     elem->size     = std::get<v2f>(value);         break;
+		case HUD_STAT_Z_INDEX:  elem->z_index  = std::get<s16>(value);         break;
+		case HUD_STAT_TEXT2:    elem->text2    = std::get<std::string>(value); break;
+		case HUD_STAT_STYLE:    elem->style    = std::get<u32>(value);         break;
+		case HUD_STAT_HIDEABLE: elem->hideable = std::get<bool>(value);        break;
+		case HudElementStat_END:
+			break;
+	}
+}
+
 const struct EnumString es_HudBuiltinElement[] =
 {
 	{HUD_FLAG_HOTBAR_VISIBLE,        "hotbar"},

--- a/src/hud_element.h
+++ b/src/hud_element.h
@@ -7,6 +7,7 @@
 
 #include "irrlichttypes_bloated.h"
 #include <string>
+#include <variant>
 #include "util/enum_string.h"
 
 #define HUD_DIR_LEFT_RIGHT 0
@@ -104,6 +105,12 @@ struct HudElement {
 extern const EnumString es_HudElementType[];
 extern const EnumString es_HudElementStat[];
 extern const EnumString es_HudBuiltinElement[];
+
+// Holds the value of a single HudElement field, as picked out by a HudElementStat.
+using HudElementStatValue = std::variant<v2f, std::string, u32, v3f, s16, bool>;
+
+// Applies a single stat value (as read via read_hud_stat_value) onto a HUD element.
+void apply_hud_stat(HudElementStat stat, const HudElementStatValue &value, HudElement *elem);
 
 // Minimap stuff
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2493,14 +2493,22 @@ void push_hud_element(lua_State *L, HudElement *elem)
 	lua_setfield(L, -2, "hideable");
 }
 
-bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
-		int stat_idx, int data_idx)
+bool read_hud_stat_name(lua_State *L, HudElementStat &stat, int stat_idx)
 {
 	std::string statstr = lua_tostring(L, stat_idx);
 	if (!string_to_enum(es_HudElementStat, stat, statstr)) {
 		script_log_unique(L, "Unknown HUD stat type: " + statstr, warningstream);
 		return false;
 	}
+	return true;
+}
+
+bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
+		int stat_idx, int data_idx)
+{
+	if (!read_hud_stat_name(L, stat, stat_idx))
+		return false;
+	std::string statstr = lua_tostring(L, stat_idx);
 
 	switch (stat) {
 		case HUD_STAT_POS:
@@ -2573,27 +2581,40 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 	return true;
 }
 
-void copy_hud_stat(HudElementStat stat, const HudElement &from, HudElement *to)
+HudElementStatValue read_hud_stat_value(lua_State *L, HudElementStat stat,
+		const std::string &statstr, HudElementType type, int data_idx)
 {
 	switch (stat) {
-		case HUD_STAT_POS:      to->pos      = from.pos;      break;
-		case HUD_STAT_NAME:     to->name     = from.name;     break;
-		case HUD_STAT_SCALE:    to->scale    = from.scale;    break;
-		case HUD_STAT_TEXT:     to->text     = from.text;     break;
-		case HUD_STAT_NUMBER:   to->number   = from.number;   break;
-		case HUD_STAT_ITEM:     to->item     = from.item;     break;
-		case HUD_STAT_DIR:      to->dir      = from.dir;      break;
-		case HUD_STAT_ALIGN:    to->align    = from.align;    break;
-		case HUD_STAT_OFFSET:   to->offset   = from.offset;   break;
-		case HUD_STAT_WORLD_POS: to->world_pos = from.world_pos; break;
-		case HUD_STAT_SIZE:     to->size     = from.size;     break;
-		case HUD_STAT_Z_INDEX:  to->z_index  = from.z_index;  break;
-		case HUD_STAT_TEXT2:    to->text2    = from.text2;    break;
-		case HUD_STAT_STYLE:    to->style    = from.style;    break;
-		case HUD_STAT_HIDEABLE: to->hideable = from.hideable; break;
+		case HUD_STAT_POS:
+		case HUD_STAT_SCALE:
+		case HUD_STAT_ALIGN:
+		case HUD_STAT_OFFSET:
+		case HUD_STAT_SIZE:
+			return read_v2f(L, data_idx);
+		case HUD_STAT_NAME:
+		case HUD_STAT_TEXT:
+		case HUD_STAT_TEXT2:
+			return std::string(luaL_checkstring(L, data_idx));
+		case HUD_STAT_NUMBER:
+		case HUD_STAT_DIR:
+		case HUD_STAT_STYLE:
+			return (u32) luaL_checknumber(L, data_idx);
+		case HUD_STAT_ITEM: {
+			u32 item = luaL_checknumber(L, data_idx);
+			if (type == HUD_ELEM_WAYPOINT && statstr == "precision")
+				item++;
+			return item;
+		}
+		case HUD_STAT_WORLD_POS:
+			return read_v3f(L, data_idx);
+		case HUD_STAT_Z_INDEX:
+			return (s16) MYMAX(S16_MIN, MYMIN(S16_MAX, luaL_checknumber(L, data_idx)));
+		case HUD_STAT_HIDEABLE:
+			return (bool) (lua_isnoneornil(L, data_idx) ? true : lua_toboolean(L, data_idx));
 		case HudElementStat_END:
 			break;
 	}
+	return {};
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2345,14 +2345,14 @@ void push_objectRef(lua_State *L, const u16 id)
 	lua_remove(L, -2); // core
 }
 
-void read_hud_element(lua_State *L, HudElement *elem)
+void read_hud_element(lua_State *L, HudElement *elem, int table_idx)
 {
 	std::string type_string;
-	bool has_type = getstringfield(L, 2, "type", type_string);
+	bool has_type = getstringfield(L, table_idx, "type", type_string);
 
 	// Handle deprecated hud_elem_type
 	std::string deprecated_type_string;
-	if (getstringfield(L, 2, "hud_elem_type", deprecated_type_string)) {
+	if (getstringfield(L, table_idx, "hud_elem_type", deprecated_type_string)) {
 		if (has_type && deprecated_type_string != type_string) {
 			log_deprecated(L, "Ambiguous HUD element fields \"type\" and \"hud_elem_type\", "
 					"\"type\" will be used.", 1, true);
@@ -2370,58 +2370,58 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	else
 		elem->type = HUD_ELEM_TEXT;
 
-	lua_getfield(L, 2, "position");
+	lua_getfield(L, table_idx, "position");
 	elem->pos = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
 	lua_pop(L, 1);
 
-	lua_getfield(L, 2, "scale");
+	lua_getfield(L, table_idx, "scale");
 	elem->scale = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
 	lua_pop(L, 1);
 
-	lua_getfield(L, 2, "size");
+	lua_getfield(L, table_idx, "size");
 	elem->size = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
 	lua_pop(L, 1);
 
-	elem->name    = getstringfield_default(L, 2, "name", "");
-	elem->text    = getstringfield_default(L, 2, "text", "");
-	elem->number  = getintfield_default(L, 2, "number", 0);
+	elem->name    = getstringfield_default(L, table_idx, "name", "");
+	elem->text    = getstringfield_default(L, table_idx, "text", "");
+	elem->number  = getintfield_default(L, table_idx, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT) {
 		// Waypoints reuse the item field to store precision,
 		// item = precision + 1 and item = 0 <=> precision = 10 for backwards compatibility.
-		int precision = getintfield_default(L, 2, "precision", 10);
+		int precision = getintfield_default(L, table_idx, "precision", 10);
 		if (precision < 0)
 			throw LuaError("Waypoint precision must be non-negative");
 		elem->item = precision + 1;
 	} else {
-		elem->item = getintfield_default(L, 2, "item", 0);
+		elem->item = getintfield_default(L, table_idx, "item", 0);
 	}
-	elem->dir     = getintfield_default(L, 2, "direction", 0);
+	elem->dir     = getintfield_default(L, table_idx, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
-			getintfield_default(L, 2, "z_index", 0)));
-	elem->text2   = getstringfield_default(L, 2, "text2", "");
+			getintfield_default(L, table_idx, "z_index", 0)));
+	elem->text2   = getstringfield_default(L, table_idx, "text2", "");
 
 	// Deprecated, only for compatibility's sake
 	if (elem->dir == 0)
-		elem->dir = getintfield_default(L, 2, "dir", 0);
+		elem->dir = getintfield_default(L, table_idx, "dir", 0);
 
-	lua_getfield(L, 2, "alignment");
+	lua_getfield(L, table_idx, "alignment");
 	if (lua_istable(L, -1))
 		elem->align = read_v2f(L, -1);
 	else
 		elem->align = elem->type == HUD_ELEM_INVENTORY ? v2f(1.0f, 1.0f) : v2f();
 	lua_pop(L, 1);
 
-	lua_getfield(L, 2, "offset");
+	lua_getfield(L, table_idx, "offset");
 	elem->offset = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
 	lua_pop(L, 1);
 
-	lua_getfield(L, 2, "world_pos");
+	lua_getfield(L, table_idx, "world_pos");
 	elem->world_pos = lua_istable(L, -1) ? read_v3f(L, -1) : v3f();
 	lua_pop(L, 1);
 
-	elem->style = getintfield_default(L, 2, "style", 0);
+	elem->style = getintfield_default(L, table_idx, "style", 0);
 
-	elem->hideable = getboolfield_default(L, 2, "hideable", true);
+	elem->hideable = getboolfield_default(L, table_idx, "hideable", true);
 
 	/* check for known deprecated element usage */
 	if ((elem->type  == HUD_ELEM_STATBAR) && (elem->size == v2f()))
@@ -2493,9 +2493,10 @@ void push_hud_element(lua_State *L, HudElement *elem)
 	lua_setfield(L, -2, "hideable");
 }
 
-bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value)
+bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
+		int stat_idx, int data_idx)
 {
-	std::string statstr = lua_tostring(L, 3);
+	std::string statstr = lua_tostring(L, stat_idx);
 	if (!string_to_enum(es_HudElementStat, stat, statstr)) {
 		script_log_unique(L, "Unknown HUD stat type: " + statstr, warningstream);
 		return false;
@@ -2503,65 +2504,65 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 
 	switch (stat) {
 		case HUD_STAT_POS:
-			elem->pos = read_v2f(L, 4);
+			elem->pos = read_v2f(L, data_idx);
 			*value = &elem->pos;
 			break;
 		case HUD_STAT_NAME:
-			elem->name = luaL_checkstring(L, 4);
+			elem->name = luaL_checkstring(L, data_idx);
 			*value = &elem->name;
 			break;
 		case HUD_STAT_SCALE:
-			elem->scale = read_v2f(L, 4);
+			elem->scale = read_v2f(L, data_idx);
 			*value = &elem->scale;
 			break;
 		case HUD_STAT_TEXT:
-			elem->text = luaL_checkstring(L, 4);
+			elem->text = luaL_checkstring(L, data_idx);
 			*value = &elem->text;
 			break;
 		case HUD_STAT_NUMBER:
-			elem->number = luaL_checknumber(L, 4);
+			elem->number = luaL_checknumber(L, data_idx);
 			*value = &elem->number;
 			break;
 		case HUD_STAT_ITEM:
-			elem->item = luaL_checknumber(L, 4);
+			elem->item = luaL_checknumber(L, data_idx);
 			if (elem->type == HUD_ELEM_WAYPOINT && statstr == "precision")
 				elem->item++;
 			*value = &elem->item;
 			break;
 		case HUD_STAT_DIR:
-			elem->dir = luaL_checknumber(L, 4);
+			elem->dir = luaL_checknumber(L, data_idx);
 			*value = &elem->dir;
 			break;
 		case HUD_STAT_ALIGN:
-			elem->align = read_v2f(L, 4);
+			elem->align = read_v2f(L, data_idx);
 			*value = &elem->align;
 			break;
 		case HUD_STAT_OFFSET:
-			elem->offset = read_v2f(L, 4);
+			elem->offset = read_v2f(L, data_idx);
 			*value = &elem->offset;
 			break;
 		case HUD_STAT_WORLD_POS:
-			elem->world_pos = read_v3f(L, 4);
+			elem->world_pos = read_v3f(L, data_idx);
 			*value = &elem->world_pos;
 			break;
 		case HUD_STAT_SIZE:
-			elem->size = read_v2f(L, 4);
+			elem->size = read_v2f(L, data_idx);
 			*value = &elem->size;
 			break;
 		case HUD_STAT_Z_INDEX:
-			elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX, luaL_checknumber(L, 4)));
+			elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX, luaL_checknumber(L, data_idx)));
 			*value = &elem->z_index;
 			break;
 		case HUD_STAT_TEXT2:
-			elem->text2 = luaL_checkstring(L, 4);
+			elem->text2 = luaL_checkstring(L, data_idx);
 			*value = &elem->text2;
 			break;
 		case HUD_STAT_STYLE:
-			elem->style = luaL_checknumber(L, 4);
+			elem->style = luaL_checknumber(L, data_idx);
 			*value = &elem->style;
 			break;
 		case HUD_STAT_HIDEABLE:
-			elem->hideable = lua_isnoneornil(L, 4) ? true : lua_toboolean(L, 4);
+			elem->hideable = lua_isnoneornil(L, data_idx) ? true : lua_toboolean(L, data_idx);
 			*value = &elem->hideable;
 			break;
 		case HudElementStat_END:
@@ -2570,6 +2571,29 @@ bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void 
 	}
 
 	return true;
+}
+
+void copy_hud_stat(HudElementStat stat, const HudElement &from, HudElement *to)
+{
+	switch (stat) {
+		case HUD_STAT_POS:      to->pos      = from.pos;      break;
+		case HUD_STAT_NAME:     to->name     = from.name;     break;
+		case HUD_STAT_SCALE:    to->scale    = from.scale;    break;
+		case HUD_STAT_TEXT:     to->text     = from.text;     break;
+		case HUD_STAT_NUMBER:   to->number   = from.number;   break;
+		case HUD_STAT_ITEM:     to->item     = from.item;     break;
+		case HUD_STAT_DIR:      to->dir      = from.dir;      break;
+		case HUD_STAT_ALIGN:    to->align    = from.align;    break;
+		case HUD_STAT_OFFSET:   to->offset   = from.offset;   break;
+		case HUD_STAT_WORLD_POS: to->world_pos = from.world_pos; break;
+		case HUD_STAT_SIZE:     to->size     = from.size;     break;
+		case HUD_STAT_Z_INDEX:  to->z_index  = from.z_index;  break;
+		case HUD_STAT_TEXT2:    to->text2    = from.text2;    break;
+		case HUD_STAT_STYLE:    to->style    = from.style;    break;
+		case HUD_STAT_HIDEABLE: to->hideable = from.hideable; break;
+		case HudElementStat_END:
+			break;
+	}
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -173,7 +173,7 @@ void push_hud_element(lua_State *L, HudElement *elem);
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
 		int stat_idx = 3, int data_idx = 4);
 
-// Applies one stat computed on the SSCSM thread onto the element's main-thread copy.
+// Used to apply one stat computed on the SSCSM thread onto the element's main-thread copy.
 void copy_hud_stat(HudElementStat stat, const HudElement &from, HudElement *to);
 
 void push_collision_move_result(lua_State *L, const CollisionMoveResult &res);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -166,11 +166,15 @@ void push_pointed_thing(lua_State *L, const PointedThing &pointed, bool csm =
 
 void push_objectRef(lua_State *L, const u16 id);
 
-void read_hud_element(lua_State *L, HudElement *elem);
+void read_hud_element(lua_State *L, HudElement *elem, int table_idx = 2);
 
 void push_hud_element(lua_State *L, HudElement *elem);
 
-bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value);
+bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
+		int stat_idx = 3, int data_idx = 4);
+
+// Applies one stat computed on the SSCSM thread onto the element's main-thread copy.
+void copy_hud_stat(HudElementStat stat, const HudElement &from, HudElement *to);
 
 void push_collision_move_result(lua_State *L, const CollisionMoveResult &res);
 

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -173,8 +173,12 @@ void push_hud_element(lua_State *L, HudElement *elem);
 bool read_hud_change(lua_State *L, HudElementStat &stat, HudElement *elem, void **value,
 		int stat_idx = 3, int data_idx = 4);
 
-// Used to apply one stat computed on the SSCSM thread onto the element's main-thread copy.
-void copy_hud_stat(HudElementStat stat, const HudElement &from, HudElement *to);
+// Parses the stat name at stat_idx into a HudElementStat (part 1 of read_hud_change).
+bool read_hud_stat_name(lua_State *L, HudElementStat &stat, int stat_idx);
+
+// Reads the value at data_idx for the given stat, without writing it into an elem.
+HudElementStatValue read_hud_stat_value(lua_State *L, HudElementStat stat,
+		const std::string &statstr, HudElementType type, int data_idx);
 
 void push_collision_move_result(lua_State *L, const CollisionMoveResult &res);
 

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -34,7 +34,7 @@ int ModApiSSCSM::l_get_node_or_nil(lua_State *L)
 // hud_add(form)
 int ModApiSSCSM::l_hud_add(lua_State *L)
 {
-	auto request = SSCSMRequestHudAdd{};
+	SSCSMRequestHudAdd request;
 	read_hud_element(L, &request.elem, 1);
 
 	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
@@ -46,7 +46,7 @@ int ModApiSSCSM::l_hud_add(lua_State *L)
 // hud_remove(id)
 int ModApiSSCSM::l_hud_remove(lua_State *L)
 {
-	auto request = SSCSMRequestHudRemove{};
+	SSCSMRequestHudRemove request;
 	request.id = luaL_checkinteger(L, 1);
 
 	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
@@ -60,7 +60,7 @@ int ModApiSSCSM::l_hud_change(lua_State *L)
 {
 	u32 id = luaL_checkinteger(L, 1);
 
-	auto get_request = SSCSMRequestHudGet{};
+	SSCSMRequestHudGet get_request;
 	get_request.id = id;
 	auto get_answer = getSSCSMEnv(L)->doRequest(std::move(get_request));
 	if (!get_answer.found) {
@@ -77,7 +77,7 @@ int ModApiSSCSM::l_hud_change(lua_State *L)
 		return 1;
 	}
 
-	auto change_request = SSCSMRequestHudChange{};
+	SSCSMRequestHudChange change_request;
 	change_request.id = id;
 	change_request.stat = stat;
 	change_request.value = scratch;
@@ -90,7 +90,7 @@ int ModApiSSCSM::l_hud_change(lua_State *L)
 // hud_get(id)
 int ModApiSSCSM::l_hud_get(lua_State *L)
 {
-	auto request = SSCSMRequestHudGet{};
+	SSCSMRequestHudGet request;
 	request.id = luaL_checkinteger(L, 1);
 
 	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
@@ -109,10 +109,8 @@ int ModApiSSCSM::l_hud_get_all(lua_State *L)
 	auto answer = getSSCSMEnv(L)->doRequest(SSCSMRequestHudGetAll{});
 
 	lua_newtable(L);
-	for (u32 id = 0; id < answer.elems.size(); id++) {
-		if (!answer.elems[id])
-			continue;
-		push_hud_element(L, &*answer.elems[id]);
+	for (auto &[id, elem] : answer.elems) {
+		push_hud_element(L, &elem);
 		lua_rawseti(L, -2, id);
 	}
 	return 1;

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -31,7 +31,99 @@ int ModApiSSCSM::l_get_node_or_nil(lua_State *L)
 	return 1;
 }
 
+// hud_add(form)
+int ModApiSSCSM::l_hud_add(lua_State *L)
+{
+	auto request = SSCSMRequestHudAdd{};
+	read_hud_element(L, &request.elem, 1);
+
+	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
+
+	lua_pushnumber(L, answer.id);
+	return 1;
+}
+
+// hud_remove(id)
+int ModApiSSCSM::l_hud_remove(lua_State *L)
+{
+	auto request = SSCSMRequestHudRemove{};
+	request.id = luaL_checkinteger(L, 1);
+
+	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
+
+	lua_pushboolean(L, answer.ok);
+	return 1;
+}
+
+// hud_change(id, stat, data)
+int ModApiSSCSM::l_hud_change(lua_State *L)
+{
+	u32 id = luaL_checkinteger(L, 1);
+
+	auto get_request = SSCSMRequestHudGet{};
+	get_request.id = id;
+	auto get_answer = getSSCSMEnv(L)->doRequest(std::move(get_request));
+	if (!get_answer.found) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	HudElement scratch = get_answer.elem;
+	HudElementStat stat;
+	void *unused;
+	bool ok = read_hud_change(L, stat, &scratch, &unused, 2, 3);
+	if (!ok) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	auto change_request = SSCSMRequestHudChange{};
+	change_request.id = id;
+	change_request.stat = stat;
+	change_request.value = scratch;
+	auto change_answer = getSSCSMEnv(L)->doRequest(std::move(change_request));
+
+	lua_pushboolean(L, change_answer.ok);
+	return 1;
+}
+
+// hud_get(id)
+int ModApiSSCSM::l_hud_get(lua_State *L)
+{
+	auto request = SSCSMRequestHudGet{};
+	request.id = luaL_checkinteger(L, 1);
+
+	auto answer = getSSCSMEnv(L)->doRequest(std::move(request));
+
+	if (!answer.found) {
+		lua_pushnil(L);
+		return 1;
+	}
+	push_hud_element(L, &answer.elem);
+	return 1;
+}
+
+// hud_get_all()
+int ModApiSSCSM::l_hud_get_all(lua_State *L)
+{
+	auto answer = getSSCSMEnv(L)->doRequest(SSCSMRequestHudGetAll{});
+
+	lua_newtable(L);
+	for (u32 id = 0; id < answer.elems.size(); id++) {
+		if (!answer.elems[id])
+			continue;
+		push_hud_element(L, &*answer.elems[id]);
+		lua_rawseti(L, -2, id);
+	}
+	return 1;
+}
+
 void ModApiSSCSM::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_node_or_nil);
+	API_FCT(hud_add);
+	API_FCT(hud_remove);
+	API_FCT(hud_change);
+	API_FCT(hud_get);
+	API_FCT(hud_get_all);
 }

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -60,6 +60,13 @@ int ModApiSSCSM::l_hud_change(lua_State *L)
 {
 	u32 id = luaL_checkinteger(L, 1);
 
+	HudElementStat stat;
+	if (!read_hud_stat_name(L, stat, 2)) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+	std::string statstr = lua_tostring(L, 2);
+
 	SSCSMRequestHudGet get_request;
 	get_request.id = id;
 	auto get_answer = getSSCSMEnv(L)->doRequest(std::move(get_request));
@@ -68,19 +75,10 @@ int ModApiSSCSM::l_hud_change(lua_State *L)
 		return 1;
 	}
 
-	HudElement scratch = get_answer.elem;
-	HudElementStat stat;
-	void *unused;
-	bool ok = read_hud_change(L, stat, &scratch, &unused, 2, 3);
-	if (!ok) {
-		lua_pushboolean(L, false);
-		return 1;
-	}
-
 	SSCSMRequestHudChange change_request;
 	change_request.id = id;
 	change_request.stat = stat;
-	change_request.value = scratch;
+	change_request.value = read_hud_stat_value(L, stat, statstr, get_answer.elem.type, 3);
 	auto change_answer = getSSCSMEnv(L)->doRequest(std::move(change_request));
 
 	lua_pushboolean(L, change_answer.ok);

--- a/src/script/lua_api/l_sscsm.h
+++ b/src/script/lua_api/l_sscsm.h
@@ -12,6 +12,17 @@ private:
 	// get_node_or_nil(pos)
 	static int l_get_node_or_nil(lua_State *L);
 
+	// hud_add(form)
+	static int l_hud_add(lua_State *L);
+	// hud_remove(id)
+	static int l_hud_remove(lua_State *L);
+	// hud_change(id, stat, data)
+	static int l_hud_change(lua_State *L);
+	// hud_get(id)
+	static int l_hud_get(lua_State *L);
+	// hud_get_all()
+	static int l_hud_get_all(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 };

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -9,7 +9,11 @@
 #include "mapnode.h"
 #include "map.h"
 #include "client/client.h"
+#include "client/localplayer.h"
+#include "hud_element.h"
 #include "log_internal.h"
+#include "script/common/c_content.h"
+#include <optional>
 
 // Poll the next event (e.g. on_globalstep)
 struct SSCSMRequestPollNextEvent final : public ISSCSMRequest
@@ -102,6 +106,117 @@ struct SSCSMRequestGetNode final : public ISSCSMRequest
 		Answer answer{};
 		answer.node = node;
 		answer.is_pos_ok = is_pos_ok;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// core.hud_add(form)
+struct SSCSMRequestHudAdd final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		u32 id;
+	};
+
+	HudElement elem;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+		u32 id = player->csm_hud.add(std::make_unique<HudElement>(std::move(elem)));
+
+		Answer answer{};
+		answer.id = id;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// core.hud_remove(id)
+struct SSCSMRequestHudRemove final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		bool ok;
+	};
+
+	u32 id;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+		Answer answer{};
+		answer.ok = player->csm_hud.remove(id);
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// core.hud_get(id), and step 1 of core.hud_change(id, stat, data)
+struct SSCSMRequestHudGet final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		bool found;
+		HudElement elem;
+	};
+
+	u32 id;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+		HudElement *e = player->csm_hud.get(id);
+
+		Answer answer{};
+		answer.found = (e != nullptr);
+		if (e)
+			answer.elem = *e;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// core.hud_get_all()
+struct SSCSMRequestHudGetAll final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		std::vector<std::optional<HudElement>> elems;
+	};
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+		Answer answer{};
+		for (const auto &e : player->csm_hud.getElements()) {
+			answer.elems.push_back(e ? std::optional<HudElement>(*e) : std::nullopt);
+		}
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};
+
+// Step 2 of core.hud_change: apply the stat computed on the SSCSM thread
+// via read_hud_change against a scratch element onto the main-thread element.
+struct SSCSMRequestHudChange final : public ISSCSMRequest
+{
+	struct Answer final : public ISSCSMAnswer
+	{
+		bool ok;
+	};
+
+	u32 id;
+	HudElementStat stat;
+	HudElement value;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+		HudElement *elem = player->csm_hud.get(id);
+
+		Answer answer{};
+		answer.ok = (elem != nullptr);
+		if (elem)
+			copy_hud_stat(stat, value, elem);
 		return serializeSSCSMAnswer(std::move(answer));
 	}
 };

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -13,7 +13,6 @@
 #include "hud_element.h"
 #include "log_internal.h"
 #include "script/common/c_content.h"
-#include <optional>
 
 // Poll the next event (e.g. on_globalstep)
 struct SSCSMRequestPollNextEvent final : public ISSCSMRequest
@@ -123,7 +122,7 @@ struct SSCSMRequestHudAdd final : public ISSCSMRequest
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
-		u32 id = player->csm_hud.add(std::make_unique<HudElement>(std::move(elem)));
+		u32 id = player->hud.add(std::make_unique<HudElement>(std::move(elem)));
 
 		Answer answer;
 		answer.id = id;
@@ -146,7 +145,7 @@ struct SSCSMRequestHudRemove final : public ISSCSMRequest
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 		Answer answer;
-		answer.ok = player->csm_hud.remove(id);
+		answer.ok = player->hud.remove(id);
 		return serializeSSCSMAnswer(std::move(answer));
 	}
 };
@@ -165,7 +164,7 @@ struct SSCSMRequestHudGet final : public ISSCSMRequest
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
-		HudElement *e = player->csm_hud.get(id);
+		HudElement *e = player->hud.get(id);
 
 		Answer answer;
 		answer.found = (e != nullptr);
@@ -188,7 +187,7 @@ struct SSCSMRequestHudGetAll final : public ISSCSMRequest
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 		Answer answer;
-		const auto &elements = player->csm_hud.getElements();
+		const auto &elements = player->hud.getElements();
 		for (u32 id = 0; id < elements.size(); id++) {
 			if (elements[id])
 				answer.elems.emplace_back(id, *elements[id]);
@@ -213,7 +212,7 @@ struct SSCSMRequestHudChange final : public ISSCSMRequest
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
-		HudElement *elem = player->csm_hud.get(id);
+		HudElement *elem = player->hud.get(id);
 
 		Answer answer;
 		answer.ok = (elem != nullptr);

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -196,8 +196,7 @@ struct SSCSMRequestHudGetAll final : public ISSCSMRequest
 	}
 };
 
-// Step 2 of core.hud_change: apply the stat computed on the SSCSM thread
-// via read_hud_change against a scratch element onto the main-thread element.
+// Step 2 of core.hud_change: apply a stat value read on the SSCSM thread onto the main-thread element.
 struct SSCSMRequestHudChange final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
@@ -207,7 +206,7 @@ struct SSCSMRequestHudChange final : public ISSCSMRequest
 
 	u32 id;
 	HudElementStat stat;
-	HudElement value;
+	HudElementStatValue value;
 
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
@@ -217,7 +216,7 @@ struct SSCSMRequestHudChange final : public ISSCSMRequest
 		Answer answer;
 		answer.ok = (elem != nullptr);
 		if (elem)
-			copy_hud_stat(stat, value, elem);
+			apply_hud_stat(stat, value, elem);
 		return serializeSSCSMAnswer(std::move(answer));
 	}
 };

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -115,7 +115,7 @@ struct SSCSMRequestHudAdd final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
 	{
-		u32 id;
+		u32 id = 0;
 	};
 
 	HudElement elem;
@@ -125,7 +125,7 @@ struct SSCSMRequestHudAdd final : public ISSCSMRequest
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 		u32 id = player->csm_hud.add(std::make_unique<HudElement>(std::move(elem)));
 
-		Answer answer{};
+		Answer answer;
 		answer.id = id;
 		return serializeSSCSMAnswer(std::move(answer));
 	}
@@ -136,7 +136,7 @@ struct SSCSMRequestHudRemove final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
 	{
-		bool ok;
+		bool ok = false;
 	};
 
 	u32 id;
@@ -145,7 +145,7 @@ struct SSCSMRequestHudRemove final : public ISSCSMRequest
 	{
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-		Answer answer{};
+		Answer answer;
 		answer.ok = player->csm_hud.remove(id);
 		return serializeSSCSMAnswer(std::move(answer));
 	}
@@ -156,7 +156,7 @@ struct SSCSMRequestHudGet final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
 	{
-		bool found;
+		bool found = false;
 		HudElement elem;
 	};
 
@@ -167,7 +167,7 @@ struct SSCSMRequestHudGet final : public ISSCSMRequest
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 		HudElement *e = player->csm_hud.get(id);
 
-		Answer answer{};
+		Answer answer;
 		answer.found = (e != nullptr);
 		if (e)
 			answer.elem = *e;
@@ -180,16 +180,18 @@ struct SSCSMRequestHudGetAll final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
 	{
-		std::vector<std::optional<HudElement>> elems;
+		std::vector<std::pair<u32, HudElement>> elems;
 	};
 
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-		Answer answer{};
-		for (const auto &e : player->csm_hud.getElements()) {
-			answer.elems.push_back(e ? std::optional<HudElement>(*e) : std::nullopt);
+		Answer answer;
+		const auto &elements = player->csm_hud.getElements();
+		for (u32 id = 0; id < elements.size(); id++) {
+			if (elements[id])
+				answer.elems.emplace_back(id, *elements[id]);
 		}
 		return serializeSSCSMAnswer(std::move(answer));
 	}
@@ -201,7 +203,7 @@ struct SSCSMRequestHudChange final : public ISSCSMRequest
 {
 	struct Answer final : public ISSCSMAnswer
 	{
-		bool ok;
+		bool ok = false;
 	};
 
 	u32 id;
@@ -213,7 +215,7 @@ struct SSCSMRequestHudChange final : public ISSCSMRequest
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 		HudElement *elem = player->csm_hud.get(id);
 
-		Answer answer{};
+		Answer answer;
 		answer.ok = (elem != nullptr);
 		if (elem)
 			copy_hud_stat(stat, value, elem);


### PR DESCRIPTION
### Goal of the PR



### How does the PR work?

- Changed `read_hud_element` and `read_hud_change` to now take explicit Lua stack indices with defaults matching the old hardcoded 2/3/4 instead of hardcoding them. Existing CSM/server callers are not affected.

- Adds new `copy_hud_stat(stat, from, to)`: applies one stat field from one HudElement onto another, used to move a stat computed on the SSCSM thread onto the real element

- Adds new SSCSM Lua bindings: `core.hud_add(form)`, `core.hud_remove(id)`, `core.hud_change(id, stat, data)`, `core.hud_get(id)`, `core.hud_get_all().`

- `hud_change` works in two round trips: fetch the current element, apply the stat change to a local copy, then send just that one stat back via `copy_hud_stat`.

- Adds new request/answer structs: SSCSMRequestHudAdd, SSCSMRequestHudRemove, SSCSMRequestHudGet, SSCSMRequestHudGetAll, SSCSMRequestHudChange. Each exec()s on the main thread and use the LocalPlayer::csm_hud store


### Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
SSCSM

### If you have used an LLM/AI to help with code or assets, you must disclose this.
Yes, Claude Code was used for many boilerplate work around lua binding as well as doing code review and fixing bugs in my code.

## To do

This PR is a Ready for Review.

## How to test

Run singleplayer with SSCSM enabled for singleplayer.

Two things: 

First observe debug output, should print:
```
sscsm_test0: loading
sscsm_test0: hud_add returned id=0
sscsm_test0: hud_get round-trip PASS
sscsm_test0: hud_get position (expected: {
        x = 0.5,
        y = 0.1,
}, got: {
        x = 0.5,
        y = 0.10000000149011612,
})
sscsm_test0: hud_get_all PASS (id 0 present: true)
sscsm_test0: hud_change PASS (expected: "sscsm_test0 hud changed", got: "sscsm_test0 hud changed")
sscsm_test0: hud_remove PASS
```

Second: In-game should show a simple text added in the top center of the screen:

<img width="1024" height="602" alt="26-07-08-19-00-34-Luanti_5 17 0-dev-unknown_ Singleplayer _ 4 6 0_NV" src="https://github.com/user-attachments/assets/c0d9939c-a6a5-42fe-8be9-24fe24142fc4" />
