### PR TITLE
Add a `motion blur` post-processing effect

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -861,6 +861,7 @@ motion_blur_strength (Motion blur strength) float 1.0 0.0 4.0
 #    Quality of the motion blur effect. Higher values take more samples along
 #    the blur direction, giving a smoother, less banded smear at a higher GPU
 #    cost.
+#    A restart is required after changing this.
 #
 #    Requires: enable_post_processing, enable_motion_blur
 motion_blur_quality (Motion blur quality) int 8 2 32

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -847,6 +847,24 @@ enable_bloom (Enable Bloom) bool false
 #    Requires: enable_post_processing, enable_bloom
 enable_volumetric_lighting (Volumetric lighting) bool false
 
+#    Blur the view in the direction of camera movement, so fast turns and
+#    movement smear the image.
+#
+#    Requires: enable_post_processing
+enable_motion_blur (Motion blur) bool false
+
+#    Strength of the motion blur effect.
+#
+#    Requires: enable_post_processing, enable_motion_blur
+motion_blur_strength (Motion blur strength) float 1.0 0.0 4.0
+
+#    Quality of the motion blur effect. Higher values take more samples along
+#    the blur direction, giving a smoother, less banded smear at a higher GPU
+#    cost.
+#
+#    Requires: enable_post_processing, enable_motion_blur
+motion_blur_quality (Motion blur quality) int 8 2 32
+
 [**Other Effects]
 
 #   Simulate translucency when looking at foliage in the sunlight.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -849,11 +849,13 @@ enable_volumetric_lighting (Volumetric lighting) bool false
 
 #    Blur the view in the direction of camera movement, so fast turns and
 #    movement smear the image.
+#    Note that a game or mod can override this and enable the effect anyway.
 #
 #    Requires: enable_post_processing
 enable_motion_blur (Motion blur) bool false
 
 #    Strength of the motion blur effect.
+#    Note that a game or mod can override this with a strength of its own.
 #
 #    Requires: enable_post_processing, enable_motion_blur
 motion_blur_strength (Motion blur strength) float 0.4 0.0 4.0

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -856,7 +856,7 @@ enable_motion_blur (Motion blur) bool false
 #    Strength of the motion blur effect.
 #
 #    Requires: enable_post_processing, enable_motion_blur
-motion_blur_strength (Motion blur strength) float 1.0 0.0 4.0
+motion_blur_strength (Motion blur strength) float 0.4 0.0 4.0
 
 #    Quality of the motion blur effect. Higher values take more samples along
 #    the blur direction, giving a smoother, less banded smear at a higher GPU

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -1,0 +1,64 @@
+#define rendered texture0
+#define depthmap texture1
+
+uniform sampler2D rendered;
+uniform sampler2D depthmap;
+
+// Inverse of the current frame's view-projection matrix (used to reconstruct
+// each pixel's world-space position from its depth).
+uniform highp mat4 mInvViewProj;
+// Previous frame's view-projection matrix, with the camera-offset delta baked
+// in (used to find where this pixel was on the screen last frame).
+uniform highp mat4 mPrevViewProj;
+// User-facing strength multiplier for the effect.
+uniform float motionBlurStrength;
+
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+// Number of samples taken along the velocity vector. Higher = smoother blur
+// but more texture fetches.
+const int NUM_SAMPLES = 8;
+
+// Maximum blur length in UV units, so fast rotation / the sky don't smear the
+// whole screen into mush.
+const float MAX_VELOCITY = 0.15;
+
+void main(void)
+{
+	vec2 uv = varTexCoord.st;
+	highp float rawDepth = texture2D(depthmap, uv).r;
+
+	// Reconstruct the world-space (camera-relative) position of this pixel.
+	highp vec4 ndc = vec4(uv * 2.0 - 1.0, rawDepth * 2.0 - 1.0, 1.0);
+	highp vec4 worldPos = mInvViewProj * ndc;
+	worldPos /= worldPos.w;
+
+	// Reproject it through last frame's camera to find its previous screen pos.
+	highp vec4 prevClip = mPrevViewProj * vec4(worldPos.xyz, 1.0);
+	vec2 prevUv = (prevClip.xy / prevClip.w) * 0.5 + 0.5;
+
+	// Screen-space velocity in UV units.
+	vec2 velocity = (uv - prevUv) * motionBlurStrength;
+
+	float len = length(velocity);
+	if (len > MAX_VELOCITY)
+		velocity *= MAX_VELOCITY / len;
+
+	vec4 color = texture2D(rendered, uv);
+
+	// Nothing (or barely anything) moved: skip the blur entirely.
+	if (len < 0.0005) {
+		gl_FragColor = vec4(color.rgb, 1.0);
+		return;
+	}
+
+	vec3 sum = vec3(0.0);
+	for (int i = 0; i < NUM_SAMPLES; i++) {
+		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5].
+		float t = float(i) / float(NUM_SAMPLES - 1) - 0.5;
+		vec2 samplePos = clamp(uv + velocity * t, vec2(0.0), vec2(1.0));
+		sum += texture2D(rendered, samplePos).rgb;
+	}
+
+	gl_FragColor = vec4(sum / float(NUM_SAMPLES), 1.0);
+}

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -23,6 +23,27 @@ const int NUM_SAMPLES = 8;
 // whole screen into mush.
 const float MAX_VELOCITY = 0.15;
 
+// --- Emissive ("lightsaber") smearing -------------------------------------
+// Ordinary motion blur AVERAGES the samples, so a moving object's light is
+// spread over many pixels and the smear looks dimmer than the object. Real
+// bright light sources don't behave that way: as they sweep across the sensor
+// each pixel they cross gets saturated with light, so the trail stays at full
+// source brightness (a solid bright bar), which then blooms. We reproduce that
+// by detecting emissive pixels and accumulating them with max() instead of
+// averaging, so the streak does not dim along its length.
+//
+// Detection uses the value channel max(r,g,b) rather than luminance, so that
+// saturated colored lights (e.g. a red glow, whose luminance is low) are still
+// treated as emissive.
+
+// Value at which a pixel starts to count as "emissive". Lower = more of the
+// scene streaks brightly; higher = only the brightest sources do.
+const float EMISSION_THRESHOLD = 0.70;
+
+// How hot the emissive streak is pushed. >1 drives the trail toward full
+// brightness (clamped by the buffer) so the following bloom pass halos it.
+const float EMISSION_STRENGTH = 1.25;
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -52,13 +73,36 @@ void main(void)
 		return;
 	}
 
+	// Per-pixel jitter of the sample offsets. Without it every pixel samples the
+	// same fixed positions along the line, so a small bright source is stamped as
+	// a few discrete ghost copies (the dashed gaps). Offsetting each pixel by a
+	// sub-step random amount makes neighbouring pixels cover the positions in
+	// between, so the emissive max() fills into a continuous streak. Free: no
+	// extra texture fetches.
+	highp float jitter = fract(sin(dot(gl_FragCoord.xy, vec2(12.9898, 78.233))) * 43758.5453);
+
+	// Diffuse blur: energy-conserving average of the samples (the normal smear).
 	vec3 sum = vec3(0.0);
+	// Emissive trail: per-channel MAX of the emissive part of each sample, so a
+	// bright source paints a full-brightness bar along its path instead of a
+	// dimmed average.
+	vec3 emissive = vec3(0.0);
 	for (int i = 0; i < NUM_SAMPLES; i++) {
-		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5].
-		float t = float(i) / float(NUM_SAMPLES - 1) - 0.5;
+		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5],
+		// jittered by a fraction of the step so the trail has no gaps.
+		float t = (float(i) + jitter) / float(NUM_SAMPLES) - 0.5;
 		vec2 samplePos = clamp(uv + velocity * t, vec2(0.0), vec2(1.0));
-		sum += texture2D(rendered, samplePos).rgb;
+		vec3 c = texture2D(rendered, samplePos).rgb;
+		sum += c;
+
+		// How emissive this sample is, by its brightest channel (soft knee).
+		float e = smoothstep(EMISSION_THRESHOLD, 1.0, max(c.r, max(c.g, c.b)));
+		emissive = max(emissive, c * e);
 	}
 
-	gl_FragColor = vec4(sum / float(NUM_SAMPLES), 1.0);
+	vec3 base = sum / float(NUM_SAMPLES);
+	// Where the trail is emissive, take the bright bar; elsewhere it is ~0 and
+	// the normal averaged blur shows through unchanged.
+	vec3 result = max(base, emissive * EMISSION_STRENGTH);
+	gl_FragColor = vec4(result, 1.0);
 }

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -1,8 +1,12 @@
 #define rendered texture0
 #define depthmap texture1
+#define rigidMask texture3
 
 uniform sampler2D rendered;
 uniform sampler2D depthmap;
+// Mask of objects that move with the camera: the player's own body and whatever
+// it is riding. See CameraRigidMaskStep. 1 where such an object is visible.
+uniform sampler2D rigidMask;
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 
@@ -135,6 +139,17 @@ void main(void)
 {
 	vec2 uv = varTexCoord.st;
 	vec4 color = texture2D(rendered, uv);
+
+	// Objects rigidly attached to the camera are motionless on screen, but the
+	// reprojection below assumes every pixel is fixed in the world and would
+	// give them the full camera smear — worst of all for the player's own body
+	// and vehicle, which sit closest to the camera. They are masked out during
+	// the scene draw, so leave them exactly as they are.
+	if (texture2D(rigidMask, uv).r > 0.5) {
+		gl_FragColor = vec4(color.rgb, 1.0);
+		return;
+	}
+
 	highp float rawDepth = texture2D(depthmap, uv).r;
 
 	// Reconstruct the world-space (camera-relative) position of this pixel.

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -4,6 +4,26 @@
 uniform sampler2D rendered;
 uniform sampler2D depthmap;
 
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+// Reconstructing a world-space position from the depth buffer needs high
+// floating-point precision. On OpenGL ES highp is only optionally supported in
+// the fragment stage, and a shader that uses it where it is unsupported fails
+// to compile outright (the second_stage shader disables dithering for the same
+// reason). Where it is missing, compile a passthrough instead of the effect.
+#if defined(GL_ES) && !defined(GL_FRAGMENT_PRECISION_HIGH)
+#define MOTION_BLUR_UNSUPPORTED 1
+#endif
+
+#ifdef MOTION_BLUR_UNSUPPORTED
+
+void main(void)
+{
+	gl_FragColor = vec4(texture2D(rendered, varTexCoord.st).rgb, 1.0);
+}
+
+#else
+
 #ifdef ENABLE_AUTO_EXPOSURE
 #define exposureMap texture2
 // 1x1 auto-exposure texture (log2 scale), same one the second stage reads. The
@@ -23,8 +43,6 @@ uniform float motionBlurStrength;
 // Higher = smoother, less banded blur but more texture fetches. Clamped on the
 // engine side to [2, MAX_SAMPLES].
 uniform float motionBlurQuality;
-
-CENTROID_ VARYING_ mediump vec2 varTexCoord;
 
 // Hard upper bound on the sample count. GLSL ES requires a constant loop bound,
 // so we always loop to MAX_SAMPLES and break early once we have taken
@@ -92,6 +110,7 @@ const float EMISSION_UNIFORM_HI = 0.60;
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
+	vec4 color = texture2D(rendered, uv);
 	highp float rawDepth = texture2D(depthmap, uv).r;
 
 	// Reconstruct the world-space (camera-relative) position of this pixel.
@@ -101,6 +120,18 @@ void main(void)
 
 	// Reproject it through last frame's camera to find its previous screen pos.
 	highp vec4 prevClip = mPrevViewProj * vec4(worldPos.xyz, 1.0);
+
+	// A pixel visible now may have been BEHIND the previous camera: during a
+	// fast turn, or when moving past geometry that was very close. Then w is
+	// negative, the perspective divide mirrors the position through the origin,
+	// and the resulting velocity points the wrong way — producing a full-length
+	// smear in the opposite direction (the magnitude clamp below does not help,
+	// it only limits length). Leave those pixels unblurred instead.
+	if (prevClip.w <= 0.0) {
+		gl_FragColor = vec4(color.rgb, 1.0);
+		return;
+	}
+
 	vec2 prevUv = (prevClip.xy / prevClip.w) * 0.5 + 0.5;
 
 	// Screen-space velocity in UV units.
@@ -119,8 +150,6 @@ void main(void)
 	float len = length(velocity);
 	if (len > MAX_VELOCITY)
 		velocity *= MAX_VELOCITY / len;
-
-	vec4 color = texture2D(rendered, uv);
 
 	// Nothing (or barely anything) moved: skip the blur entirely.
 	if (len < 0.0005) {
@@ -150,7 +179,11 @@ void main(void)
 	// guards against motionBlurQuality arriving as 0 (e.g. an engine build that
 	// doesn't yet upload the uniform), which would otherwise divide by zero below
 	// and flash the screen black.
-	int numSamples = clamp(int(motionBlurQuality), 2, MAX_SAMPLES);
+	//
+	// Clamp in float and convert afterwards: GLSL ES 1.00 and GLSL 1.20 have no
+	// integer overload of clamp(), so clamp(int, int, int) fails to compile on
+	// the OpenGL ES 2 and legacy OpenGL code paths.
+	int numSamples = int(clamp(motionBlurQuality, 2.0, float(MAX_SAMPLES)));
 	float invSamples = 1.0 / float(numSamples);
 	for (int i = 0; i < MAX_SAMPLES; i++) {
 		// Stop once we have taken the requested number of samples. The loop bound
@@ -193,3 +226,5 @@ void main(void)
 	vec3 result = max(base, emissive * EMISSION_STRENGTH);
 	gl_FragColor = vec4(result, 1.0);
 }
+
+#endif // MOTION_BLUR_UNSUPPORTED

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -4,6 +4,13 @@
 uniform sampler2D rendered;
 uniform sampler2D depthmap;
 
+#ifdef ENABLE_AUTO_EXPOSURE
+#define exposureMap texture2
+// 1x1 auto-exposure texture (log2 scale), same one the second stage reads. The
+// engine only binds this when auto exposure is enabled.
+uniform sampler2D exposureMap;
+#endif
+
 // Inverse of the current frame's view-projection matrix (used to reconstruct
 // each pixel's world-space position from its depth).
 uniform highp mat4 mInvViewProj;
@@ -12,16 +19,35 @@ uniform highp mat4 mInvViewProj;
 uniform highp mat4 mPrevViewProj;
 // User-facing strength multiplier for the effect.
 uniform float motionBlurStrength;
+// User-facing quality: how many samples to take along the velocity vector.
+// Higher = smoother, less banded blur but more texture fetches. Clamped on the
+// engine side to [2, MAX_SAMPLES].
+uniform float motionBlurQuality;
 
 CENTROID_ VARYING_ mediump vec2 varTexCoord;
 
-// Number of samples taken along the velocity vector. Higher = smoother blur
-// but more texture fetches.
-const int NUM_SAMPLES = 8;
+// Hard upper bound on the sample count. GLSL ES requires a constant loop bound,
+// so we always loop to MAX_SAMPLES and break early once we have taken
+// motionBlurQuality samples.
+const int MAX_SAMPLES = 32;
 
 // Maximum blur length in UV units, so fast rotation / the sky don't smear the
 // whole screen into mush.
 const float MAX_VELOCITY = 0.15;
+
+// --- Exposure-linked blur length ------------------------------------------
+// When auto exposure is on, the eye/camera opens up in dark scenes (exposure
+// factor > 1) and stops down in bright ones (factor < 1). We tie the blur
+// length to that factor so darker, exposure-boosted areas smear MORE and
+// well-lit areas smear LESS, mirroring how a real longer exposure both
+// brightens the frame and captures more motion.
+//
+// INFLUENCE: 0 = ignore exposure entirely, 1 = scale blur length directly by
+// the exposure factor. MIN/MAX clamp the multiplier so an extreme exposure
+// (pitch-black or blown-out) can't collapse or explode the smear.
+const float EXPOSURE_BLUR_INFLUENCE = 1.0;
+const float EXPOSURE_BLUR_MIN = 0.5;
+const float EXPOSURE_BLUR_MAX = 2.5;
 
 // --- Emissive ("lightsaber") smearing -------------------------------------
 // Ordinary motion blur AVERAGES the samples, so a moving object's light is
@@ -44,6 +70,25 @@ const float EMISSION_THRESHOLD = 0.70;
 // brightness (clamped by the buffer) so the following bloom pass halos it.
 const float EMISSION_STRENGTH = 1.25;
 
+// Brighter light smears FURTHER. The emissive part of the blur samples along a
+// line that is up to this many times longer than the ordinary (diffuse) blur.
+// Because we gather with max() over that longer line, a saturated source paints
+// a streak well past where the averaged blur fades out, so bright areas visibly
+// get "more" motion blur than the rest of the scene. The extra reach is scaled
+// per-sample by how emissive the sampled pixel is, so a dim glow only extends a
+// little while a full-bright source uses the whole boosted length.
+const float EMISSION_LENGTH_BOOST = 2.5;
+
+// The emissive boost must fire for a localized moving light (a lamp, a
+// lightsaber) but NOT for a large uniformly-bright region such as the sky, which
+// would otherwise flash brighter whenever the camera moves. We tell them apart
+// by the DARKEST point along the smear line: a real light source is small, so
+// its smear line runs off the source into darker background (low minimum); the
+// sky is bright along the entire line (high minimum). If the darkest sample is
+// below _LO the streak is fully boosted; above _HI it is fully suppressed.
+const float EMISSION_UNIFORM_LO = 0.35;
+const float EMISSION_UNIFORM_HI = 0.60;
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -60,6 +105,16 @@ void main(void)
 
 	// Screen-space velocity in UV units.
 	vec2 velocity = (uv - prevUv) * motionBlurStrength;
+
+#ifdef ENABLE_AUTO_EXPOSURE
+	// Auto-exposure is stored on a log2 scale; pow(2, x) gives the linear
+	// factor (>1 dark scene, <1 bright scene). Scale the blur length by it so
+	// the smear grows in the dark and shrinks in the light.
+	float exposure = pow(2., texture2D(exposureMap, vec2(0.5)).r);
+	float exposureFactor = clamp(mix(1.0, exposure, EXPOSURE_BLUR_INFLUENCE),
+			EXPOSURE_BLUR_MIN, EXPOSURE_BLUR_MAX);
+	velocity *= exposureFactor;
+#endif
 
 	float len = length(velocity);
 	if (len > MAX_VELOCITY)
@@ -87,20 +142,52 @@ void main(void)
 	// bright source paints a full-brightness bar along its path instead of a
 	// dimmed average.
 	vec3 emissive = vec3(0.0);
-	for (int i = 0; i < NUM_SAMPLES; i++) {
+	// Darkest value-channel sample seen along the emissive line, used below to
+	// decide whether this is a localized source (line dips dark) or a uniform
+	// bright region like the sky (line stays bright).
+	float minEmissiveV = 1.0;
+	// Resolve the sample count locally and clamp it to a sane range. This also
+	// guards against motionBlurQuality arriving as 0 (e.g. an engine build that
+	// doesn't yet upload the uniform), which would otherwise divide by zero below
+	// and flash the screen black.
+	int numSamples = clamp(int(motionBlurQuality), 2, MAX_SAMPLES);
+	float invSamples = 1.0 / float(numSamples);
+	for (int i = 0; i < MAX_SAMPLES; i++) {
+		// Stop once we have taken the requested number of samples. The loop bound
+		// stays constant (MAX_SAMPLES) so GLSL ES is happy; the break makes the
+		// effective sample count follow the motionBlurQuality setting.
+		if (i >= numSamples)
+			break;
+
 		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5],
 		// jittered by a fraction of the step so the trail has no gaps.
-		float t = (float(i) + jitter) / float(NUM_SAMPLES) - 0.5;
+		float t = (float(i) + jitter) * invSamples - 0.5;
+
+		// Diffuse sample along the ordinary blur line.
 		vec2 samplePos = clamp(uv + velocity * t, vec2(0.0), vec2(1.0));
 		vec3 c = texture2D(rendered, samplePos).rgb;
 		sum += c;
 
-		// How emissive this sample is, by its brightest channel (soft knee).
-		float e = smoothstep(EMISSION_THRESHOLD, 1.0, max(c.r, max(c.g, c.b)));
-		emissive = max(emissive, c * e);
+		// Emissive sample along an EXTENDED line so bright sources reach further.
+		// The reach grows with how emissive the sampled pixel is, so brighter =
+		// longer smear.
+		vec2 emPos = clamp(uv + velocity * (t * EMISSION_LENGTH_BOOST), vec2(0.0), vec2(1.0));
+		vec3 ec = texture2D(rendered, emPos).rgb;
+		float ev = max(ec.r, max(ec.g, ec.b));
+		float e = smoothstep(EMISSION_THRESHOLD, 1.0, ev);
+		emissive = max(emissive, ec * e);
+		minEmissiveV = min(minEmissiveV, ev);
 	}
 
-	vec3 base = sum / float(NUM_SAMPLES);
+	// Suppress the boost for uniformly-bright regions (the sky): if even the
+	// darkest point along the smear line is bright, this is not a localized light
+	// source, so don't push it brighter on motion. A real light source's line
+	// dips into dark background, keeping localness ~1 across its whole streak
+	// (body included), so the source stays a solid bright bar with no leftover.
+	float localness = 1.0 - smoothstep(EMISSION_UNIFORM_LO, EMISSION_UNIFORM_HI, minEmissiveV);
+	emissive *= localness;
+
+	vec3 base = sum * invSamples;
 	// Where the trail is emissive, take the bright bar; elsewhere it is ~0 and
 	// the normal averaged blur shows through unchanged.
 	vec3 result = max(base, emissive * EMISSION_STRENGTH);

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -39,15 +39,18 @@ uniform highp mat4 mInvViewProj;
 uniform highp mat4 mPrevViewProj;
 // User-facing strength multiplier for the effect.
 uniform float motionBlurStrength;
-// User-facing quality: how many samples to take along the velocity vector.
-// Higher = smoother, less banded blur but more texture fetches. Clamped on the
-// engine side to [2, MAX_SAMPLES].
-uniform float motionBlurQuality;
 
-// Hard upper bound on the sample count. GLSL ES requires a constant loop bound,
-// so we always loop to MAX_SAMPLES and break early once we have taken
-// motionBlurQuality samples.
-const int MAX_SAMPLES = 32;
+// How many samples to take along the velocity vector. Higher = smoother, less
+// banded blur but more texture fetches.
+//
+// This arrives as a compile-time constant from the `motion_blur_quality`
+// setting rather than as a uniform, so the loop bound below is a literal the
+// driver can unroll. That is also why changing the setting needs the world
+// reloaded: it selects a different shader program. The engine clamps the value
+// to [2, 32] and caches one program per distinct value.
+#ifndef MOTION_BLUR_SAMPLES
+#define MOTION_BLUR_SAMPLES 8
+#endif
 
 // Maximum blur length in UV units, so fast rotation / the sky don't smear the
 // whole screen into mush.
@@ -196,23 +199,8 @@ void main(void)
 	// decide whether this is a localized source (line dips dark) or a uniform
 	// bright region like the sky (line stays bright).
 	float minEmissiveV = 1.0;
-	// Resolve the sample count locally and clamp it to a sane range. This also
-	// guards against motionBlurQuality arriving as 0 (e.g. an engine build that
-	// doesn't yet upload the uniform), which would otherwise divide by zero below
-	// and flash the screen black.
-	//
-	// Clamp in float and convert afterwards: GLSL ES 1.00 and GLSL 1.20 have no
-	// integer overload of clamp(), so clamp(int, int, int) fails to compile on
-	// the OpenGL ES 2 and legacy OpenGL code paths.
-	int numSamples = int(clamp(motionBlurQuality, 2.0, float(MAX_SAMPLES)));
-	float invSamples = 1.0 / float(numSamples);
-	for (int i = 0; i < MAX_SAMPLES; i++) {
-		// Stop once we have taken the requested number of samples. The loop bound
-		// stays constant (MAX_SAMPLES) so GLSL ES is happy; the break makes the
-		// effective sample count follow the motionBlurQuality setting.
-		if (i >= numSamples)
-			break;
-
+	const float invSamples = 1.0 / float(MOTION_BLUR_SAMPLES);
+	for (int i = 0; i < MOTION_BLUR_SAMPLES; i++) {
 		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5],
 		// jittered by a fraction of the step so the trail has no gaps.
 		float t = (float(i) + jitter) * invSamples - 0.5;

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -93,7 +93,7 @@ const float EMISSION_THRESHOLD = 0.70;
 
 // How hot the emissive streak is pushed. >1 drives the trail toward full
 // brightness (clamped by the buffer) so the following bloom pass halos it.
-const float EMISSION_STRENGTH = 1.25;
+const float EMISSION_STRENGTH = 1.15;
 
 // Brighter light smears FURTHER. The emissive part of the blur samples along a
 // line that is up to this many times longer than the ordinary (diffuse) blur.
@@ -102,17 +102,60 @@ const float EMISSION_STRENGTH = 1.25;
 // get "more" motion blur than the rest of the scene. The extra reach is scaled
 // per-sample by how emissive the sampled pixel is, so a dim glow only extends a
 // little while a full-bright source uses the whole boosted length.
-const float EMISSION_LENGTH_BOOST = 2.5;
+const float EMISSION_LENGTH_BOOST = 1.9;
 
-// The emissive boost must fire for a localized moving light (a lamp, a
-// lightsaber) but NOT for a large uniformly-bright region such as the sky, which
-// would otherwise flash brighter whenever the camera moves. We tell them apart
-// by the DARKEST point along the smear line: a real light source is small, so
-// its smear line runs off the source into darker background (low minimum); the
-// sky is bright along the entire line (high minimum). If the darkest sample is
-// below _LO the streak is fully boosted; above _HI it is fully suppressed.
-const float EMISSION_UNIFORM_LO = 0.35;
-const float EMISSION_UNIFORM_HI = 0.60;
+// The emissive boost must fire for a localized light (a lamp, a lightsaber, the
+// sun) but NOT for a large uniformly-bright region such as plain sky, which
+// would otherwise flash brighter whenever the camera moves.
+//
+// What separates the two is CONTRAST along the smear line, not absolute
+// brightness: a light source is small, so its line runs off the source into
+// something darker, whereas open sky looks the same all the way along. Testing
+// the darkest point alone (as this used to) fails the sun, which sits in a sky
+// bright enough to keep that minimum high and so gets suppressed along with it.
+//
+// Below _LO the line is treated as uniform and the streak is suppressed; above
+// _HI it is a localized source and streaks fully.
+const float EMISSION_CONTRAST_LO = 0.08;
+const float EMISSION_CONTRAST_HI = 0.25;
+
+// The localness test above stops the SKY being boosted, but on its own it does
+// nothing to stop the sky being painted ONTO something else. A max() gather
+// takes the brightest thing anywhere along the line, so every ground pixel
+// within reach of the horizon picks up sky brightness and the background bleeds
+// forward over the terrain. At full strength that reach is a fifth of the
+// screen, which is exactly what it looks like.
+//
+// So weight each emissive sample by how close it is to this pixel in depth.
+// Depth is non-linear, but (1 - depth) behaves like 1/distance, so their ratio
+// is a scale-invariant "how much nearer or farther" measure: ~1 is the same
+// distance, below 1 is farther away, above 1 is nearer. Samples at or in front
+// of this pixel count fully, ones clearly behind it fade out. The sky sits at
+// the far plane, so it scores 0 against any real geometry and is rejected
+// outright, while sky-on-sky (a sun streak) still works because both sides of
+// the ratio then vanish together.
+//
+// Deliberately strict: a sample must be within roughly 1.5x this pixel's
+// distance before it counts at all. Samples NEARER than this pixel always pass,
+// which is the direction you want kept -- a torch in the foreground should still
+// streak across the hills behind it.
+const float EMISSION_DEPTH_LO = 0.65;
+const float EMISSION_DEPTH_HI = 0.92;
+// Added to both sides of the depth ratio so that far-against-far reads as "same
+// distance" rather than 0/0. Roughly "distances beyond this are all infinity".
+const float EMISSION_DEPTH_EPSILON = 1e-4;
+
+// Ceiling on how far the emissive trail may lift a pixel above its ordinary
+// blurred value, as a fraction: 0 disables the emissive path entirely, 1 lets it
+// win outright. This is the master dial for "how much do bright things take over
+// the image" -- turn it down if light sources feel overbearing, up if they feel
+// flat.
+const float EMISSION_MAX_GAIN = 0.4;
+
+// How far outside the view to push the previous position of a pixel that was
+// behind the previous camera. Only the direction survives; the clamp does the
+// rest. Anything comfortably above 1 works.
+const float BEHIND_CAMERA_PUSH = 8.0;
 
 // --- Working color space ---------------------------------------------------
 // The color buffer at this point in the pipeline is gamma-encoded; second_stage
@@ -162,16 +205,22 @@ void main(void)
 
 	// A pixel visible now may have been BEHIND the previous camera: during a
 	// fast turn, or when moving past geometry that was very close. Then w is
-	// negative, the perspective divide mirrors the position through the origin,
-	// and the resulting velocity points the wrong way — producing a full-length
-	// smear in the opposite direction (the magnitude clamp below does not help,
-	// it only limits length). Leave those pixels unblurred instead.
-	if (prevClip.w <= 0.0) {
-		gl_FragColor = vec4(color.rgb, 1.0);
-		return;
-	}
+	// negative and the perspective divide mirrors the position through the
+	// origin, so the naive velocity points the wrong way.
+	//
+	// Dividing by |w| instead of w undoes exactly that mirroring, recovering the
+	// correct direction. The magnitude is meaningless for such a pixel (its true
+	// previous position is off screen entirely), so push it far out and let the
+	// clamp below turn it into a full-length smear the right way round.
+	//
+	// Note that simply leaving these pixels unblurred is NOT good enough: during
+	// a fast spin they form a whole band, which reads as a sharply defined
+	// unblurred patch on the side the camera is turning away from.
+	highp vec2 prevNdc = prevClip.xy / max(abs(prevClip.w), 1e-6);
+	if (prevClip.w < 0.0)
+		prevNdc *= BEHIND_CAMERA_PUSH;
 
-	vec2 prevUv = (prevClip.xy / prevClip.w) * 0.5 + 0.5;
+	vec2 prevUv = prevNdc * 0.5 + 0.5;
 
 	// Screen-space velocity in UV units.
 	vec2 velocity = (uv - prevUv) * motionBlurStrength;
@@ -210,10 +259,11 @@ void main(void)
 	// bright source paints a full-brightness bar along its path instead of a
 	// dimmed average.
 	vec3 emissive = vec3(0.0);
-	// Darkest value-channel sample seen along the emissive line, used below to
-	// decide whether this is a localized source (line dips dark) or a uniform
-	// bright region like the sky (line stays bright).
+	// Darkest and brightest value-channel samples along the emissive line. Their
+	// difference is the contrast test below, which decides whether this is a
+	// localized source or a uniformly bright region.
 	float minEmissiveV = 1.0;
+	float maxEmissiveV = 0.0;
 	const float invSamples = 1.0 / float(MOTION_BLUR_SAMPLES);
 	for (int i = 0; i < MOTION_BLUR_SAMPLES; i++) {
 		// Spread samples symmetrically around the current pixel: t in [-0.5, 0.5],
@@ -236,22 +286,36 @@ void main(void)
 		// they mean exactly what they did before the linear-space change.
 		float ev = max(ec.r, max(ec.g, ec.b));
 		float e = smoothstep(EMISSION_THRESHOLD, 1.0, ev);
+
+		// Reject samples that lie well behind this pixel, so a bright
+		// background cannot smear itself forward over nearer geometry. The
+		// epsilon on both sides is what makes far-against-far read as "same
+		// distance" (ratio 1) rather than 0/0, so a bright sky still streaks
+		// against itself while being rejected against any real geometry.
+		highp float emDepth = texture2D(depthmap, emPos).r;
+		float depthRatio = (1.0 - emDepth + EMISSION_DEPTH_EPSILON)
+				/ (1.0 - rawDepth + EMISSION_DEPTH_EPSILON);
+		e *= smoothstep(EMISSION_DEPTH_LO, EMISSION_DEPTH_HI, depthRatio);
+
 		emissive = max(emissive, gammaToLinear(ec) * e);
 		minEmissiveV = min(minEmissiveV, ev);
+		maxEmissiveV = max(maxEmissiveV, ev);
 	}
 
-	// Suppress the boost for uniformly-bright regions (the sky): if even the
-	// darkest point along the smear line is bright, this is not a localized light
-	// source, so don't push it brighter on motion. A real light source's line
-	// dips into dark background, keeping localness ~1 across its whole streak
-	// (body included), so the source stays a solid bright bar with no leftover.
-	float localness = 1.0 - smoothstep(EMISSION_UNIFORM_LO, EMISSION_UNIFORM_HI, minEmissiveV);
+	// Suppress the boost where the smear line is uniformly bright (open sky) and
+	// allow it where the line has contrast (a light source against its
+	// surroundings, including the sun against the sky).
+	float localness = smoothstep(EMISSION_CONTRAST_LO, EMISSION_CONTRAST_HI,
+			maxEmissiveV - minEmissiveV);
 	emissive *= localness;
 
 	vec3 base = sum * invSamples;
 	// Where the trail is emissive, take the bright bar; elsewhere it is ~0 and
-	// the normal averaged blur shows through unchanged.
-	vec3 result = max(base, emissive * EMISSION_STRENGTH_LINEAR);
+	// the normal averaged blur shows through unchanged. The result is then
+	// admitted only up to EMISSION_MAX_GAIN, so bright sources streak without
+	// taking over the image.
+	vec3 boosted = max(base, emissive * EMISSION_STRENGTH_LINEAR);
+	vec3 result = mix(base, boosted, EMISSION_MAX_GAIN);
 	gl_FragColor = vec4(linearToGamma(result), 1.0);
 }
 

--- a/client/shaders/motion_blur/opengl_fragment.glsl
+++ b/client/shaders/motion_blur/opengl_fragment.glsl
@@ -107,6 +107,27 @@ const float EMISSION_LENGTH_BOOST = 2.5;
 const float EMISSION_UNIFORM_LO = 0.35;
 const float EMISSION_UNIFORM_HI = 0.60;
 
+// --- Working color space ---------------------------------------------------
+// The color buffer at this point in the pipeline is gamma-encoded; second_stage
+// is what converts it to linear (pow 2.2) much later. Averaging gamma-encoded
+// values is not energy-conserving — it makes a smear noticeably darker than the
+// light that produced it. Averaging a full-bright pixel with a dark one gives
+// ~0.55 encoded (0.27 linear) where the true answer is ~0.50 linear. That
+// missing energy is a large part of what the emissive path above exists to
+// fight. So decode to linear before combining samples, and re-encode on the way
+// out.
+//
+// Gamma 2.0 rather than the engine's 2.2: the round trip is exact either way,
+// so a pixel that ends up unblurred comes out bit-identical and the pass stays
+// a true no-op where nothing moved. Only the weighting of the average differs,
+// and square/sqrt is far cheaper than a pow() per sample.
+vec3 gammaToLinear(vec3 c) { return c * c; }
+vec3 linearToGamma(vec3 c) { return sqrt(c); }
+
+// EMISSION_STRENGTH expresses a perceptual multiplier, so square it to apply in
+// the linear domain we now accumulate in.
+const float EMISSION_STRENGTH_LINEAR = EMISSION_STRENGTH * EMISSION_STRENGTH;
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -199,16 +220,20 @@ void main(void)
 		// Diffuse sample along the ordinary blur line.
 		vec2 samplePos = clamp(uv + velocity * t, vec2(0.0), vec2(1.0));
 		vec3 c = texture2D(rendered, samplePos).rgb;
-		sum += c;
+		sum += gammaToLinear(c);
 
 		// Emissive sample along an EXTENDED line so bright sources reach further.
 		// The reach grows with how emissive the sampled pixel is, so brighter =
 		// longer smear.
 		vec2 emPos = clamp(uv + velocity * (t * EMISSION_LENGTH_BOOST), vec2(0.0), vec2(1.0));
 		vec3 ec = texture2D(rendered, emPos).rgb;
+		// Note that the emissive *detection* below deliberately stays in the
+		// gamma-encoded domain: these thresholds describe how bright a pixel
+		// looks, which is a perceptual question, and keeping them here means
+		// they mean exactly what they did before the linear-space change.
 		float ev = max(ec.r, max(ec.g, ec.b));
 		float e = smoothstep(EMISSION_THRESHOLD, 1.0, ev);
-		emissive = max(emissive, ec * e);
+		emissive = max(emissive, gammaToLinear(ec) * e);
 		minEmissiveV = min(minEmissiveV, ev);
 	}
 
@@ -223,8 +248,8 @@ void main(void)
 	vec3 base = sum * invSamples;
 	// Where the trail is emissive, take the bright bar; elsewhere it is ~0 and
 	// the normal averaged blur shows through unchanged.
-	vec3 result = max(base, emissive * EMISSION_STRENGTH);
-	gl_FragColor = vec4(result, 1.0);
+	vec3 result = max(base, emissive * EMISSION_STRENGTH_LINEAR);
+	gl_FragColor = vec4(linearToGamma(result), 1.0);
 }
 
 #endif // MOTION_BLUR_UNSUPPORTED

--- a/client/shaders/motion_blur/opengl_vertex.glsl
+++ b/client/shaders/motion_blur/opengl_vertex.glsl
@@ -1,0 +1,7 @@
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+void main(void)
+{
+	varTexCoord.st = inTexCoord0.st;
+	gl_Position = inVertexPosition;
+}

--- a/client/shaders/object_mask/opengl_fragment.glsl
+++ b/client/shaders/object_mask/opengl_fragment.glsl
@@ -1,0 +1,20 @@
+// Fragment stage of the camera-rigid object mask. Writes a flat 1.0 wherever a
+// camera-rigid object is visible; the target is cleared to 0 beforehand, and the
+// shared scene depth buffer takes care of rejecting parts hidden behind terrain.
+
+uniform sampler2D baseTexture;
+
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+void main(void)
+{
+	// Honour alpha cutouts so the mask follows the visible silhouette rather
+	// than the bounding geometry. Without this, the transparent parts of a model
+	// (the player's hat layer, say) would mask the background around the object
+	// and leave a conspicuous unblurred halo. Threshold matches shadow/pass1,
+	// which ignores the node alpha mode in the same way.
+	if (texture2D(baseTexture, varTexCoord).a < 0.70)
+		discard;
+
+	gl_FragColor = vec4(1.0);
+}

--- a/client/shaders/object_mask/opengl_vertex.glsl
+++ b/client/shaders/object_mask/opengl_vertex.glsl
@@ -1,0 +1,37 @@
+// Vertex stage of the camera-rigid object mask.
+//
+// This must place vertices at exactly the same clip position that object_shader
+// gave them when the scene was drawn, or the mask will not line up with the
+// object it is masking. That means reproducing the GPU skinning, otherwise an
+// animated model would be masked in its bind pose. Compare shadow/pass1, which
+// has the same requirement for the same reason.
+
+#ifdef USE_SKINNING
+layout (std140) uniform JointMatrices {
+	mat4 joints[MAX_JOINTS];
+};
+#endif
+
+CENTROID_ VARYING_ mediump vec2 varTexCoord;
+
+void main(void)
+{
+#ifdef USE_SKINNING
+	uvec4 jids = inVertexJointIDs;
+	vec4 skinPos = inVertexPosition;
+	if (inVertexWeights != vec4(0.0)) {
+		// Note that this deals correctly with a disabled vertex attribute.
+		mat4 mSkin =
+				inVertexWeights.x * joints[jids.x] +
+				inVertexWeights.y * joints[jids.y] +
+				inVertexWeights.z * joints[jids.z] +
+				inVertexWeights.w * joints[jids.w];
+		skinPos = vec4((mSkin * vec4(inVertexPosition.xyz, 1.0)).xyz, 1.0);
+	}
+#else
+	vec4 skinPos = inVertexPosition;
+#endif
+
+	varTexCoord = (mTexture * vec4(inTexCoord0.xy, 1.0, 1.0)).st;
+	gl_Position = mWorldViewProj * skinPos;
+}

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9661,6 +9661,25 @@ You **must not** mix names and track numbers to refer to the same animation.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `motion_blur` is a table that controls camera motion blur.
+        * This has no effect on older clients, or on clients who have
+          post-processing disabled.
+        * `strength` sets the absolute strength of the effect, from 0 (off) to
+          4.0. Omit it (or set it to `nil`) to hand control back to the player.
+          * Unlike the other sections here, naming the `motion_blur` table is
+            itself the act of setting it: `{motion_blur = {}}` resets the
+            strength rather than leaving the current value untouched.
+          * A strength given here **overrides the player's own motion blur
+            settings entirely**. It may exceed the strength they configured, and
+            it enables the effect even for a player who has "Motion blur" turned
+            off.
+          * When unset, the player's own settings apply: their configured
+            strength if they have the effect enabled, otherwise no blur.
+          * Note that motion blur is a common motion sickness trigger. Prefer
+            leaving it unset, and forcing it on only where the effect is
+            important to your game.
+        * `get_lighting()` omits `strength` entirely while it is unset, rather
+          than reporting a number.
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/games/devtest/mods/lighting/init.lua
+++ b/games/devtest/mods/lighting/init.lua
@@ -29,6 +29,14 @@ local lighting_sections = {
 			{n = "strength", d = "Strength", min = 0, max = 1},
 		},
 	},
+	{
+		-- Absolute strength, overriding the player's own setting. Unset until
+		-- the slider is touched, in which case the player's setting applies.
+		n = "motion_blur", d = "Motion Blur",
+		entries = {
+			{n = "strength", d = "Strength", min = 0, max = 4},
+		},
+	},
 }
 
 local function dump_lighting(lighting)
@@ -45,7 +53,11 @@ local function dump_lighting(lighting)
 		local count = 0
 		for _,v in ipairs(parameters) do
 			count = count + 1
-			result = result.."    "..v.n.." = "..(math.floor(state[v.n] * 1000)/1000)
+			local value = state[v.n]
+			-- Some parameters are optional and absent until explicitly set,
+			-- in which case the client falls back to its own settings.
+			value = value and (math.floor(value * 1000)/1000) or "<unset>"
+			result = result.."    "..v.n.." = "..value
 			if count < #parameters then
 				result = result..","
 			end

--- a/games/devtest/mods/unittests/player.lua
+++ b/games/devtest/mods/unittests/player.lua
@@ -213,3 +213,48 @@ local function test_player_guid(player)
 	assert(core.objects_by_guid[player:get_guid()] == player)
 end
 unittests.register("test_player_guid", test_player_guid, {player=true})
+
+--
+-- Motion blur lighting parameter
+--
+local function test_motion_blur_lighting(player)
+	local old_lighting = player:get_lighting()
+
+	-- Unset by default: the player's own settings decide.
+	player:set_lighting(nil)
+	assert(player:get_lighting().motion_blur.strength == nil)
+
+	-- An absolute strength, which may exceed what the player configured.
+	player:set_lighting({motion_blur = {strength = 2.5}})
+	assert(player:get_lighting().motion_blur.strength == 2.5)
+
+	-- Setting an unrelated section must leave it alone.
+	player:set_lighting({saturation = 1})
+	assert(player:get_lighting().motion_blur.strength == 2.5)
+
+	-- Naming the section with no strength hands control back to the player.
+	player:set_lighting({motion_blur = {}})
+	assert(player:get_lighting().motion_blur.strength == nil)
+
+	-- Explicit nil does the same.
+	player:set_lighting({motion_blur = {strength = 4}})
+	assert(player:get_lighting().motion_blur.strength == 4)
+	player:set_lighting({motion_blur = {strength = nil}})
+	assert(player:get_lighting().motion_blur.strength == nil)
+
+	-- Clamped to [0,4].
+	player:set_lighting({motion_blur = {strength = 99}})
+	assert(player:get_lighting().motion_blur.strength == 4)
+	player:set_lighting({motion_blur = {strength = -1}})
+	assert(player:get_lighting().motion_blur.strength == 0)
+
+	-- 0 is a real value meaning "off", distinct from unset.
+	assert(player:get_lighting().motion_blur.strength ~= nil)
+
+	-- A full reset clears it.
+	player:set_lighting(nil)
+	assert(player:get_lighting().motion_blur.strength == nil)
+
+	player:set_lighting(old_lighting)
+end
+unittests.register("test_motion_blur_lighting", test_motion_blur_lighting, {player=true})

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -482,6 +482,10 @@ void ClientEnvironment::getSelectedActiveObjects(
 
 void ClientEnvironment::updateFrameTime(bool is_paused)
 {
+	// Counts every frame, including paused ones, so that it stays a reliable
+	// frame-boundary signal regardless of pause state or frame rate.
+	m_frame_counter++;
+
 	// if paused, m_frame_time_pause_accumulator increases by dtime,
 	// otherwise, m_frame_time increases by dtime
 	if (is_paused) {

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -136,6 +136,15 @@ public:
 	void updateFrameTime(bool is_paused);
 	u64 getFrameTime() const { return m_frame_time; }
 	u64 getFrameTimeDelta() const { return m_frame_dtime; }
+	/**
+	 * Monotonic count of frames drawn, incremented once per frame.
+	 *
+	 * Unlike getFrameTime() this is exact: it has no resolution limit (frame
+	 * time is in milliseconds, so above 1000 FPS consecutive frames share a
+	 * timestamp) and it keeps advancing while the game is paused. Use it to
+	 * detect frame boundaries.
+	 */
+	u64 getFrameCounter() const { return m_frame_counter; }
 
 private:
 	irr_ptr<ClientMap> m_map;
@@ -152,4 +161,5 @@ private:
 	u64 m_frame_time = 0;
 	u64 m_frame_dtime = 0;
 	u64 m_frame_time_pause_accumulator = 0;
+	u64 m_frame_counter = 0;
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -109,6 +109,23 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	CachedPixelShaderSetting<float>
 		m_volumetric_light_strength_pixel{"volumetricLightStrength"};
 
+	bool m_motion_blur_enabled;
+	float m_motion_blur_strength;
+	CachedPixelShaderSetting<float, 16> m_motion_blur_inv_view_proj{"mInvViewProj"};
+	CachedPixelShaderSetting<float, 16> m_motion_blur_prev_view_proj{"mPrevViewProj"};
+	CachedPixelShaderSetting<float> m_motion_blur_strength_pixel{"motionBlurStrength"};
+	// Previous frame's view-projection matrix and camera offset, used to
+	// compute per-pixel screen-space velocity for motion blur.
+	core::matrix4 m_prev_view_proj;
+	core::matrix4 m_cur_view_proj;
+	v3s16 m_prev_camera_offset;
+	v3s16 m_cur_camera_offset;
+	// Matrices actually uploaded to the shader, recomputed once per frame.
+	core::matrix4 m_motion_blur_inv_vp;
+	core::matrix4 m_motion_blur_prev_vp;
+	u32 m_motion_blur_last_frame = 0;
+	bool m_motion_blur_have_prev = false;
+
 	static constexpr std::array<const char*, 1> SETTING_CALLBACKS = {
 		"exposure_compensation",
 	};
@@ -137,6 +154,8 @@ public:
 		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
+		m_motion_blur_enabled = g_settings->getBool("enable_motion_blur");
+		m_motion_blur_strength = g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f);
 		m_crack_animation_length_i = game->crack_animation_length;
 	}
 
@@ -176,6 +195,50 @@ public:
 
 		m_texel_size0_vertex.set(m_texel_size0, services);
 		m_texel_size0_pixel.set(m_texel_size0, services);
+
+		if (m_motion_blur_enabled) {
+			// onSetUniforms is called once per material, i.e. many times per
+			// frame. The motion-blur matrices depend only on the camera, so we
+			// recompute them just once per frame (when the frame time changes)
+			// and reuse the cached result for every other call.
+			u32 frame_time = m_client->getEnv().getFrameTime();
+			if (!m_motion_blur_have_prev || frame_time != m_motion_blur_last_frame) {
+				auto *camera = m_client->getCamera();
+				auto *camera_node = camera->getCameraNode();
+
+				core::matrix4 view_proj = camera_node->getProjectionMatrix();
+				view_proj *= camera_node->getViewMatrix();
+				v3s16 camera_offset = camera->getOffset();
+
+				if (!m_motion_blur_have_prev) {
+					// First frame: no history yet, reproject onto itself so the
+					// velocity is zero (no blur).
+					m_prev_view_proj = view_proj;
+					m_prev_camera_offset = camera_offset;
+					m_motion_blur_have_prev = true;
+				} else {
+					m_prev_view_proj = m_cur_view_proj;
+					m_prev_camera_offset = m_cur_camera_offset;
+				}
+				m_cur_view_proj = view_proj;
+				m_cur_camera_offset = camera_offset;
+				m_motion_blur_last_frame = frame_time;
+
+				view_proj.getInverse(m_motion_blur_inv_vp);
+
+				// The world is rendered relative to the camera offset, which can
+				// change between frames. Bake the offset delta into the previous
+				// view-projection matrix so reprojection stays continuous.
+				v3f offset_delta = intToFloat(camera_offset - m_prev_camera_offset, BS);
+				core::matrix4 offset_translation;
+				offset_translation.setTranslation(offset_delta);
+				m_motion_blur_prev_vp = m_prev_view_proj * offset_translation;
+			}
+
+			m_motion_blur_inv_view_proj.set(m_motion_blur_inv_vp, services);
+			m_motion_blur_prev_view_proj.set(m_motion_blur_prev_vp, services);
+			m_motion_blur_strength_pixel.set(&m_motion_blur_strength, services);
+		}
 
 		{
 			float tmp = m_crack_animation_length_i;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -111,11 +111,9 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 
 	bool m_motion_blur_enabled;
 	float m_motion_blur_strength;
-	float m_motion_blur_quality;
 	CachedPixelShaderSetting<float, 16> m_motion_blur_inv_view_proj{"mInvViewProj"};
 	CachedPixelShaderSetting<float, 16> m_motion_blur_prev_view_proj{"mPrevViewProj"};
 	CachedPixelShaderSetting<float> m_motion_blur_strength_pixel{"motionBlurStrength"};
-	CachedPixelShaderSetting<float> m_motion_blur_quality_pixel{"motionBlurQuality"};
 	/*
 		Motion blur reprojects each pixel through the previous frame's camera,
 		so it needs that camera's view-projection matrix and camera offset.
@@ -144,10 +142,9 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	bool m_motion_blur_seen_frame = false;
 	u32 m_motion_blur_view = 0;
 
-	static constexpr std::array<const char*, 3> SETTING_CALLBACKS = {
+	static constexpr std::array<const char*, 2> SETTING_CALLBACKS = {
 		"exposure_compensation",
 		"motion_blur_strength",
-		"motion_blur_quality",
 	};
 
 	void readMotionBlurStrength()
@@ -155,27 +152,18 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 		m_motion_blur_strength = g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f);
 	}
 
-	void readMotionBlurQuality()
-	{
-		// Must match MAX_SAMPLES in the motion_blur fragment shader.
-		m_motion_blur_quality = rangelim(
-				(float)g_settings->getS32("motion_blur_quality"), 2.0f, 32.0f);
-	}
-
 public:
 	void onSettingsChange(const std::string &name)
 	{
 		if (name == "exposure_compensation")
 			m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
-		// Note that `enable_motion_blur` itself is deliberately absent: it
-		// decides whether the render pipeline gets a motion blur step at all,
-		// and the pipeline is only built when the world is loaded (same as
-		// `enable_bloom`). Strength and quality are plain uniforms, so those
-		// can and should take effect immediately.
+		// Strength is a plain uniform, so it can take effect immediately.
+		// `enable_motion_blur` and `motion_blur_quality` are deliberately
+		// absent: the former decides whether the render pipeline gets a motion
+		// blur step at all, the latter is compiled into the shader as a
+		// constant, and both are only applied when the world is loaded.
 		else if (name == "motion_blur_strength")
 			readMotionBlurStrength();
-		else if (name == "motion_blur_quality")
-			readMotionBlurQuality();
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -197,7 +185,6 @@ public:
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
 		m_motion_blur_enabled = g_settings->getBool("enable_motion_blur");
 		readMotionBlurStrength();
-		readMotionBlurQuality();
 		m_crack_animation_length_i = game->crack_animation_length;
 	}
 
@@ -288,7 +275,6 @@ public:
 			m_motion_blur_inv_view_proj.set(inv_view_proj, services);
 			m_motion_blur_prev_view_proj.set(prev_view_proj, services);
 			m_motion_blur_strength_pixel.set(&m_motion_blur_strength, services);
-			m_motion_blur_quality_pixel.set(&m_motion_blur_quality, services);
 		}
 
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -116,17 +116,33 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	CachedPixelShaderSetting<float, 16> m_motion_blur_prev_view_proj{"mPrevViewProj"};
 	CachedPixelShaderSetting<float> m_motion_blur_strength_pixel{"motionBlurStrength"};
 	CachedPixelShaderSetting<float> m_motion_blur_quality_pixel{"motionBlurQuality"};
-	// Previous frame's view-projection matrix and camera offset, used to
-	// compute per-pixel screen-space velocity for motion blur.
-	core::matrix4 m_prev_view_proj;
-	core::matrix4 m_cur_view_proj;
-	v3s16 m_prev_camera_offset;
-	v3s16 m_cur_camera_offset;
-	// Matrices actually uploaded to the shader, recomputed once per frame.
-	core::matrix4 m_motion_blur_inv_vp;
-	core::matrix4 m_motion_blur_prev_vp;
-	u32 m_motion_blur_last_frame = 0;
-	bool m_motion_blur_have_prev = false;
+	/*
+		Motion blur reprojects each pixel through the previous frame's camera,
+		so it needs that camera's view-projection matrix and camera offset.
+
+		This has to be tracked per *view*, not just per frame. The stereo modes
+		(anaglyph, sidebyside, topbottom, crossview) run the whole 3D stage —
+		including this post-processing pipeline — once per eye, with
+		OffsetCameraStep moving the camera node in between. A single history
+		slot would hand the right eye the left eye's matrix, which differs by
+		the eye separation and would show up as a constant sideways smear in
+		one eye.
+
+		Views are rendered in a fixed order within a frame, so indexing the
+		history by "how many times we have been called this frame" reliably
+		gives each eye its own slot. A hypothetical mode with more views than
+		this would share the last slot rather than misbehave.
+	*/
+	static constexpr u32 MOTION_BLUR_MAX_VIEWS = 2;
+	struct MotionBlurView {
+		core::matrix4 view_proj;
+		v3s16 camera_offset;
+		bool valid = false;
+	};
+	std::array<MotionBlurView, MOTION_BLUR_MAX_VIEWS> m_motion_blur_views;
+	u64 m_motion_blur_frame = 0;
+	bool m_motion_blur_seen_frame = false;
+	u32 m_motion_blur_view = 0;
 
 	static constexpr std::array<const char*, 3> SETTING_CALLBACKS = {
 		"exposure_compensation",
@@ -223,46 +239,54 @@ public:
 		m_texel_size0_pixel.set(m_texel_size0, services);
 
 		if (m_motion_blur_enabled) {
-			// onSetUniforms is called once per material, i.e. many times per
-			// frame. The motion-blur matrices depend only on the camera, so we
-			// recompute them just once per frame (when the frame time changes)
-			// and reuse the cached result for every other call.
-			u32 frame_time = m_client->getEnv().getFrameTime();
-			if (!m_motion_blur_have_prev || frame_time != m_motion_blur_last_frame) {
-				auto *camera = m_client->getCamera();
-				auto *camera_node = camera->getCameraNode();
+			auto *camera = m_client->getCamera();
+			auto *camera_node = camera->getCameraNode();
 
-				core::matrix4 view_proj = camera_node->getProjectionMatrix();
-				view_proj *= camera_node->getViewMatrix();
-				v3s16 camera_offset = camera->getOffset();
+			// Read the camera fresh every call rather than caching it per
+			// frame: in stereo modes this runs once per eye against a
+			// different camera transform, so a cached matrix would reconstruct
+			// the second eye's world positions with the first eye's camera.
+			core::matrix4 view_proj = camera_node->getProjectionMatrix();
+			view_proj *= camera_node->getViewMatrix();
+			v3s16 camera_offset = camera->getOffset();
 
-				if (!m_motion_blur_have_prev) {
-					// First frame: no history yet, reproject onto itself so the
-					// velocity is zero (no blur).
-					m_prev_view_proj = view_proj;
-					m_prev_camera_offset = camera_offset;
-					m_motion_blur_have_prev = true;
-				} else {
-					m_prev_view_proj = m_cur_view_proj;
-					m_prev_camera_offset = m_cur_camera_offset;
-				}
-				m_cur_view_proj = view_proj;
-				m_cur_camera_offset = camera_offset;
-				m_motion_blur_last_frame = frame_time;
+			// Pick this view's history slot: back to the first on a new frame,
+			// otherwise the next eye of the frame we are already in.
+			u64 frame = m_client->getEnv().getFrameCounter();
+			if (!m_motion_blur_seen_frame || frame != m_motion_blur_frame) {
+				m_motion_blur_frame = frame;
+				m_motion_blur_seen_frame = true;
+				m_motion_blur_view = 0;
+			} else if (m_motion_blur_view + 1 < MOTION_BLUR_MAX_VIEWS) {
+				m_motion_blur_view++;
+			}
+			MotionBlurView &history = m_motion_blur_views[m_motion_blur_view];
 
-				view_proj.getInverse(m_motion_blur_inv_vp);
+			core::matrix4 inv_view_proj;
+			view_proj.getInverse(inv_view_proj);
 
+			core::matrix4 prev_view_proj;
+			if (history.valid) {
 				// The world is rendered relative to the camera offset, which can
 				// change between frames. Bake the offset delta into the previous
 				// view-projection matrix so reprojection stays continuous.
-				v3f offset_delta = intToFloat(camera_offset - m_prev_camera_offset, BS);
+				v3f offset_delta = intToFloat(camera_offset - history.camera_offset, BS);
 				core::matrix4 offset_translation;
 				offset_translation.setTranslation(offset_delta);
-				m_motion_blur_prev_vp = m_prev_view_proj * offset_translation;
+				prev_view_proj = history.view_proj * offset_translation;
+			} else {
+				// No history for this view yet (first frame, or first frame
+				// after the view count grew): reproject onto itself so the
+				// velocity is zero and nothing blurs.
+				prev_view_proj = view_proj;
 			}
 
-			m_motion_blur_inv_view_proj.set(m_motion_blur_inv_vp, services);
-			m_motion_blur_prev_view_proj.set(m_motion_blur_prev_vp, services);
+			history.view_proj = view_proj;
+			history.camera_offset = camera_offset;
+			history.valid = true;
+
+			m_motion_blur_inv_view_proj.set(inv_view_proj, services);
+			m_motion_blur_prev_view_proj.set(prev_view_proj, services);
 			m_motion_blur_strength_pixel.set(&m_motion_blur_strength, services);
 			m_motion_blur_quality_pixel.set(&m_motion_blur_quality, services);
 		}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -111,9 +111,11 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 
 	bool m_motion_blur_enabled;
 	float m_motion_blur_strength;
+	float m_motion_blur_quality;
 	CachedPixelShaderSetting<float, 16> m_motion_blur_inv_view_proj{"mInvViewProj"};
 	CachedPixelShaderSetting<float, 16> m_motion_blur_prev_view_proj{"mPrevViewProj"};
 	CachedPixelShaderSetting<float> m_motion_blur_strength_pixel{"motionBlurStrength"};
+	CachedPixelShaderSetting<float> m_motion_blur_quality_pixel{"motionBlurQuality"};
 	// Previous frame's view-projection matrix and camera offset, used to
 	// compute per-pixel screen-space velocity for motion blur.
 	core::matrix4 m_prev_view_proj;
@@ -156,6 +158,9 @@ public:
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
 		m_motion_blur_enabled = g_settings->getBool("enable_motion_blur");
 		m_motion_blur_strength = g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f);
+		// Must match MAX_SAMPLES in the motion_blur fragment shader.
+		m_motion_blur_quality = (float)g_settings->getS32("motion_blur_quality");
+		m_motion_blur_quality = rangelim(m_motion_blur_quality, 2.0f, 32.0f);
 		m_crack_animation_length_i = game->crack_animation_length;
 	}
 
@@ -238,6 +243,7 @@ public:
 			m_motion_blur_inv_view_proj.set(m_motion_blur_inv_vp, services);
 			m_motion_blur_prev_view_proj.set(m_motion_blur_prev_vp, services);
 			m_motion_blur_strength_pixel.set(&m_motion_blur_strength, services);
+			m_motion_blur_quality_pixel.set(&m_motion_blur_quality, services);
 		}
 
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -128,15 +128,38 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 	u32 m_motion_blur_last_frame = 0;
 	bool m_motion_blur_have_prev = false;
 
-	static constexpr std::array<const char*, 1> SETTING_CALLBACKS = {
+	static constexpr std::array<const char*, 3> SETTING_CALLBACKS = {
 		"exposure_compensation",
+		"motion_blur_strength",
+		"motion_blur_quality",
 	};
+
+	void readMotionBlurStrength()
+	{
+		m_motion_blur_strength = g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f);
+	}
+
+	void readMotionBlurQuality()
+	{
+		// Must match MAX_SAMPLES in the motion_blur fragment shader.
+		m_motion_blur_quality = rangelim(
+				(float)g_settings->getS32("motion_blur_quality"), 2.0f, 32.0f);
+	}
 
 public:
 	void onSettingsChange(const std::string &name)
 	{
 		if (name == "exposure_compensation")
 			m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
+		// Note that `enable_motion_blur` itself is deliberately absent: it
+		// decides whether the render pipeline gets a motion blur step at all,
+		// and the pipeline is only built when the world is loaded (same as
+		// `enable_bloom`). Strength and quality are plain uniforms, so those
+		// can and should take effect immediately.
+		else if (name == "motion_blur_strength")
+			readMotionBlurStrength();
+		else if (name == "motion_blur_quality")
+			readMotionBlurQuality();
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -157,10 +180,8 @@ public:
 		m_bloom_enabled = g_settings->getBool("enable_bloom");
 		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
 		m_motion_blur_enabled = g_settings->getBool("enable_motion_blur");
-		m_motion_blur_strength = g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f);
-		// Must match MAX_SAMPLES in the motion_blur fragment shader.
-		m_motion_blur_quality = (float)g_settings->getS32("motion_blur_quality");
-		m_motion_blur_quality = rangelim(m_motion_blur_quality, 2.0f, 32.0f);
+		readMotionBlurStrength();
+		readMotionBlurQuality();
 		m_crack_animation_length_i = game->crack_animation_length;
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -63,6 +63,10 @@ class GameGlobalShaderUniformSetter : public IShaderUniformSetter
 {
 	Sky *m_sky;
 	Client *m_client;
+	/// Only the motion blur shader consumes the motion blur uniforms, and this
+	/// setter is instantiated per shader program, so everything else can skip
+	/// the work (which includes a 4x4 matrix inverse) entirely.
+	bool m_is_motion_blur_shader;
 
 	CachedVertexShaderSetting<float> m_animation_timer_vertex{"animationTimer"};
 	CachedPixelShaderSetting<float> m_animation_timer_pixel{"animationTimer"};
@@ -173,9 +177,10 @@ public:
 
 	void setSky(Sky *sky) { m_sky = sky; }
 
-	GameGlobalShaderUniformSetter(Sky *sky, Game *game) :
+	GameGlobalShaderUniformSetter(Sky *sky, Game *game, bool is_motion_blur_shader) :
 		m_sky(sky),
-		m_client(game->getClient())
+		m_client(game->getClient()),
+		m_is_motion_blur_shader(is_motion_blur_shader)
 	{
 		for (auto &name : SETTING_CALLBACKS)
 			g_settings->registerChangedCallback(name, settingsCallback, this);
@@ -225,7 +230,9 @@ public:
 		m_texel_size0_vertex.set(m_texel_size0, services);
 		m_texel_size0_pixel.set(m_texel_size0, services);
 
-		if (m_motion_blur_enabled) {
+		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
+
+		if (m_is_motion_blur_shader) {
 			auto *camera = m_client->getCamera();
 			auto *camera_node = camera->getCameraNode();
 
@@ -274,7 +281,14 @@ public:
 
 			m_motion_blur_inv_view_proj.set(inv_view_proj, services);
 			m_motion_blur_prev_view_proj.set(prev_view_proj, services);
-			m_motion_blur_strength_pixel.set(&m_motion_blur_strength, services);
+
+			// A strength pushed by the server wins outright: it may exceed the
+			// player's configured strength and switches the effect on even if
+			// the player has it disabled. Their settings apply only when the
+			// server has left it unset.
+			float strength = resolveMotionBlurStrength(lighting,
+					m_motion_blur_enabled, m_motion_blur_strength);
+			m_motion_blur_strength_pixel.set(&strength, services);
 		}
 
 		{
@@ -285,8 +299,6 @@ public:
 			tmp = m_crack_texture_scale_i;
 			m_crack_texture_scale.set(&tmp, services);
 		}
-
-		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 
 		const AutoExposure &exposure_params = lighting.exposure;
 		std::array<float, 7> exposure_buffer = {
@@ -398,7 +410,8 @@ public:
 	{
 		if (str_starts_with(name, "shadow/"))
 			return nullptr;
-		auto *scs = new GameGlobalShaderUniformSetter(m_sky, m_game);
+		auto *scs = new GameGlobalShaderUniformSetter(m_sky, m_game,
+				name == "motion_blur");
 		if (!m_sky)
 			created_nosky.push_back(scs);
 		return scs;

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -107,6 +107,8 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	static const u8 TEXTURE_MSAA_COLOR = 7;
 	static const u8 TEXTURE_MSAA_DEPTH = 8;
 
+	static const u8 TEXTURE_MOTIONBLUR = 9;
+
 	static const u8 TEXTURE_SCALE_DOWN = 10;
 	static const u8 TEXTURE_SCALE_UP = 20;
 
@@ -147,6 +149,7 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 
 	const bool enable_ssaa = antialiasing == "ssaa";
 	const bool enable_fxaa = g_settings->getBool("fxaa");
+	const bool enable_motion_blur = g_settings->getBool("enable_motion_blur");
 
 	verbosestream << "addPostProcessing(): AA = "
 		<< (enable_msaa ? "msaa" : enable_ssaa ? "ssaa" : "none")
@@ -191,7 +194,25 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 
 	// post-processing stage
 
-	u8 source = TEXTURE_COLOR;
+	// The base color texture that all following steps read from. Motion blur,
+	// if enabled, replaces it with a blurred copy.
+	u8 base = TEXTURE_COLOR;
+
+	// Camera (velocity) motion blur. Reconstructs each pixel's world position
+	// from the depth buffer and reprojects it with the previous frame's
+	// view-projection matrix to obtain a screen-space velocity, then blurs
+	// the color buffer along it.
+	if (enable_motion_blur) {
+		buffer->setTexture(TEXTURE_MOTIONBLUR, scale, "motionblur", color_format);
+		shader_id = client->getShaderSource()->getShaderRaw("motion_blur");
+		auto motion_blur = pipeline->addStep<PostProcessingStep>(shader_id, std::vector<u8> { TEXTURE_COLOR, TEXTURE_DEPTH });
+		motion_blur->setRenderSource(buffer);
+		motion_blur->setBilinearFilter(0, true);
+		motion_blur->setRenderTarget(pipeline->createOwned<TextureBufferOutput>(buffer, TEXTURE_MOTIONBLUR));
+		base = TEXTURE_MOTIONBLUR;
+	}
+
+	u8 source = base;
 
 	// common downsampling step for bloom or autoexposure
 	if (enable_bloom || enable_auto_exposure) {
@@ -260,14 +281,14 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	}
 
 	// FXAA
-	u8 final_stage_source = TEXTURE_COLOR;
+	u8 final_stage_source = base;
 
 	if (enable_fxaa) {
 		final_stage_source = TEXTURE_FXAA;
 
 		buffer->setTexture(TEXTURE_FXAA, scale, "fxaa", color_format);
 		shader_id = client->getShaderSource()->getShaderRaw("fxaa");
-		PostProcessingStep *effect = pipeline->createOwned<PostProcessingStep>(shader_id, std::vector<u8> { TEXTURE_COLOR });
+		PostProcessingStep *effect = pipeline->createOwned<PostProcessingStep>(shader_id, std::vector<u8> { base });
 		pipeline->addStep(effect);
 		effect->setBilinearFilter(0, true);
 		effect->setRenderSource(buffer);

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -205,7 +205,15 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	if (enable_motion_blur) {
 		buffer->setTexture(TEXTURE_MOTIONBLUR, scale, "motionblur", color_format);
 		shader_id = client->getShaderSource()->getShaderRaw("motion_blur");
-		auto motion_blur = pipeline->addStep<PostProcessingStep>(shader_id, std::vector<u8> { TEXTURE_COLOR, TEXTURE_DEPTH });
+		// When auto exposure is on, also feed the (previous frame's) exposure
+		// texture as texture2 so the blur can scale its length with exposure:
+		// longer smear in dark, exposure-boosted scenes and shorter in bright
+		// ones. TEXTURE_EXPOSURE_1 holds the settled exposure at this point in
+		// the pipeline (it is swapped in at the end of the frame).
+		std::vector<u8> motion_blur_textures { TEXTURE_COLOR, TEXTURE_DEPTH };
+		if (enable_auto_exposure)
+			motion_blur_textures.push_back(TEXTURE_EXPOSURE_1);
+		auto motion_blur = pipeline->addStep<PostProcessingStep>(shader_id, motion_blur_textures);
 		motion_blur->setRenderSource(buffer);
 		motion_blur->setBilinearFilter(0, true);
 		motion_blur->setRenderTarget(pipeline->createOwned<TextureBufferOutput>(buffer, TEXTURE_MOTIONBLUR));

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -6,9 +6,13 @@
 
 #include "secondstage.h"
 #include "client/client.h"
+#include "client/camera.h"
+#include "client/content_cao.h"
+#include "client/localplayer.h"
 #include "client/shader.h"
 #include "settings.h"
 #include "plain.h"
+#include <ICameraSceneNode.h>
 #include <ISceneManager.h>
 
 PostProcessingStep::PostProcessingStep(u32 _shader_id, const std::vector<u8> &_texture_map) :
@@ -82,6 +86,116 @@ void PostProcessingStep::setBilinearFilter(u8 index, bool value)
 	material.TextureLayers[index].MagFilter = value ? video::ETMAGF_LINEAR : video::ETMAGF_NEAREST;
 }
 
+void SharedDepthTextureOutput::activate(PipelineContext &context)
+{
+	// Never let the base class issue its blanket clear, which would destroy the
+	// borrowed depth buffer. Clearing our own colour attachment afterwards is
+	// enough: the mask has to start from zero every frame, the depth does not.
+	m_clear = false;
+	TextureBufferOutput::activate(context);
+	context.device->getVideoDriver()->clearBuffers(video::ECBF_COLOR,
+			video::SColor(0, 0, 0, 0));
+}
+
+CameraRigidMaskStep::CameraRigidMaskStep(Client *client) :
+	m_client(client)
+{
+	auto *driver = client->getSceneManager()->getVideoDriver();
+	auto *shdsrc = client->getShaderSource();
+
+	// The mask is drawn over entity meshes, which may be skinned, so the shader
+	// has to be built with skinning support exactly as the shadow depth shader
+	// is. One variant covers both cases: the vertex shader falls back to the
+	// unskinned path when the weight attribute is disabled.
+	ShaderConstants consts;
+	const auto max_joints = driver->getMaxJointTransforms();
+	if (max_joints > 0) {
+		consts["USE_SKINNING"] = 1;
+		consts["MAX_JOINTS"] = max_joints;
+	}
+
+	u32 shader_id = shdsrc->getShader("object_mask", consts, video::EMT_SOLID);
+	m_mask_material = shdsrc->getShaderInfo(shader_id).material;
+}
+
+void CameraRigidMaskStep::renderObject(video::IVideoDriver *driver, GenericCAO *cao)
+{
+	scene::ISceneNode *node = cao->getSceneNode();
+	if (node && node->isVisible()) {
+		const u32 count = node->getMaterialCount();
+
+		// Swap in the mask shader, following the same backup/restore dance the
+		// shadow renderer uses for entities. Depth writes are disabled because
+		// the depth buffer is shared with the scene: the values would come out
+		// identical, but writing to a buffer later steps read from is a trap
+		// worth not leaving lying around.
+		m_saved_material_types.clear();
+		m_saved_material_types.reserve(count);
+		for (u32 i = 0; i < count; i++) {
+			auto &material = node->getMaterial(i);
+			m_saved_material_types.push_back(material.MaterialType);
+			material.MaterialType = m_mask_material;
+		}
+
+		auto &override_material = driver->getOverrideMaterial();
+		override_material.reset();
+		override_material.Material.ZWriteEnable = video::EZW_OFF;
+		override_material.EnableProps = video::EMP_ZWRITE_ENABLE;
+		// We are drawing outside the scene manager, so the "enabled in this
+		// pass" flag the scene manager would normally maintain is ours to set.
+		override_material.Enabled = true;
+
+		driver->setTransform(video::ETS_WORLD, node->getAbsoluteTransformation());
+		node->render();
+
+		override_material.reset();
+
+		for (u32 i = 0; i < count; i++)
+			node->getMaterial(i).MaterialType = m_saved_material_types[i];
+	}
+
+	// Recurse into anything attached to this object. Note that renderObject
+	// reuses m_saved_material_types, so the recursion has to come after this
+	// object is done with it.
+	for (auto child_id : cao->getAttachmentChildIds()) {
+		if (GenericCAO *child = m_client->getEnv().getGenericCAO(child_id))
+			renderObject(driver, child);
+	}
+}
+
+void CameraRigidMaskStep::run(PipelineContext &context)
+{
+	if (m_target)
+		m_target->activate(context);
+
+	LocalPlayer *player = m_client->getEnv().getLocalPlayer();
+	if (!player)
+		return;
+	GenericCAO *cao = player->getCAO();
+	if (!cao)
+		return;
+
+	auto *driver = context.device->getVideoDriver();
+
+	// The camera transforms are still those left behind by the 3D draw, but set
+	// them explicitly rather than relying on that.
+	auto *camera_node = m_client->getCamera()->getCameraNode();
+	driver->setTransform(video::ETS_PROJECTION, camera_node->getProjectionMatrix());
+	driver->setTransform(video::ETS_VIEW, camera_node->getViewMatrix());
+
+	// Climb to the root of the attachment tree the player belongs to (the boat
+	// it is sitting in, say) and mask that whole tree.
+	GenericCAO *root = cao;
+	while (ClientActiveObject *parent = root->getParent()) {
+		GenericCAO *parent_cao = dynamic_cast<GenericCAO *>(parent);
+		if (!parent_cao)
+			break;
+		root = parent_cao;
+	}
+
+	renderObject(driver, root);
+}
+
 RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep, v2f scale, Client *client)
 {
 	auto buffer = pipeline->createOwned<TextureBuffer>();
@@ -108,6 +222,7 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	static const u8 TEXTURE_MSAA_DEPTH = 8;
 
 	static const u8 TEXTURE_MOTIONBLUR = 9;
+	static const u8 TEXTURE_RIGID_MASK = 30;
 
 	static const u8 TEXTURE_SCALE_DOWN = 10;
 	static const u8 TEXTURE_SCALE_UP = 20;
@@ -203,6 +318,17 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	// view-projection matrix to obtain a screen-space velocity, then blurs
 	// the color buffer along it.
 	if (enable_motion_blur) {
+		// Mask of objects that move with the camera (the player's own body and
+		// whatever it is riding). These are motionless on screen, so the blur
+		// has to be told to leave them alone; see CameraRigidMaskStep. A plain
+		// 8-bit target is plenty for a 0/1 mask. This shares TEXTURE_DEPTH, so
+		// it must run after the 3D draw has filled it and before anything
+		// overwrites it.
+		buffer->setTexture(TEXTURE_RIGID_MASK, scale, "rigidmask", video::ECF_A8R8G8B8);
+		auto rigid_mask = pipeline->addStep<CameraRigidMaskStep>(client);
+		rigid_mask->setRenderTarget(pipeline->createOwned<SharedDepthTextureOutput>(
+				buffer, std::vector<u8> { TEXTURE_RIGID_MASK }, TEXTURE_DEPTH));
+
 		buffer->setTexture(TEXTURE_MOTIONBLUR, scale, "motionblur", color_format);
 		// The sample count is baked into the shader as a compile-time constant
 		// so that its sampling loop has a literal bound and can be unrolled.
@@ -227,7 +353,7 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 		// created unconditionally above and cleared to zero, which decodes to a
 		// neutral exposure factor of 1.
 		std::vector<u8> motion_blur_textures {
-				TEXTURE_COLOR, TEXTURE_DEPTH, TEXTURE_EXPOSURE_1 };
+				TEXTURE_COLOR, TEXTURE_DEPTH, TEXTURE_EXPOSURE_1, TEXTURE_RIGID_MASK };
 		auto motion_blur = pipeline->addStep<PostProcessingStep>(shader_id, motion_blur_textures);
 		motion_blur->setRenderSource(buffer);
 		motion_blur->setBilinearFilter(0, true);

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -205,14 +205,21 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	if (enable_motion_blur) {
 		buffer->setTexture(TEXTURE_MOTIONBLUR, scale, "motionblur", color_format);
 		shader_id = client->getShaderSource()->getShaderRaw("motion_blur");
-		// When auto exposure is on, also feed the (previous frame's) exposure
-		// texture as texture2 so the blur can scale its length with exposure:
-		// longer smear in dark, exposure-boosted scenes and shorter in bright
-		// ones. TEXTURE_EXPOSURE_1 holds the settled exposure at this point in
-		// the pipeline (it is swapped in at the end of the frame).
-		std::vector<u8> motion_blur_textures { TEXTURE_COLOR, TEXTURE_DEPTH };
-		if (enable_auto_exposure)
-			motion_blur_textures.push_back(TEXTURE_EXPOSURE_1);
+		// Feed the (previous frame's) exposure texture as texture2 so the blur
+		// can scale its length with exposure: longer smear in dark,
+		// exposure-boosted scenes and shorter in bright ones. TEXTURE_EXPOSURE_1
+		// holds the settled exposure at this point in the pipeline (it is
+		// swapped in at the end of the frame).
+		//
+		// This is bound unconditionally on purpose. The shader guards its use
+		// behind ENABLE_AUTO_EXPOSURE, which the shader source derives from the
+		// raw `enable_auto_exposure` setting, whereas `enable_auto_exposure`
+		// here *also* requires float render target support. When those two
+		// disagree the shader would sample an unbound sampler. The texture is
+		// created unconditionally above and cleared to zero, which decodes to a
+		// neutral exposure factor of 1.
+		std::vector<u8> motion_blur_textures {
+				TEXTURE_COLOR, TEXTURE_DEPTH, TEXTURE_EXPOSURE_1 };
 		auto motion_blur = pipeline->addStep<PostProcessingStep>(shader_id, motion_blur_textures);
 		motion_blur->setRenderSource(buffer);
 		motion_blur->setBilinearFilter(0, true);

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -204,7 +204,15 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 	// the color buffer along it.
 	if (enable_motion_blur) {
 		buffer->setTexture(TEXTURE_MOTIONBLUR, scale, "motionblur", color_format);
-		shader_id = client->getShaderSource()->getShaderRaw("motion_blur");
+		// The sample count is baked into the shader as a compile-time constant
+		// so that its sampling loop has a literal bound and can be unrolled.
+		// One program is compiled and cached per distinct value; the cost is
+		// that changing the setting only takes effect on world reload.
+		ShaderConstants motion_blur_constants;
+		motion_blur_constants["MOTION_BLUR_SAMPLES"] =
+				(int)rangelim(g_settings->getS32("motion_blur_quality"), 2, 32);
+		shader_id = client->getShaderSource()->getShader("motion_blur",
+				motion_blur_constants, video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF);
 		// Feed the (previous frame's) exposure texture as texture2 so the blur
 		// can scale its length with exposure: longer smear in dark,
 		// exposure-boosted scenes and shorter in bright ones. TEXTURE_EXPOSURE_1

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -171,6 +171,14 @@ void CameraRigidMaskStep::run(PipelineContext &context)
 	LocalPlayer *player = m_client->getEnv().getLocalPlayer();
 	if (!player)
 		return;
+
+	// Nothing will be blurred this frame, so nothing needs masking. The target
+	// was still activated above, which clears the mask to zero.
+	if (resolveMotionBlurStrength(player->getLighting(),
+			g_settings->getBool("enable_motion_blur"),
+			g_settings->getFloat("motion_blur_strength", 0.0f, 4.0f)) <= 0.0f)
+		return;
+
 	GenericCAO *cao = player->getCAO();
 	if (!cao)
 		return;
@@ -264,7 +272,13 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 
 	const bool enable_ssaa = antialiasing == "ssaa";
 	const bool enable_fxaa = g_settings->getBool("fxaa");
-	const bool enable_motion_blur = g_settings->getBool("enable_motion_blur");
+	// Note this is deliberately NOT gated on the `enable_motion_blur` setting.
+	// A server can push a motion blur strength that overrides the player's
+	// settings, including switching the effect on for someone who has it off,
+	// so the pass has to exist even when the player does not currently want it.
+	// It idles cheaply in that case: the shader early-outs at zero velocity and
+	// the mask step below skips its geometry entirely.
+	const bool enable_motion_blur = true;
 
 	verbosestream << "addPostProcessing(): AA = "
 		<< (enable_msaa ? "msaa" : enable_ssaa ? "ssaa" : "none")

--- a/src/client/render/secondstage.h
+++ b/src/client/render/secondstage.h
@@ -5,6 +5,9 @@
 
 #pragma once
 #include "pipeline.h"
+#include <vector>
+
+class GenericCAO;
 
 /**
  *  Step to apply post-processing filter to the rendered image
@@ -56,5 +59,59 @@ private:
 	TextureBufferOutput *target_fbo;
 };
 
+
+/**
+ * Render target that borrows the depth buffer of an earlier step.
+ *
+ * TextureBufferOutput clears every attachment on its first activation of a
+ * frame. That is wrong when the depth attachment is shared: it would wipe the
+ * scene depth that this target wants to test against, and that later steps still
+ * need to read. Suppress the blanket clear and clear only the colour attachment.
+ */
+class SharedDepthTextureOutput : public TextureBufferOutput
+{
+public:
+	using TextureBufferOutput::TextureBufferOutput;
+
+	void activate(PipelineContext &context) override;
+};
+
+/**
+ * Renders the objects that are rigidly attached to the camera into a mask.
+ *
+ * Camera motion blur reconstructs each pixel's world position and reprojects it
+ * through the previous frame's camera, which silently assumes every pixel is
+ * fixed in the world. That is wrong for anything carried along by the camera:
+ * the local player's own body, and whatever it is riding, are motionless on
+ * screen yet get the largest smear of anything in the frame, because they sit
+ * closest to the camera. This step marks those pixels so the blur can skip them.
+ *
+ * The set is the connected attachment component containing the local player:
+ * walk up the parent chain to its root, then render that whole subtree. Anything
+ * attached to the thing the player is riding rides along with it too.
+ *
+ * The scene depth buffer is shared rather than rebuilt, so parts of the player
+ * hidden behind terrain in third person simply fail the depth test and stay out
+ * of the mask, with no special casing.
+ */
+class CameraRigidMaskStep : public RenderStep
+{
+public:
+	CameraRigidMaskStep(Client *client);
+
+	void setRenderSource(RenderSource *source) override {}
+	void setRenderTarget(RenderTarget *target) override { m_target = target; }
+	void reset(PipelineContext &context) override {}
+	void run(PipelineContext &context) override;
+
+private:
+	void renderObject(video::IVideoDriver *driver, GenericCAO *cao);
+
+	Client *m_client;
+	RenderTarget *m_target = nullptr;
+	video::E_MATERIAL_TYPE m_mask_material = video::EMT_SOLID;
+	/// Scratch space for the material swap, kept to avoid reallocating per frame.
+	std::vector<video::E_MATERIAL_TYPE> m_saved_material_types;
+};
 
 RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep, v2f scale, Client *client);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -339,6 +339,8 @@ void set_default_settings()
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");
 	settings->setDefault("enable_volumetric_lighting", "false");
+	settings->setDefault("enable_motion_blur", "false");
+	settings->setDefault("motion_blur_strength", "1.0");
 	settings->setDefault("enable_water_reflections", "false");
 	settings->setDefault("enable_translucent_foliage", "false");
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -340,7 +340,7 @@ void set_default_settings()
 	settings->setDefault("enable_bloom_debug", "false");
 	settings->setDefault("enable_volumetric_lighting", "false");
 	settings->setDefault("enable_motion_blur", "false");
-	settings->setDefault("motion_blur_strength", "1.0");
+	settings->setDefault("motion_blur_strength", "0.4");
 	settings->setDefault("motion_blur_quality", "8");
 	settings->setDefault("enable_water_reflections", "false");
 	settings->setDefault("enable_translucent_foliage", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,6 +341,7 @@ void set_default_settings()
 	settings->setDefault("enable_volumetric_lighting", "false");
 	settings->setDefault("enable_motion_blur", "false");
 	settings->setDefault("motion_blur_strength", "1.0");
+	settings->setDefault("motion_blur_quality", "8");
 	settings->setDefault("enable_water_reflections", "false");
 	settings->setDefault("enable_translucent_foliage", "false");
 

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -52,5 +52,28 @@ struct Lighting
 	float bloom_intensity {0.05f};
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
+	/**
+	 * Absolute motion blur strength, or negative to leave it to the player.
+	 *
+	 * A non-negative value overrides the player's own motion blur settings
+	 * outright: it may exceed their configured strength, and it switches the
+	 * effect on even for a player who has it disabled. Negative means unset,
+	 * in which case the player's own settings apply.
+	 */
+	float motion_blur_strength {-1.0f};
 	v3f shadow_direction;
 };
+
+/**
+ * Resolve the motion blur strength to actually render with.
+ *
+ * A server-provided strength wins outright; the player's settings are only
+ * consulted when the server has left it unset.
+ */
+inline float resolveMotionBlurStrength(const Lighting &lighting,
+		bool player_enabled, float player_strength)
+{
+	if (lighting.motion_blur_strength >= 0.0f)
+		return lighting.motion_blur_strength;
+	return player_enabled ? player_strength : 0.0f;
+}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1916,5 +1916,10 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 			break;
 		// >= 5.16.0-dev
 		*pkt >> lighting.shadow_direction;
+
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.17.0-dev
+		*pkt >> lighting.motion_blur_strength;
 	} while (0);
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2874,6 +2874,22 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
 		}
 		lua_pop(L, 1); // bloom
+
+		lua_getfield(L, 2, "motion_blur");
+		if (lua_istable(L, -1)) {
+			// Unlike the sections above, an absent (or explicitly nil)
+			// `strength` is meaningful here: it hands control back to the
+			// player's own settings rather than leaving the current value
+			// alone. Naming the section at all is the act of setting it.
+			lua_getfield(L, -1, "strength");
+			if (lua_isnil(L, -1))
+				lighting.motion_blur_strength = -1.0f;
+			else
+				lighting.motion_blur_strength =
+						rangelim((float)luaL_checknumber(L, -1), 0.0f, 4.0f);
+			lua_pop(L, 1); // strength
+		}
+		lua_pop(L, 1); // motion_blur
 }
 
 	getServer(L)->setLighting(player, lighting);
@@ -2928,6 +2944,14 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.bloom_radius);
 	lua_setfield(L, -2, "radius");
 	lua_setfield(L, -2, "bloom");
+	lua_newtable(L); // "motion_blur"
+	// Left absent when unset, so that a round trip through set_lighting keeps
+	// the "player decides" state rather than pinning it to a number.
+	if (lighting.motion_blur_strength >= 0.0f) {
+		lua_pushnumber(L, lighting.motion_blur_strength);
+		lua_setfield(L, -2, "strength");
+	}
+	lua_setfield(L, -2, "motion_blur");
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2061,6 +2061,8 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 
 	pkt << lighting.shadow_direction;
 
+	pkt << lighting.motion_blur_strength;
+
 	Send(&pkt);
 }
 


### PR DESCRIPTION
## Thing:

Adds an optional camera motion blur post-processing effect. Disabled by default.

## How does it work?

It's a depth-reprojection blur, with no extra scene pass for the blur itself.
It just takes the motion of the camera and compares it to the depth map for "terrain velocity".
Importantly though, the player's model/sprite+all_attached_objects are excluded from the effect.

Notes on the details:

- **Bright** trails: bright pixels are added with `max()` along a longer line rather than averaged, so a moving light source leaves an un-dimming streak that the bloom pass uses afterwards.
- Sample count is a constant so the loop bound is a literal and can be unrolled; one program is compiled and cached per quality value.

### Cost

One extra full-resolution color buffer, one 8-bit mask buffer, and 2 texture fetches per sample (default 8, max 32). No cost when the camera is still, since there is a small dead-zone for movement.

## Does it resolve any reported issue?

No.. But its cool!

## Does this relate to a goal in the roadmap?

No. This would need concept approval. :P

## Why is this PR needed?

Visual polish is nice. I've played with it for a few days and it definitely adds a small layer of immersion on the more polished side. I've also given it lua support with set_lighting, so it could be taken to extremes and set really high for effects like vertigo/dizziness.

## AI disclosure

Yes. AI was used for reviewing the initial implementation and for writing the subsequent correctness/portability fixes and the camera-rigid mask pass. All changes were reviewed and tested by me.

This PR is Ready for Review.

### Known limitations

- Only camera motion is used for blur. An entity moving past a stationary camera gets no blur, neither do fast animations. True per-object velocity is not currently reachable, since `EVDF_MULTIPLE_RENDER_TARGETS` returns `false` in our Irrlicht.
- Blur length scales with frame time, so lower frame rates smear more.

## How to test

1. Enable Post Processing, then **Motion blur** in Settings > Graphics > Effects.
2. Turn quickly and move fast. The scene should smear along the direction of motion.
3. Adjust **Motion blur strength** in-game; it applies immediately. **Motion blur quality** requires a world reload (it selects a different shader program).
4. Enable Bloom (optional) and look at a torch or other light source while turning. It should leave a glowing trail.
5. Third person (F7) and while riding a boat or attached to some object: your body and the vehicle should stay sharp. Walk behind terrain in third person, and the occluded parts should blur normally.
6. With Auto Exposure on, blur length should grow in dark areas and shrink in bright ones. (though this is kind of hard to notice.)
