### PR TITLE
Keep buttons hovered across formspec update

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3525,8 +3525,17 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_is_form_regenerated = true;
 	}
 
-	// Restore hover state for inventory lists
+	// Restore hover state
 	if (m_pointer.X != -1) {
+		SEvent event;
+		event.EventType = EET_MOUSE_INPUT_EVENT;
+		event.MouseInput.Event = EMIE_MOUSE_MOVED;
+		event.MouseInput.X = m_pointer.X;
+		event.MouseInput.Y = m_pointer.Y;
+
+		Environment->postEventFromUser(event);
+
+		// explicitly update inventory lists
 		for (GUIInventoryList *list : m_inventorylists) {
 			s32 hovered = list->getItemIndexAtPos(m_pointer);
 			if (hovered != -1) {


### PR DESCRIPTION
Closes #17329 

- **Goal of the PR**
  To keep buttons hovered if the mouse is still over them when the formspec updates

- **How does the PR work?**
  Uses `Environment->postEventFromUser(event)` with what is technically a fake hover event if a button was hovered before the formspec update

- **Does it resolve any reported issue?**
  #17329 
- **Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**
  Probably [UI Improvements](https://github.com/luanti-org/luanti/blob/master/doc/direction.md#23-ui-improvements)
- **If you have used an LLM/AI to help with code or assets, you must disclose this.**
  Nope. I can read similar code and also read Irrlicht documentation.

## To do

This PR is Ready for Review.

## How to test

Idk, best way is to probably just navigate to the ContentDB menu and select some big package, then as it's caching the screenshots, hover the "Install" button and watch it stay hovered

https://github.com/user-attachments/assets/482d00b2-6806-4700-930a-1e4bdde7e9e2

