### PR TITLE
Initial implimentation of method 0 Zip writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ doc/mkdocs/venv/
 
 ## Build files
 build/
+build-intellisense/
 CMakeFiles
 Makefile
 cmake_install.cmake

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -4,6 +4,7 @@
 
 #include "filesys.h"
 #include "util/string.h"
+#include <algorithm>
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
@@ -21,6 +22,7 @@
 #include <IFileList.h>
 #include <IFileSystem.h>
 #include <IReadFile.h>
+#include <zlib.h>
 #endif
 
 #ifdef _WIN32
@@ -1063,6 +1065,430 @@ bool extractZipFile(io::IFileSystem *fs, const char *filename, const std::string
 		}
 	}
 
+	return true;
+}
+
+struct ZipEntry {
+	std::string path;
+	std::string archive_path;
+	u32 file_size;
+	u32 crc32;
+	u32 header_offset;
+};
+
+static bool writeZipU16(std::ostream &os, u16 value)
+{
+	u8 bytes[2];
+	u8 low = static_cast<u8>(value & 0xFF);
+	u8 high = static_cast<u8>((value >> 8) & 0xFF);
+	bytes[0] = low;
+	bytes[1] = high;
+	os.write(reinterpret_cast<const char *>(bytes), 2);
+	return static_cast<bool>(os);
+}
+
+static bool writeZipU32(std::ostream &os, u32 value)
+{
+	u8 bytes[4];
+	u8 low = static_cast<u8>(value & 0xFF);
+	u8 mid_low = static_cast<u8>((value >> 8) & 0xFF);
+	u8 mid_high = static_cast<u8>((value >> 16) & 0xFF);
+	u8 high = static_cast<u8>((value >> 24) & 0xFF);
+	bytes[0] = low;
+	bytes[1] = mid_low;
+	bytes[2] = mid_high;
+	bytes[3] = high;
+	os.write(reinterpret_cast<const char *>(bytes), 4);
+	return static_cast<bool>(os);
+}
+
+static bool copyZipFileBytes(std::ostream &os, const std::string &filename)
+{
+	auto file = open_ifstream(filename.c_str(), true);
+	if (!file) {
+		warningstream << "fs::createZipFile(): failed to open source file "
+				<< filename << std::endl;
+		return false;
+	}
+
+	char buffer[4096];
+	while (file) {
+		file.read(buffer, sizeof(buffer));
+		std::streamsize bytes_read = file.gcount();
+
+		if (bytes_read > 0)
+			os.write(buffer, bytes_read);
+		if (!os) {
+			warningstream << "fs::createZipFile(): failed to write copy of file "
+					<< filename << std::endl;
+			return false;
+		}
+	}
+
+	if (!file.eof()) {
+		warningstream << "fs::createZipFile(): failed to read file "
+				<< filename << std::endl;
+		return false;
+	}
+	return true;
+}
+
+static bool getZipFileCrc32(const std::string &filename, u32 &out_crc32)
+{
+	auto file = open_ifstream(filename.c_str(), true);
+	if (!file) {
+		warningstream << "fs::createZipFile(): failed to open source file "
+				<< filename << std::endl;
+		return false;
+	}
+
+	uLong crc = crc32(0L, Z_NULL, 0);
+	char buffer[4096];
+	while (file) {
+		file.read(buffer, sizeof(buffer));
+		std::streamsize bytes_read = file.gcount();
+
+		if (bytes_read > 0) {
+			uInt chunk_size = static_cast<uInt>(bytes_read);
+			crc = crc32(crc, reinterpret_cast<const Bytef *>(buffer), chunk_size);
+		}
+	}
+
+	if (!file.eof()) {
+		warningstream << "fs::createZipFile(): failed while reading source file "
+				<< filename << std::endl;
+		return false;
+	}
+	out_crc32 = static_cast<u32>(crc);
+	return true;
+}
+
+static bool getZipFileSize(const std::string &filename, u32 &out_size)
+{
+	auto file = open_ifstream(filename.c_str(), true, std::ios::ate);
+	if (!file) {
+		warningstream << "fs::createZipFile(): failed to open source file "
+				<< filename << std::endl;
+		return false;
+	}
+
+	auto pos = file.tellg();
+	if (pos == std::streampos(-1) || !file) {
+		warningstream << "fs::createZipFile(): failed to determine size of file "
+				<< filename << std::endl;
+		return false;
+	}
+
+	std::streamoff raw_size = pos;
+	if (raw_size < 0) {
+		warningstream << "fs::createZipFile(): failed to determine size of file "
+				<< filename << std::endl;
+		return false;
+	}
+	if (raw_size > U32_MAX) {
+		warningstream << "fs::createZipFile(): file too large for ZIP32 "
+				<< filename << std::endl;
+		return false;
+	}
+
+	out_size = static_cast<u32>(raw_size);
+	return true;
+}
+
+static bool collectZipEntries(
+		const std::string &current_directory,
+		const std::string &archive_prefix,
+		std::vector<ZipEntry> &entries)
+{
+	std::vector<DirListNode> listing = GetDirListing(current_directory);
+	for (const DirListNode &node : listing) {
+		if (node.dir) {
+			const std::string next_directory = current_directory + DIR_DELIM + node.name;
+			const std::string next_prefix = archive_prefix + node.name + "/";
+			if (!collectZipEntries(next_directory, next_prefix, entries))
+				return false;
+		} else {
+			std::string full_path = current_directory + DIR_DELIM + node.name;
+			u32 file_size = 0;
+			if (!getZipFileSize(full_path, file_size))
+				return false;
+
+			u32 crc32 = 0;
+			if (!getZipFileCrc32(full_path, crc32))
+				return false;
+
+			ZipEntry entry;
+			entry.path = full_path;
+			entry.archive_path = archive_prefix + node.name;
+			entry.file_size = file_size;
+			entry.crc32 = crc32;
+			entry.header_offset = 0;
+			entries.push_back(entry);
+		}
+	}
+	return true;
+}
+
+static bool writeZipCentralDirectoryFileHeader(std::ostream &os, const ZipEntry &entry)
+{
+	// Central directory file header signature
+	if (!writeZipU32(os, 0x02014b50))
+		return false;
+	// Version made by
+	if (!writeZipU16(os, 20))
+		return false;
+	// Version needed to extract
+	if (!writeZipU16(os, 20))
+		return false;
+	// General purpose bit flag
+	if (!writeZipU16(os, 0))
+		return false;
+	// Compression method
+	if (!writeZipU16(os, 0))
+		return false;
+	// Last file modification time
+	if (!writeZipU16(os, 0))
+		return false;
+	// Last file modification date, DOS 01/01/1980
+	if (!writeZipU16(os, 0x0021))
+		return false;
+	// Entry CRC32
+	if (!writeZipU32(os, entry.crc32))
+		return false;
+	// Compressed file size
+	if (!writeZipU32(os, entry.file_size))
+		return false;
+	// Uncompressed file size
+	if (!writeZipU32(os, entry.file_size))
+		return false;
+
+	// File name length
+	auto raw_length = entry.archive_path.size();
+	if (raw_length == 0 || raw_length > U16_MAX)
+		return false;
+	u16 filename_length = static_cast<u16>(raw_length);
+	if (!writeZipU16(os, filename_length))
+		return false;
+	// Extra field length
+	if (!writeZipU16(os, 0))
+		return false;
+	// File comment length
+	if (!writeZipU16(os, 0))
+		return false;
+	// Disk number start
+	if (!writeZipU16(os, 0))
+		return false;
+	// Internal file attributes
+	if (!writeZipU16(os, 0))
+		return false;
+	// External file attributes
+	if (!writeZipU32(os, 0))
+		return false;
+	// Relative offset of local header
+	if (!writeZipU32(os, entry.header_offset))
+		return false;
+
+	// File name bytes
+	os.write(entry.archive_path.data(), filename_length);
+	return static_cast<bool>(os);
+}
+
+static bool writeZipEndOfCentralDirectory(std::ostream &os, u16 entry_count,
+		u32 central_directory_size, u32 central_directory_offset)
+{
+	// End of central directory signature
+	if (!writeZipU32(os, 0x06054b50))
+		return false;
+	// Disk number
+	if (!writeZipU16(os, 0))
+		return false;
+	// Central directory start disk
+	if (!writeZipU16(os, 0))
+		return false;
+	// Entries on disk
+	if (!writeZipU16(os, entry_count))
+		return false;
+	// Total entries
+	if (!writeZipU16(os, entry_count))
+		return false;
+	// Central directory size
+	if (!writeZipU32(os, central_directory_size))
+		return false;
+	// Central directory offset
+	if (!writeZipU32(os, central_directory_offset))
+		return false;
+	// Comment length
+	if (!writeZipU16(os, 0))
+		return false;
+
+	return true;
+}
+
+static bool writeZipLocalFileHeader(std::ostream &os, const ZipEntry &entry)
+{
+	// Local file header signature
+	if (!writeZipU32(os, 0x04034b50))
+		return false;
+	// Version needed to extract
+	if (!writeZipU16(os, 20))
+		return false;
+	// General purpose bit flag
+	if (!writeZipU16(os, 0))
+		return false;
+	// Compression method
+	if (!writeZipU16(os, 0))
+		return false;
+	// Last file modification time
+	if (!writeZipU16(os, 0))
+		return false;
+	// Last file modification date, DOS 01/01/1980
+	if (!writeZipU16(os, 0x0021))
+		return false;
+	// CRC32
+	if (!writeZipU32(os, entry.crc32))
+		return false;
+	// Compressed file size
+	if (!writeZipU32(os, entry.file_size))
+		return false;
+	// Uncompressed file size
+	if (!writeZipU32(os, entry.file_size))
+		return false;
+
+	// File name length
+	auto raw_length = entry.archive_path.size();
+	if (raw_length == 0 || raw_length > U16_MAX)
+		return false;
+	u16 filename_length = static_cast<u16>(raw_length);
+	if (!writeZipU16(os, filename_length))
+		return false;
+	// Extra field length
+	if (!writeZipU16(os, 0))
+		return false;
+
+	// File name bytes
+	os.write(entry.archive_path.data(), filename_length);
+	return static_cast<bool>(os);
+}
+
+static bool getZipStreamOffset(std::ostream &os, u32 &out_offset)
+{
+	std::streampos raw_offset = os.tellp();
+	if (raw_offset == std::streampos(-1))
+		return false;
+
+	std::streamoff offset = static_cast<std::streamoff>(raw_offset);
+	if (offset < 0 || offset > U32_MAX)
+		return false;
+
+	out_offset = static_cast<u32>(offset);
+	return true;
+}
+
+bool createZipFile(const std::string &source_dir, const std::string &zipfile)
+{
+	if (!fs::IsDir(source_dir))
+		return false;
+
+	std::vector<ZipEntry> entries;
+	if (!collectZipEntries(source_dir, "", entries))
+		return false;
+
+	std::size_t raw_entry_count = entries.size();
+	if (raw_entry_count > U16_MAX)
+		return false;
+	u16 entry_count = static_cast<u16>(raw_entry_count);
+
+	std::sort(entries.begin(), entries.end(),
+			[](const ZipEntry &a, const ZipEntry &b) {
+				return a.archive_path < b.archive_path;
+			});
+
+	auto os = open_ofstream(zipfile.c_str(), true);
+	if (!os) {
+		warningstream << "fs::createZipFile(): failed to open output stream for "
+				<< zipfile << std::endl;
+		return false;
+	}
+
+	for (ZipEntry &entry : entries) {
+		u32 header_offset = 0;
+		if (!getZipStreamOffset(os, header_offset)) {
+			warningstream << "fs::createZipFile(): failed to obtain stream offset for "
+					<< entry.path << std::endl;
+			os.close();
+			remove(zipfile.c_str());
+			return false;
+		}
+		entry.header_offset = header_offset;
+
+		if (!writeZipLocalFileHeader(os, entry)) {
+			warningstream << "fs::createZipFile(): failed to write local file header for "
+					<< zipfile << std::endl;
+			os.close();
+			remove(zipfile.c_str());
+			return false;
+		}
+		if (!copyZipFileBytes(os, entry.path)) {
+			warningstream << "fs::createZipFile(): failed to write file data for "
+					<< zipfile << std::endl;
+			os.close();
+			remove(zipfile.c_str());
+			return false;
+		}
+	}
+
+	u32 central_directory_offset = 0;
+	if (!getZipStreamOffset(os, central_directory_offset)) {
+		warningstream << "fs::createZipFile(): failed to obtain central directory offset for "
+				<< zipfile << std::endl;
+		os.close();
+		remove(zipfile.c_str());
+		return false;
+	}
+
+	for (const ZipEntry &entry : entries) {
+		if (!writeZipCentralDirectoryFileHeader(os, entry)) {
+			warningstream << "fs::createZipFile(): failed to write central directory header for "
+					<< zipfile << std::endl;
+			os.close();
+			remove(zipfile.c_str());
+			return false;
+		}
+	}
+
+	u32 central_directory_end = 0;
+	if (!getZipStreamOffset(os, central_directory_end)) {
+		warningstream << "fs::createZipFile(): failed to obtain central directory end offset for "
+				<< zipfile << std::endl;
+		os.close();
+		remove(zipfile.c_str());
+		return false;
+	}
+	if (central_directory_end < central_directory_offset) {
+		warningstream << "fs::createZipFile(): invalid central directory offsets for "
+				<< zipfile << std::endl;
+		os.close();
+		remove(zipfile.c_str());
+		return false;
+	}
+
+	u32 central_directory_size = central_directory_end - central_directory_offset;
+	if (!writeZipEndOfCentralDirectory(os, entry_count, central_directory_size,
+			central_directory_offset)) {
+		warningstream << "fs::createZipFile(): failed to write end of central directory for "
+				<< zipfile << std::endl;
+		os.close();
+		remove(zipfile.c_str());
+		return false;
+	}
+
+	os.close();
+	if (!os) {
+		warningstream << "fs::createZipFile(): failed on closing output stream for "
+				<< zipfile << std::endl;
+		remove(zipfile.c_str());
+		return false;
+	}
 	return true;
 }
 #endif

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -156,6 +156,8 @@ bool safeWriteToFile(const std::string &path, std::string_view content);
 
 #if IS_CLIENT_BUILD
 bool extractZipFile(io::IFileSystem *fs, const char *filename, const std::string &destination);
+
+bool createZipFile(const std::string &source_dir, const std::string &zipfile);
 #endif
 
 bool ReadFile(const std::string &path, std::string &out, bool log_error = false);

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -32,6 +32,10 @@ public:
 	void testNonExist();
 	void testRecursiveDelete();
 	void testGetRecursiveSubPaths();
+
+#if CHECK_CLIENT_BUILD()
+	void testWriteZipFile();
+#endif
 };
 
 static TestFileSys g_test_instance;
@@ -50,6 +54,10 @@ void TestFileSys::runTests(IGameDef *gamedef)
 	TEST(testNonExist);
 	TEST(testRecursiveDelete);
 	TEST(testGetRecursiveSubPaths);
+
+#if CHECK_CLIENT_BUILD()
+	TEST(testWriteZipFile);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,7 +158,6 @@ void TestFileSys::testPathStartsWith()
 	}
 }
 
-
 void TestFileSys::testMakePathRelativeTo()
 {
 	const auto dir_path = getTestTempDirectory() + DIR_DELIM "testMakePathRelativeToTestDir";
@@ -209,7 +216,6 @@ void TestFileSys::testMakePathRelativeTo()
 	UASSERTEQ(auto, rel("d1/../d1/d2/", "d1"), p("d2"));
 }
 
-
 void TestFileSys::testRemoveLastPathComponent()
 {
 	std::string path, result, removed;
@@ -265,7 +271,6 @@ void TestFileSys::testRemoveLastPathComponent()
 #endif
 }
 
-
 void TestFileSys::testRemoveLastPathComponentWithTrailingDelimiter()
 {
 	std::string path, result, removed;
@@ -297,7 +302,6 @@ void TestFileSys::testRemoveLastPathComponentWithTrailingDelimiter()
 	UASSERT(removed == p("home/user/minetest/bin/../worlds/world1"));
 }
 
-
 void TestFileSys::testRemoveRelativePathComponent()
 {
 	std::string path, result;
@@ -324,7 +328,6 @@ void TestFileSys::testRemoveRelativePathComponent()
 	result = fs::RemoveRelativePathComponents(path);
 	UASSERT(result == p("/a/e"));
 }
-
 
 void TestFileSys::testAbsolutePath()
 {
@@ -367,7 +370,6 @@ void TestFileSys::testAbsolutePath()
 	// or with an empty path
 	UASSERTEQ(auto, fs::AbsolutePathPartial(""), "");
 }
-
 
 void TestFileSys::testSafeWriteToFile()
 {
@@ -427,6 +429,127 @@ void TestFileSys::testCopyFileContents()
 	UASSERT(fs::ReadFile(file2, contents_actual));
 	UASSERTEQ(auto, contents_actual, test_data);
 }
+
+#if CHECK_CLIENT_BUILD()
+void TestFileSys::testWriteZipFile()
+{
+	const auto dir_path = getTestTempDirectory() + DIR_DELIM "ziptest";
+	const auto nested_dir = dir_path + DIR_DELIM "sub";
+	UASSERT(fs::CreateAllDirs(nested_dir));
+
+	const std::string top_level_data = "hello";
+	const std::string nested_data = "nested data";
+
+	const auto top_level_file = dir_path + DIR_DELIM "file.txt";
+	{
+		auto os = open_ofstream(top_level_file.c_str(), false);
+		UASSERT(os.good());
+		os.write(top_level_data.data(), top_level_data.size());
+		UASSERT(os.good());
+	}
+
+	const auto nested_file = nested_dir + DIR_DELIM "nested.txt";
+	{
+		auto os = open_ofstream(nested_file.c_str(), false);
+		UASSERT(os.good());
+		os.write(nested_data.data(), nested_data.size());
+		UASSERT(os.good());
+	}
+
+	const auto zip_path = getTestTempFile();
+	UASSERT(fs::createZipFile(dir_path, zip_path));
+	UASSERT(fs::IsFile(zip_path));
+
+	std::string contents;
+	UASSERT(fs::ReadFile(zip_path, contents));
+
+	size_t position = 0;
+	auto read_u16 = [&]() -> u16 {
+		UASSERT(position + 2 <= contents.size());
+		u16 value = static_cast<u8>(contents[position]) |
+				(static_cast<u16>(static_cast<u8>(contents[position + 1])) << 8);
+		position += 2;
+		return value;
+	};
+	auto read_u32 = [&]() -> u32 {
+		UASSERT(position + 4 <= contents.size());
+		u32 value = static_cast<u8>(contents[position]) |
+				(static_cast<u32>(static_cast<u8>(contents[position + 1])) << 8) |
+				(static_cast<u32>(static_cast<u8>(contents[position + 2])) << 16) |
+				(static_cast<u32>(static_cast<u8>(contents[position + 3])) << 24);
+		position += 4;
+		return value;
+	};
+	auto read_string = [&](size_t length) {
+		UASSERT(position + length <= contents.size());
+		std::string value = contents.substr(position, length);
+		position += length;
+		return value;
+	};
+
+	auto expect_local_file = [&](const std::string &archive_path,
+			const std::string &file_data, u32 crc32, size_t expected_offset) {
+		UASSERTEQ(size_t, position, expected_offset);
+		UASSERTEQ(u32, read_u32(), 0x04034b50);
+		UASSERTEQ(u16, read_u16(), 20);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0x0021);
+		UASSERTEQ(u32, read_u32(), crc32);
+		UASSERTEQ(u32, read_u32(), static_cast<u32>(file_data.size()));
+		UASSERTEQ(u32, read_u32(), static_cast<u32>(file_data.size()));
+		UASSERTEQ(u16, read_u16(), static_cast<u16>(archive_path.size()));
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(auto, read_string(archive_path.size()), archive_path);
+		UASSERTEQ(auto, read_string(file_data.size()), file_data);
+	};
+
+	auto expect_central_directory_entry = [&](const std::string &archive_path,
+			const std::string &file_data, u32 crc32, u32 local_header_offset) {
+		UASSERTEQ(u32, read_u32(), 0x02014b50);
+		UASSERTEQ(u16, read_u16(), 20);
+		UASSERTEQ(u16, read_u16(), 20);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0x0021);
+		UASSERTEQ(u32, read_u32(), crc32);
+		UASSERTEQ(u32, read_u32(), static_cast<u32>(file_data.size()));
+		UASSERTEQ(u32, read_u32(), static_cast<u32>(file_data.size()));
+		UASSERTEQ(u16, read_u16(), static_cast<u16>(archive_path.size()));
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u16, read_u16(), 0);
+		UASSERTEQ(u32, read_u32(), 0);
+		UASSERTEQ(u32, read_u32(), local_header_offset);
+		UASSERTEQ(auto, read_string(archive_path.size()), archive_path);
+	};
+
+	// createZipFile sorts entries by archive path before writing.
+	expect_local_file("file.txt", top_level_data, 0x3610a686, 0);
+	expect_local_file("sub/nested.txt", nested_data, 0xb8428ee9, 43);
+
+	const size_t central_directory_offset = position;
+	expect_central_directory_entry("file.txt", top_level_data, 0x3610a686, 0);
+	expect_central_directory_entry("sub/nested.txt", nested_data, 0xb8428ee9, 43);
+	const u32 central_directory_size = static_cast<u32>(position - central_directory_offset);
+
+	UASSERTEQ(u32, read_u32(), 0x06054b50);
+	UASSERTEQ(u16, read_u16(), 0);
+	UASSERTEQ(u16, read_u16(), 0);
+	UASSERTEQ(u16, read_u16(), 2);
+	UASSERTEQ(u16, read_u16(), 2);
+	UASSERTEQ(u32, read_u32(), central_directory_size);
+	UASSERTEQ(u32, read_u32(), static_cast<u32>(central_directory_offset));
+	UASSERTEQ(u16, read_u16(), 0);
+	UASSERTEQ(size_t, position, contents.size());
+
+	fs::DeleteSingleFileOrEmptyDirectory(zip_path);
+	fs::RecursiveDelete(dir_path);
+}
+#endif
 
 void TestFileSys::testNonExist()
 {


### PR DESCRIPTION
## Goal

Add a content-agnostic ZIP writer that can be used as the foundation for exporting worlds.

## How it works

The new `fs::createZipFile()` helper:

* Recursively collects files from a source directory.
* Sorts archive paths for deterministic output.
* Writes ZIP32 archives using the Store method without compression.
* Writes local file headers, file contents, central-directory records, and the End of Central Directory record.
* Removes partially written archives when writing fails.

Compression, ZIP64, world-export UI, and import handling are outside the scope of this PR.

## Related issue

This is directly related to #10600 .

It implements the ZIP-writing foundation required for exporting worlds. The main-menu export controls and the remaining import/export workflow can be added separately.

## Roadmap

This does not directly implement a listed roadmap goal. It supports the future world-export UI requested in #10600.

## Why this is needed

Luanti currently has ZIP extraction support but no equivalent helper for creating ZIP archives.

A general filesystem ZIP writer avoids coupling archive generation directly to the main menu or world-management code and provides a reusable base for world export.

## AI disclosure

AI was used to review the implementation, explain parts of the ZIP format, and help draft the unit test. The production implementation was written and tested manually.

## To do

This PR is a Work in Progress.

* [x] Implement recursive ZIP32 Store archive writing
* [x] Add a unit test covering nested files and ZIP structure
* [ ] Confirm the helper API and PR scope with maintainers

## How to test

bin\RelWithDebInfo\luanti.exe --run-unittests --test-module TestFileSys

The `testWriteZipFile` test creates top-level and nested source files, writes an archive, and verifies the local headers, file contents, central directory, offsets, CRCs, and EOCD.

