### PR TITLE
IrrlichtMt: Add CBatchDraw2D to reduce draw calls

### DIFF
--- a/irr/include/CBatchDraw2D.h
+++ b/irr/include/CBatchDraw2D.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 SmallJoker <mk939@ymail.com>
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#pragma once
+
+#include "rect.h"
+#include "SColor.h"
+#include <vector>
+
+namespace video
+{
+
+class IVideoDriver;
+class SMaterial;
+struct S3DVertex;
+
+class CBatchDraw2D
+{
+public:
+	/// Amount of shapes to pre-allocate.
+	CBatchDraw2D(size_t nLines, size_t nRectsFilled);
+
+	void reset();
+
+	void addRectangle(bool filled, video::SColor color, const core::rect<s32> &rect);
+
+	/// `clip` and `material` are optional
+	void draw(IVideoDriver *driver, bool trianglesFirst,
+			const core::rect<s32> *clip, const video::SMaterial *material);
+
+private:
+	std::vector<video::S3DVertex> Vertices;
+	std::vector<u16> IndicesLines, IndicesTriangles;
+};
+
+}

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -502,9 +502,8 @@ public:
 	\param iType Index type, e.g. video::EIT_16BIT for 16bit indices. */
 	virtual void draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 			const void *indexList, u32 primCount,
-			E_VERTEX_TYPE vType = EVT_STANDARD,
-			scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES,
-			E_INDEX_TYPE iType = EIT_16BIT) = 0;
+			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+			const core::rect<s32> *clipRect = nullptr) = 0;
 
 	//! Draws an indexed triangle list.
 	/** Note that there may be at maximum 65536 vertices, because

--- a/irr/src/CBatchDraw2D.cpp
+++ b/irr/src/CBatchDraw2D.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SmallJoker <mk939@ymail.com>
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "CBatchDraw2D.h"
+
+#include "IVideoDriver.h"
+#include "S3DVertex.h"
+
+namespace video {
+
+/// Amount of shapes to pre-allocate.
+CBatchDraw2D::CBatchDraw2D(size_t nLines, size_t nRectsFilled)
+{
+	IndicesLines.reserve(nLines * 2);
+	IndicesTriangles.reserve(nRectsFilled * 6);
+
+	Vertices.reserve(nLines * 2 + nRectsFilled * 4);
+
+	assert(Vertices.capacity() <= UINT16_MAX); // video::EIT_16BIT check
+}
+
+void CBatchDraw2D::reset()
+{
+	IndicesLines.clear();
+	IndicesTriangles.clear();
+	Vertices.clear();
+}
+
+void CBatchDraw2D::addRectangle(bool filled, video::SColor color, const core::rect<s32> &rect)
+{
+	const u16 prev_i = (u16)Vertices.size();
+	if (filled) {
+		for (u16 i : { 0,1,2, 0,2,3 })
+			IndicesTriangles.emplace_back(prev_i + i);
+	} else {
+		for (u16 i : { 0,1, 1,2, 2,3, 3,0 })
+			IndicesLines.emplace_back(prev_i + i);
+	}
+
+	/*
+		Winding order: GL_CW
+		0 --- 1
+		|     |
+		3 --- 2
+	*/
+	const auto min = rect.UpperLeftCorner;
+	const auto max = rect.LowerRightCorner;
+	Vertices.emplace_back(min.X, min.Y - 0.5f, 4, 0,0,0, color, 0,0);
+	Vertices.emplace_back(max.X, min.Y - 0.5f, 4, 0,0,0, color, 1,0);
+	Vertices.emplace_back(max.X, max.Y - 0.0f, 4, 0,0,0, color, 1,1);
+	Vertices.emplace_back(min.X, max.Y - 0.0f, 4, 0,0,0, color, 0,1);
+}
+
+void CBatchDraw2D::draw(IVideoDriver *driver, bool trianglesFirst,
+		const core::rect<s32> *clip, const video::SMaterial *material)
+{
+	video::SMaterial mat;
+	if (material) {
+		mat = *material;
+	} else {
+		mat = driver->getMaterial2D();
+		mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+	}
+	driver->setMaterial(mat);
+
+	for (int i = 0; i < 2; ++i) {
+		if (trianglesFirst) {
+			driver->draw2DVertexPrimitiveList(
+				Vertices.data(), Vertices.size(),
+				IndicesTriangles.data(), IndicesTriangles.size() / 3,
+				video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT,
+				clip
+			);
+		} else {
+			driver->draw2DVertexPrimitiveList(
+				Vertices.data(), Vertices.size(),
+				IndicesLines.data(), IndicesLines.size() / 2,
+				video::EVT_STANDARD, scene::EPT_LINES, video::EIT_16BIT,
+				clip
+			);
+		}
+		trianglesFirst ^= true; // draw the other shape next
+	}
+}
+
+} // video

--- a/irr/src/CGUISkin.cpp
+++ b/irr/src/CGUISkin.cpp
@@ -6,6 +6,7 @@
 
 #include "CGUISkin.h"
 
+#include "CBatchDraw2D.h"
 #include "IGUIFont.h"
 #include "IGUISpriteBank.h"
 #include "IGUIElement.h"
@@ -296,20 +297,22 @@ void CGUISkin::drawColored3DButtonPaneStandard(IGUIElement* element,
 
 	core::rect<s32> rect = r;
 
-	Driver->draw2DRectangle(colors[EGDC_3D_DARK_SHADOW], rect, clip);
+	video::CBatchDraw2D batch(0, 4);
+	batch.addRectangle(true, colors[EGDC_3D_DARK_SHADOW], rect);
 
 	rect.LowerRightCorner.X -= 1;
 	rect.LowerRightCorner.Y -= 1;
-	Driver->draw2DRectangle(colors[EGDC_3D_HIGH_LIGHT], rect, clip);
+	batch.addRectangle(true, colors[EGDC_3D_HIGH_LIGHT], rect);
 
 	rect.UpperLeftCorner.X += 1;
 	rect.UpperLeftCorner.Y += 1;
-	Driver->draw2DRectangle(colors[EGDC_3D_SHADOW], rect, clip);
+	batch.addRectangle(true, colors[EGDC_3D_SHADOW], rect);
 
 	rect.LowerRightCorner.X -= 1;
 	rect.LowerRightCorner.Y -= 1;
+	batch.addRectangle(true, colors[EGDC_3D_FACE], rect);
 
-	Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
+	batch.draw(Driver, true, clip, nullptr);
 }
 // END PATCH
 

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -462,6 +462,7 @@ add_library(IrrlichtMt STATIC
 	CSceneManager.h
 	CMeshCache.h
 
+	CBatchDraw2D.cpp
 	CBillboardSceneNode.cpp
 	CCameraSceneNode.cpp
 	CDummyTransformationSceneNode.cpp

--- a/irr/src/CNullDriver.cpp
+++ b/irr/src/CNullDriver.cpp
@@ -573,7 +573,10 @@ void CNullDriver::drawVertexPrimitiveList(const void *vertices, u32 vertexCount,
 }
 
 //! draws a vertex primitive list in 2d
-void CNullDriver::draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount, const void *indexList, u32 primitiveCount, E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType)
+void CNullDriver::draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
+		const void *indexList, u32 primitiveCount,
+		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+		const core::rect<s32> *clipRect)
 {
 	if ((iType == EIT_16BIT) && (vertexCount > 65536))
 		os::Printer::log("Too many vertices for 16bit index type, render artifacts may occur.");

--- a/irr/src/CNullDriver.h
+++ b/irr/src/CNullDriver.h
@@ -120,8 +120,8 @@ public:
 	//! draws a vertex primitive list in 2d
 	virtual void draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 			const void *indexList, u32 primitiveCount,
-			E_VERTEX_TYPE vType = EVT_STANDARD, scene::E_PRIMITIVE_TYPE pType = scene::EPT_TRIANGLES,
-			E_INDEX_TYPE iType = EIT_16BIT) override;
+			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+			const core::rect<s32> *clipRect = nullptr) override;
 
 	//! Draws a 3d line.
 	virtual void draw3DLine(const core::vector3df &start,

--- a/irr/src/COpenGLDriver.cpp
+++ b/irr/src/COpenGLDriver.cpp
@@ -825,12 +825,16 @@ void COpenGLDriver::renderArray(const void *indexList, u32 primitiveCount,
 //! draws a vertex primitive list in 2d
 void COpenGLDriver::draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 		const void *indexList, u32 primitiveCount,
-		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType)
+		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+		const core::rect<s32> *clipRect)
 {
 	if (!primitiveCount || !vertexCount)
 		return;
 
 	if (!checkPrimitiveCount(primitiveCount))
+		return;
+
+	if (clipRect && !clipRect->isValid())
 		return;
 
 	CNullDriver::draw2DVertexPrimitiveList(vertices, vertexCount, indexList, primitiveCount, vType, pType, iType);
@@ -928,7 +932,22 @@ void COpenGLDriver::draw2DVertexPrimitiveList(const void *vertices, u32 vertexCo
 		break;
 	}
 
+
+	if (clipRect) {
+		const core::dimension2d<u32> &targetSize = getCurrentRenderTargetSize();
+
+		glEnable(GL_SCISSOR_TEST);
+		glScissor(
+			clipRect->UpperLeftCorner.X,
+			targetSize.Height - clipRect->LowerRightCorner.Y,
+			clipRect->getWidth(), clipRect->getHeight()
+		);
+	}
+
 	renderArray(indexList, primitiveCount, pType, iType);
+
+	if (clipRect)
+		glDisable(GL_SCISSOR_TEST);
 
 	if (Feature.MaxTextureUnits > 0) {
 		if ((vType != EVT_STANDARD) || CacheHandler->getTextureCache()[1]) {

--- a/irr/src/COpenGLDriver.h
+++ b/irr/src/COpenGLDriver.h
@@ -104,7 +104,8 @@ public:
 	//! draws a vertex primitive list in 2d
 	virtual void draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 			const void *indexList, u32 primitiveCount,
-			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
+			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+			const core::rect<s32> *clipRect = nullptr) override;
 
 	//! queries the features of the driver, returns true if feature is available
 	bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -689,7 +689,8 @@ void COpenGL3DriverBase::drawVertexPrimitiveList(const void *vertices, u32 verte
 //! draws a vertex primitive list in 2d
 void COpenGL3DriverBase::draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 		const void *indexList, u32 primitiveCount,
-		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType)
+		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+		const core::rect<s32> *clipRect)
 {
 	if (!primitiveCount || !vertexCount)
 		return;
@@ -700,6 +701,9 @@ void COpenGL3DriverBase::draw2DVertexPrimitiveList(const void *vertices, u32 ver
 	if (!checkPrimitiveCount(primitiveCount))
 		return;
 
+	if (clipRect && !clipRect->isValid())
+		return;
+
 	CNullDriver::draw2DVertexPrimitiveList(vertices, vertexCount, indexList, primitiveCount, vType, pType, iType);
 
 	setRenderStates2DMode(
@@ -708,7 +712,21 @@ void COpenGL3DriverBase::draw2DVertexPrimitiveList(const void *vertices, u32 ver
 		Material.MaterialType == EMT_TRANSPARENT_ALPHA_CHANNEL
 	);
 
+	if (clipRect) {
+		const core::dimension2d<u32> &targetSize = getCurrentRenderTargetSize();
+
+		GL.Enable(GL_SCISSOR_TEST);
+		GL.Scissor(
+			clipRect->UpperLeftCorner.X, targetSize.Height - clipRect->LowerRightCorner.Y,
+			clipRect->getWidth(), clipRect->getHeight()
+		);
+	}
+
 	drawGeneric(vertices, indexList, primitiveCount, vType, pType, iType);
+
+	if (clipRect)
+		GL.Disable(GL_SCISSOR_TEST);
+	TEST_GL_ERROR(this);
 }
 
 void COpenGL3DriverBase::draw2DImage(const video::ITexture *texture, const core::position2d<s32> &destPos,

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -75,7 +75,8 @@ public:
 	//! draws a vertex primitive list in 2d
 	virtual void draw2DVertexPrimitiveList(const void *vertices, u32 vertexCount,
 			const void *indexList, u32 primitiveCount,
-			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
+			E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType,
+			const core::rect<s32> *clipRect = nullptr) override;
 
 	//! queries the features of the driver, returns true if feature is available
 	bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override


### PR DESCRIPTION
PoC class with demo in 'CGUISkin::drawColored3DButtonPaneStandard'

Depending on the progress / concept approval here, I will update #17332 accordingly.

## To do

This PR is Ready for Review.

## How to test

1. Have a build from `master`
2. Take a screenshot of the main menu buttons (full-screen)
3. Build with this PR
4. Take another screenshot and overlay them in GIMP to check for pixel-perfectness
5. Join devtest, `/test_formspec`, `NoClip` tab. The left side must all be clipped.
6. Compare `opengl3` and `opengl` drivers
