### PR TITLE
Use correct help command in CSM formspec

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -53,7 +53,8 @@ core.after(0, load_mod_command_tree)
 local function build_chatcommands_formspec(name, sel, copy)
 	local rows = {}
 	rows[1] = "#FFF,0,"..F(S("Command"))..","..F(S("Parameters"))
-	local help_command = INIT == "client" and ".help <cmd>" or "/help <cmd>"
+	local cmd_prefix = INIT == "client" and "." or "/"
+	local help_command = cmd_prefix .. "help <cmd>"
 
 	local description = S("For more information, click on "
 		.. "any entry in the list.").. "\n" ..
@@ -70,7 +71,7 @@ local function build_chatcommands_formspec(name, sel, copy)
 				description = cmds[2].description
 				if copy then
 					local msg = S("Command: @1 @2",
-						core.colorize("#0FF", (INIT == "client" and "." or "/") .. cmds[1]), cmds[2].params)
+						core.colorize("#0FF", cmd_prefix .. cmds[1]), cmds[2].params)
 					if INIT == "client" then
 						core.display_chat_message(msg)
 					else
@@ -81,8 +82,8 @@ local function build_chatcommands_formspec(name, sel, copy)
 		end
 	end
 
-	-- TRANSLATORS: @1 is the command used to get help for one command.
 	return LIST_FORMSPEC_DESCRIPTION:format(
+			-- TRANSLATORS: @1 is the command used to get help for one command.
 			F(S("Available commands: (see also: @1)", help_command)),
 			table.concat(rows, ","), sel or 0,
 			F(description), F(S("Close"))

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -53,6 +53,7 @@ core.after(0, load_mod_command_tree)
 local function build_chatcommands_formspec(name, sel, copy)
 	local rows = {}
 	rows[1] = "#FFF,0,"..F(S("Command"))..","..F(S("Parameters"))
+	local help_command = INIT == "client" and ".help <cmd>" or "/help <cmd>"
 
 	local description = S("For more information, click on "
 		.. "any entry in the list.").. "\n" ..
@@ -80,8 +81,9 @@ local function build_chatcommands_formspec(name, sel, copy)
 		end
 	end
 
+	-- TRANSLATORS: @1 is the command used to get help for one command.
 	return LIST_FORMSPEC_DESCRIPTION:format(
-			F(S("Available commands: (see also: /help <cmd>)")),
+			F(S("Available commands: (see also: @1)", help_command)),
 			table.concat(rows, ","), sel or 0,
 			F(description), F(S("Close"))
 		)


### PR DESCRIPTION
## Goal of the PR

Use the client-side command prefix in the CSM command help formspec while preserving the server-side prefix.

## How does the PR work?

The shared help formspec now derives the full help command from the runtime context. Client-side forms show `.help <cmd>`; server-side forms continue to show `/help <cmd>`. The command is passed as a translation parameter so translators do not need to translate its syntax.

Fixes #17191.

## Roadmap

This is a bug fix, so it does not require a roadmap concept approval.

## AI disclosure

I used an LLM/AI assistant to help inspect the code path, implement the change, and prepare this pull request.

## To do

This PR is Ready for Review.

- [x] Use the CSM command prefix in client-side help
- [x] Preserve the server-side help command
- [x] Verify the shared formspec in both runtime modes
- [x] Confirm upstream CI passes

## How to test

- Executed `builtin/common/information_formspecs.lua` with an isolated Lua harness and verified both client and server formspec output
- Verified the file parses successfully with `loadfile`
- Ran `git diff --check`
- Upstream `Builtin Luacheck and Unit Tests` and `Compile and run multiplayer tests` passed
