### PR TITLE
Main menu: Make render info text copyable (closes #16953)

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -83,8 +83,8 @@ return {
 		hypertext = table.concat(hypertext):sub(1, -2)
 
 		local fs = "image[1.5,0.6;2.5,2.5;" .. core.formspec_escape(logofile) .. "]" ..
-			"style[label_button;border=false]" ..
-			"button[0.1,3.4;5.3,0.5;label_button;" ..
+			"style_type[label;valign=center;halign=center]" ..
+			"label[0.1,3.4;5.3,0.5;" ..
 			core.formspec_escape(version.project .. " " .. version.string) .. "]" ..
 			"button_url[1.5,4.1;2.5,0.8;homepage;luanti.org;https://www.luanti.org/]"
 
@@ -99,9 +99,8 @@ return {
 
 		local active_renderer_info = fgettext("Active renderer:") .. "\n" ..
 			core.formspec_escape(get_renderer_info())
-		fs = fs .. "style[label_button2;border=false]" ..
-			"button[0.1,6;5.3,1;label_button2;" .. active_renderer_info .. "]"..
-			"tooltip[label_button2;" .. active_renderer_info .. "]" ..
+		fs = fs .. "style_type[textarea;valign=center]" ..
+			"textarea[0.1,6;5.7,1;;" .. active_renderer_info .. ";]" ..
 			"hypertext[5.5,0.25;9.75,6.6;credits;" .. core.formspec_escape(hypertext) .. "]"
 
 		return fs


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Allow the user to easily copy their active renderer in the "about" tab.
- How does the PR work?
It utilizes the new styling options from #16982 by changing the formspec button to a read-only textarea element.
- Does it resolve any reported issue?
Closes #16953.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Not directly, maybe 2.3.
- If not a bug fix, why is this PR needed? What usecases does it solve?
Allows the user to easily copy their active renderer.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
I haven't.

## To do

This PR is ready for review.

## How to test

open luanti → go to "about" tab → use cursor or triple click to select the renderer info text → copy it.

## Preview
<img width="1366" height="768" alt="animation" src="https://github.com/user-attachments/assets/dee98a9f-e7f6-439e-85b1-d34826f9fc48" />
