### PR TITLE
Use mesh cache when building node visuals

### DIFF
--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -14,7 +14,7 @@
 static inline f32 my_atof(const char *p)
 {
 	// FIXME: should we check the endptr??
-	return (f32)strtod(p, nullptr);
+	return strtof(p, nullptr);
 }
 
 namespace scene

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -12,6 +12,7 @@
 #include "clientmap.h"
 #include "clientmedia.h"
 #include "client/mesh_generator_thread.h"
+#include "client/mesh.h"
 #include "client/particles.h"
 #include "client/renderingengine.h"
 #include "client/sound.h"
@@ -68,6 +69,8 @@
 #include <IAnimatedMesh.h>
 #include <IFileSystem.h>
 #include <IReadFile.h>
+#include <IMeshCache.h>
+#include <SMesh.h>
 #include <json/json.h>
 
 #include <iostream>
@@ -118,6 +121,14 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 	}
 
 	e.append(" @").append(oss.str());
+}
+
+static bool isMeshStatic(scene::IAnimatedMesh *mesh)
+{
+	if (mesh->getTrackCount() == 0)
+		return true;
+	// are empty tracks supposed to be cleaned up on load? seems they're not
+	return mesh->getTrackCount() == 1 && mesh->getMaxFrameNumber(0) == 0.0f;
 }
 
 /*
@@ -2043,29 +2054,56 @@ ParticleManager* Client::getParticleManager()
 	return m_particle_manager.get();
 }
 
-scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
+scene::IAnimatedMesh *Client::getOriginalMesh(const std::string &filename, bool *must_clone)
 {
-	StringMap::const_iterator it = m_mesh_data.find(filename);
-	if (it == m_mesh_data.end()) {
-		errorstream << "Client::getMesh(): Mesh not found: \"" << filename
-			<< "\"" << std::endl;
-		return NULL;
-	}
-	const std::string &data    = it->second;
+	assert(must_clone); // caller must make use of this
 
-	// Create the mesh, remove it from cache and return it
-	// This allows unique vertex colors and other properties for each instance
+	auto it = m_mesh_data.find(filename);
+	if (it == m_mesh_data.end())
+		return nullptr;
+	const std::string &data = it->second;
+
+	// Try getting it from cache explicitly
+	auto *sm = m_rendering_engine->get_scene_manager();
+	auto *mesh = sm->getMeshCache()->getMeshByName(filename.c_str());
+	if (mesh) {
+		*must_clone = true;
+		mesh->grab();
+		return mesh;
+	}
+
+	// Load the mesh from file data
 	io::IReadFile *rfile = m_rendering_engine->get_filesystem()->createMemoryReadFile(
 			data.c_str(), data.size(), filename.c_str());
 	FATAL_ERROR_IF(!rfile, "Could not create/open RAM file");
 
-	scene::IAnimatedMesh *mesh = m_rendering_engine->get_scene_manager()->getMesh(rfile);
+	mesh = sm->getMesh(rfile);
 	rfile->drop();
 	if (!mesh)
 		return nullptr;
 	mesh->grab();
-	if (!cache)
-		m_rendering_engine->removeMesh(mesh);
+	// We can (currently) only clone static meshes, so only cache those
+	if (isMeshStatic(mesh)) {
+		*must_clone = true;
+	} else {
+		sm->getMeshCache()->removeMesh(mesh);
+		*must_clone = false;
+	}
+	return mesh;
+}
+
+scene::IAnimatedMesh *Client::getMesh(const std::string &filename)
+{
+	bool must_clone;
+	auto *mesh = getOriginalMesh(filename, &must_clone);
+	if (mesh && must_clone) {
+		// Clone it to allow unique vertex colors and other modifications
+		assert(isMeshStatic(mesh));
+		auto *ret = cloneStaticMesh(mesh);
+		assert(ret);
+		mesh->drop();
+		return ret;
+	}
 	return mesh;
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -123,13 +123,6 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 	e.append(" @").append(oss.str());
 }
 
-static bool isMeshStatic(const scene::IAnimatedMesh *mesh)
-{
-	if (!mesh)
-		return false;
-	return mesh->getTrackCount() == 0;
-}
-
 /*
 	Client
 */
@@ -2055,26 +2048,23 @@ ParticleManager* Client::getParticleManager()
 
 scene::IAnimatedMesh *Client::getMesh(const std::string &filename, bool *is_shared)
 {
-	const auto &set_shared = [=] (bool v) {
-		if (is_shared)
-			*is_shared = v;
-	};
-
 	auto it = m_mesh_data.find(filename);
 	if (it == m_mesh_data.end())
 		return nullptr;
-	const std::string &data = it->second;
+
+	if (is_shared)
+		*is_shared = true; // this is currently always the case
 
 	// Try getting it from cache explicitly
 	auto *sm = m_rendering_engine->get_scene_manager();
 	auto *mesh = sm->getMeshCache()->getMeshByName(filename.c_str());
 	if (mesh) {
-		set_shared(true);
 		mesh->grab();
 		return mesh;
 	}
 
 	// Load the mesh from file data
+	const std::string &data = it->second;
 	io::IReadFile *rfile = m_rendering_engine->get_filesystem()->createMemoryReadFile(
 			data.c_str(), data.size(), filename.c_str());
 	FATAL_ERROR_IF(!rfile, "Could not create/open RAM file");
@@ -2084,28 +2074,6 @@ scene::IAnimatedMesh *Client::getMesh(const std::string &filename, bool *is_shar
 	if (!mesh)
 		return nullptr;
 	mesh->grab();
-	// We can (currently) only clone static meshes, so only cache those
-	if (isMeshStatic(mesh)) {
-		set_shared(true);
-	} else {
-		sm->getMeshCache()->removeMesh(mesh);
-		set_shared(false);
-	}
-
-	return mesh;
-}
-
-scene::IAnimatedMesh *Client::getMeshCopy(const std::string &filename)
-{
-	bool is_shared;
-	auto *mesh = getMesh(filename, &is_shared);
-	if (mesh && is_shared) {
-		assert(isMeshStatic(mesh));
-		auto *ret = cloneStaticMesh(mesh);
-		assert(ret);
-		mesh->drop();
-		return ret;
-	}
 	return mesh;
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -123,12 +123,11 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 	e.append(" @").append(oss.str());
 }
 
-static bool isMeshStatic(scene::IAnimatedMesh *mesh)
+static bool isMeshStatic(const scene::IAnimatedMesh *mesh)
 {
-	if (mesh->getTrackCount() == 0)
-		return true;
-	// are empty tracks supposed to be cleaned up on load? seems they're not
-	return mesh->getTrackCount() == 1 && mesh->getMaxFrameNumber(0) == 0.0f;
+	if (!mesh)
+		return false;
+	return mesh->getTrackCount() == 0;
 }
 
 /*
@@ -2054,9 +2053,12 @@ ParticleManager* Client::getParticleManager()
 	return m_particle_manager.get();
 }
 
-scene::IAnimatedMesh *Client::getOriginalMesh(const std::string &filename, bool *must_clone)
+scene::IAnimatedMesh *Client::getMesh(const std::string &filename, bool *is_shared)
 {
-	assert(must_clone); // caller must make use of this
+	const auto &set_shared = [=] (bool v) {
+		if (is_shared)
+			*is_shared = v;
+	};
 
 	auto it = m_mesh_data.find(filename);
 	if (it == m_mesh_data.end())
@@ -2067,7 +2069,7 @@ scene::IAnimatedMesh *Client::getOriginalMesh(const std::string &filename, bool 
 	auto *sm = m_rendering_engine->get_scene_manager();
 	auto *mesh = sm->getMeshCache()->getMeshByName(filename.c_str());
 	if (mesh) {
-		*must_clone = true;
+		set_shared(true);
 		mesh->grab();
 		return mesh;
 	}
@@ -2084,20 +2086,20 @@ scene::IAnimatedMesh *Client::getOriginalMesh(const std::string &filename, bool 
 	mesh->grab();
 	// We can (currently) only clone static meshes, so only cache those
 	if (isMeshStatic(mesh)) {
-		*must_clone = true;
+		set_shared(true);
 	} else {
 		sm->getMeshCache()->removeMesh(mesh);
-		*must_clone = false;
+		set_shared(false);
 	}
+
 	return mesh;
 }
 
-scene::IAnimatedMesh *Client::getMesh(const std::string &filename)
+scene::IAnimatedMesh *Client::getMeshCopy(const std::string &filename)
 {
-	bool must_clone;
-	auto *mesh = getOriginalMesh(filename, &must_clone);
-	if (mesh && must_clone) {
-		// Clone it to allow unique vertex colors and other modifications
+	bool is_shared;
+	auto *mesh = getMesh(filename, &is_shared);
+	if (mesh && is_shared) {
 		assert(isMeshStatic(mesh));
 		auto *ret = cloneStaticMesh(mesh);
 		assert(ret);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -12,7 +12,6 @@
 #include "clientmap.h"
 #include "clientmedia.h"
 #include "client/mesh_generator_thread.h"
-#include "client/mesh.h"
 #include "client/particles.h"
 #include "client/renderingengine.h"
 #include "client/sound.h"
@@ -70,7 +69,6 @@
 #include <IFileSystem.h>
 #include <IReadFile.h>
 #include <IMeshCache.h>
-#include <SMesh.h>
 #include <json/json.h>
 
 #include <iostream>

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -375,9 +375,17 @@ public:
 	virtual ISoundManager* getSoundManager();
 	MtEventManager* getEventManager();
 	virtual ParticleManager* getParticleManager();
+
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
+
+	// Gets an unique copy of a named mesh
+	// (returned pointer must be dropped)
+	scene::IAnimatedMesh *getMesh(const std::string &filename);
+	// Gets a pointer to a named mesh, you may need to clone it before use
+	// (returned pointer must be dropped)
+	scene::IAnimatedMesh *getOriginalMesh(const std::string &filename, bool *must_clone);
+
 	ModVFS *getModVFS() { return m_mod_vfs.get(); }
 	ModStorageDatabase *getModStorageDatabase() override { return m_mod_storage_database; }
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -379,12 +379,9 @@ public:
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
 
-	// Gets an unique copy of a named mesh
-	// (returned pointer must be dropped)
-	scene::IAnimatedMesh *getMeshCopy(const std::string &filename);
 	// Gets a pointer to a named mesh
-	// You may need to clone it before modifying (-> `is_shared`)
-	// (returned pointer must be dropped)
+	// If you want to modify it, you may need to clone it first (-> `is_shared`)
+	// (the returned pointer must be dropped)
 	scene::IAnimatedMesh *getMesh(const std::string &filename, bool *is_shared = nullptr);
 
 	ModVFS *getModVFS() { return m_mod_vfs.get(); }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -381,10 +381,11 @@ public:
 
 	// Gets an unique copy of a named mesh
 	// (returned pointer must be dropped)
-	scene::IAnimatedMesh *getMesh(const std::string &filename);
-	// Gets a pointer to a named mesh, you may need to clone it before use
+	scene::IAnimatedMesh *getMeshCopy(const std::string &filename);
+	// Gets a pointer to a named mesh
+	// You may need to clone it before modifying (-> `is_shared`)
 	// (returned pointer must be dropped)
-	scene::IAnimatedMesh *getOriginalMesh(const std::string &filename, bool *must_clone);
+	scene::IAnimatedMesh *getMesh(const std::string &filename, bool *is_shared = nullptr);
 
 	ModVFS *getModVFS() { return m_mod_vfs.get(); }
 	ModStorageDatabase *getModStorageDatabase() override { return m_mod_storage_database; }

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -690,6 +690,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		});
 		break;
 	} case OBJECTVISUAL_MESH: {
+		// NOTE: the mesh can be shared, don't modify it
 		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh);
 		if (mesh) {
 			if (!checkMeshNormals(mesh)) {
@@ -705,6 +706,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 			m_animated_meshnode->setScale(m_prop.visual_size);
 
 			// set vertex colors to ensure alpha is set
+			// (FIXME: doing this to a shared mesh is fishy)
 			setMeshColor(mesh, video::SColor(0xFFFFFFFF));
 
 			setSceneNodeMaterials(m_animated_meshnode, mesh->needsHwSkinning());

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -690,7 +690,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		});
 		break;
 	} case OBJECTVISUAL_MESH: {
-		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh, true);
+		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh);
 		if (mesh) {
 			if (!checkMeshNormals(mesh)) {
 				infostream << "GenericCAO: recalculating normals for mesh "
@@ -705,7 +705,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 			m_animated_meshnode->setScale(m_prop.visual_size);
 
 			// set vertex colors to ensure alpha is set
-			setMeshColor(m_animated_meshnode->getMesh(), video::SColor(0xFFFFFFFF));
+			setMeshColor(mesh, video::SColor(0xFFFFFFFF));
 
 			setSceneNodeMaterials(m_animated_meshnode, mesh->needsHwSkinning());
 
@@ -731,8 +731,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 					++it;
 				}
 			});
-		} else
+		} else {
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
+		}
 		break;
 	}
 	case OBJECTVISUAL_WIELDITEM:

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -496,8 +496,8 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 	if (f->drawtype != NDT_MESH || mesh.empty())
 		return;
 
-	bool must_clone;
-	if (scene::IMesh *src_mesh = client->getOriginalMesh(mesh, &must_clone)) {
+	bool need_copy;
+	if (scene::IMesh *src_mesh = client->getMesh(mesh, &need_copy)) {
 		bool apply_bs = false;
 		if (auto *skinned_mesh = dynamic_cast<scene::SkinnedMesh *>(src_mesh)) {
 			/*
@@ -512,7 +512,7 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 			mesh_ptr = cloneStaticMesh(src_mesh);
 			src_mesh->drop();
 		} else {
-			if (must_clone) {
+			if (need_copy) {
 				mesh_ptr = cloneStaticMesh(src_mesh);
 				src_mesh->drop();
 			} else {

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -496,14 +496,15 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 	if (f->drawtype != NDT_MESH || mesh.empty())
 		return;
 
-	// Note: By freshly reading, we get an unencumbered mesh.
-	if (scene::IMesh *src_mesh = client->getMesh(mesh)) {
+	bool must_clone;
+	if (scene::IMesh *src_mesh = client->getOriginalMesh(mesh, &must_clone)) {
 		bool apply_bs = false;
 		if (auto *skinned_mesh = dynamic_cast<scene::SkinnedMesh *>(src_mesh)) {
-			// Compatibility: Animated meshes, as well as static gltf meshes, are not scaled by BS.
-			// See https://github.com/luanti-org/luanti/pull/16112#issuecomment-2881860329
-			bool is_gltf = skinned_mesh->getSourceFormat() ==
-					scene::SkinnedMesh::SourceFormat::GLTF;
+			/*
+			 * Compatibility mess: Animated meshes - as well as static gltf meshes -
+			 * are not scaled by BS. see <https://github.com/luanti-org/luanti/pull/16112#issuecomment-2881860329>
+			 */
+			bool is_gltf = skinned_mesh->getSourceFormat() == scene::SkinnedMesh::SourceFormat::GLTF;
 			apply_bs = skinned_mesh->isStatic() && !is_gltf;
 			// Nodes do not support mesh animation, so we clone the static pose.
 			// This simplifies working with the mesh: We can just scale the vertices
@@ -511,12 +512,18 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 			mesh_ptr = cloneStaticMesh(src_mesh);
 			src_mesh->drop();
 		} else {
-			auto *static_mesh = dynamic_cast<scene::SMesh *>(src_mesh);
-			assert(static_mesh);
-			mesh_ptr = static_mesh;
-			// Compatibility: Apply BS scaling to static meshes (.obj). See #15811.
+			if (must_clone) {
+				mesh_ptr = cloneStaticMesh(src_mesh);
+				src_mesh->drop();
+			} else {
+				mesh_ptr = dynamic_cast<scene::SMesh *>(src_mesh);
+			}
+			assert(mesh_ptr);
+			// Compatibility: Apply BS scaling to static meshes (.obj), see #15811.
 			apply_bs = true;
 		}
+		src_mesh = nullptr;
+
 		scaleMesh(mesh_ptr, v3f((apply_bs ? BS : 1.0f) * f->visual_scale));
 		recalculateBoundingBox(mesh_ptr);
 		if (!checkMeshNormals(mesh_ptr)) {
@@ -526,6 +533,7 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 			manip->recalculateNormals(mesh_ptr, true, false);
 		}
 	} else {
+		errorstream << "NodeVisuals::updateMesh(): Could not load mesh " << mesh << std::endl;
 		mesh_ptr = nullptr;
 	}
 }

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -261,11 +261,6 @@ void RenderingEngine::setResizable(bool resize)
 	m_device->setResizable(resize);
 }
 
-void RenderingEngine::removeMesh(const scene::IMesh* mesh)
-{
-	m_device->getSceneManager()->getMeshCache()->removeMesh(mesh);
-}
-
 void RenderingEngine::cleanupMeshCache()
 {
 	auto mesh_cache = m_device->getSceneManager()->getMeshCache();

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -82,8 +82,6 @@ public:
 	bool setWindowIcon();
 	void cleanupMeshCache();
 
-	void removeMesh(const scene::IMesh* mesh);
-
 	/**
 	 * This takes 3d_mode into account - side-by-side will return a
 	 * halved horizontal size.


### PR DESCRIPTION
somewhat related old PR: #11652

tested on VE-C:
afterContentReceived took 2821ms **old**
afterContentReceived took 2150ms **new**

## To do

This PR is Ready for Review.

## How to test

1. check that static and animated models look correct for mesh nodes, entities and `model[]`