### PR TITLE
Emerges from the send loop should not reset the loop

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -276,13 +276,16 @@ bool EmergeManager::enqueueBlockEmerge(
 	session_t peer_id,
 	v3s16 blockpos,
 	bool allow_generate,
-	bool ignore_queue_limits)
+	bool ignore_queue_limits,
+	bool low_priority)
 {
 	u16 flags = 0;
 	if (allow_generate)
 		flags |= BLOCK_EMERGE_ALLOW_GEN;
 	if (ignore_queue_limits)
 		flags |= BLOCK_EMERGE_FORCE_QUEUE;
+	if (low_priority)
+		flags |= BLOCK_EMERGE_LOW_PRIORITY;
 
 	return enqueueBlockEmergeEx(blockpos, peer_id, flags, NULL, NULL);
 }
@@ -767,6 +770,7 @@ void *EmergeThread::run()
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
+			event.low_priority = bedata.flags & BLOCK_EMERGE_LOW_PRIORITY;
 			event.setModifiedBlocks(modified_blocks);
 			Server::EnvAutoLock envlock(m_server);
 			m_map->dispatchEvent(event);

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -12,8 +12,9 @@
 #include "mapgen/mapgen.h" // for MapgenParams
 #include "map.h"
 
-#define BLOCK_EMERGE_ALLOW_GEN   (1 << 0)
-#define BLOCK_EMERGE_FORCE_QUEUE (1 << 1)
+#define BLOCK_EMERGE_ALLOW_GEN    (1 << 0)
+#define BLOCK_EMERGE_FORCE_QUEUE  (1 << 1)
+#define BLOCK_EMERGE_LOW_PRIORITY (1 << 2)
 
 #define EMERGE_DBG_OUT(x) {                            \
 	if (enable_mapgen_debug_info)                      \
@@ -170,7 +171,8 @@ public:
 		session_t peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
-		bool ignore_queue_limits=false);
+		bool ignore_queue_limits=false,
+		bool low_priority=false);
 
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -23,6 +23,7 @@
 #include "util/srp.h"
 #include "util/string.h"
 #include "face_position_cache.h"
+#include "profiler.h"
 
 static std::string string_sanitize_ascii(const std::string &s, u32 max_length)
 {
@@ -366,7 +367,10 @@ void RemoteClient::GetNextBlocks (
 			if (want_emerge) {
 				if (nearest_emerged_d == -1)
 					nearest_emerged_d = d;
-				if (emerge->enqueueBlockEmerge(peer_id, p, generate))
+				// send as low-priority so that the emerge process
+				// does not interfere with the nearest_emerged_d logic
+				// see SetBlockNotSent(...)
+				if (emerge->enqueueBlockEmerge(peer_id, p, generate, false, true))
 					continue;
 				else
 					goto queue_full_break;
@@ -451,6 +455,7 @@ void RemoteClient::SetBlockNotSent(v3s16 p, bool low_priority)
 		// Instead, the send loop will get to the block in the next full loop iteration.
 		if (!low_priority || this_d < m_block_cull_optimize_distance) {
 			m_nearest_unsent_d = std::min(m_nearest_unsent_d, this_d);
+			g_profiler->add("Server: Send loop reset [#]", 1);
 		}
 	}
 }


### PR DESCRIPTION
Another interesting one...

I was measuring the number of times the send loop is reset by a closer block and found that to be a large number while loading.
It turned out this is because the emerges called from the send loop cause a reset of the loop to the distance of the new block. So the blocks loaded from the send loop reset its own send state.

The fix is to mark these emerge events as low_priority, which makes sure that they won't interfere with the send logic.
The send loop handles this correctly already.

This is made worse with multiple emerge threads, which all trample on each other, resetting the send loop.
(I was perplexed why more emerge threads would slow the loading process... This was one of the reasons.)

This also adds a new metric `Server: Send loop reset [#]`. That is useful generally, such as for the issue recently report about a wielded light prevent the server from making progress in loading the map. Now this could the checked via this metric.

- If you have used an LLM/AI to help with code or assets, you must disclose this.
nope

## To do

This PR is Ready for Review.

## How to test

Load any world, preferably with with a very large viewing_range and observe no changes, but faster loading time.
Observe the new `Server: Send loop reset [#]` metric, without any other reasons (like changing blocks) it should stay close to 0.
Try also with multiple emerge threads with existing and new worlds.