### PR TITLE
Hook up curl debug callback

### DIFF
--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -153,6 +153,19 @@ static size_t httpfetch_discardfunction(
 	return size * nmemb;
 }
 
+static int httpfetch_debugfunction(
+		CURL *handle, curl_infotype type, char *data, size_t size, void *clientp)
+{
+	(void)handle;
+	(void)clientp;
+	if (type == CURLINFO_TEXT) {
+		std::string_view text(data, size); // it's not null-terminated
+		tracestream << text;
+	}
+	return 0;
+}
+
+
 static bool string_safe_for_curl(std::string_view s, const char *kind)
 {
 	// NUL isn't unsafe but will truncate the string, so warn too
@@ -247,6 +260,11 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 	bool enable_ipv6 = g_settings->getBool("enable_ipv6");
 	curl_easy_setopt(curl, CURLOPT_IPRESOLVE,
 		 enable_ipv6 ? CURL_IPRESOLVE_WHATEVER : CURL_IPRESOLVE_V4);
+
+	if (tracestream) {
+		curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, httpfetch_debugfunction);
+		curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	}
 
 	// Restrict protocols so that curl vulnerabilities in
 	// other protocols don't affect us.


### PR DESCRIPTION
## To do

This PR is Ready for Review.

## How to test

1. Run `./bin/luanti --trace`
2. see stuff like
```
...
2026-07-25 19:38:29: TRACE[CurlFetch]: TLSv1.3 (IN), TLS handshake, CERT verify (15):
2026-07-25 19:38:29: TRACE[CurlFetch]: TLSv1.3 (IN), TLS handshake, Finished (20):
2026-07-25 19:38:29: TRACE[CurlFetch]: TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
2026-07-25 19:38:29: TRACE[CurlFetch]: TLSv1.3 (OUT), TLS handshake, Finished (20):
2026-07-25 19:38:29: TRACE[CurlFetch]: SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768 / RSASSA-PSS
2026-07-25 19:38:29: TRACE[CurlFetch]: ALPN: server accepted h2
2026-07-25 19:38:29: TRACE[CurlFetch]: Server certificate:
2026-07-25 19:38:29: TRACE[CurlFetch]:   subject: CN=servers.luanti.org
2026-07-25 19:38:29: TRACE[CurlFetch]:   start date: Jun  3 10:15:36 2026 GMT
2026-07-25 19:38:29: TRACE[CurlFetch]:   expire date: Sep  1 10:15:35 2026 GMT
2026-07-25 19:38:29: TRACE[CurlFetch]:   issuer: C=US; O=Let's Encrypt; CN=YR2
...
```