### PR TITLE
Fix CAO anim handling regressions

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9125,7 +9125,7 @@ You **must not** mix names and track numbers to refer to the same animation.
 
 * `play_animation(track, [animation])`
     * Starts or restarts an animation on the given track.
-    * `.x` and `.b3d` models only have a single, unnamed animation track `1`.
+    * `.x` and `.b3d` models have only (at most) a single, unnamed animation track `1`.
     * `animation` is an optional table with the following optional fields:
       * `min_frame = 0.0`, `max_frame = math.huge`, animation range in frames (seconds);
          clamped on the client to first and last frame in the corresponding track.
@@ -9144,6 +9144,8 @@ You **must not** mix names and track numbers to refer to the same animation.
     * Animations continue playing at the current frame when
       the mesh is changed using `set_properties({mesh = ...})`,
       but animation blending may be interrupted.
+      If you change to a mesh missing some of the currently playing tracks,
+      you **must** stop playback on these tracks first.
 * `update_animation(track, update)`
     * `update` is a table with the following optional fields:
       * `speed`: New animation speed

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -438,6 +438,16 @@ public:
 	SkinnedMesh::Animation &getAnimation(u16 index)
 	{ return mesh->animations.at(index); }
 
+	//! Used by the .b3d and .x readers to add a single animation, if necessary
+	SkinnedMesh::Animation &getSingleAnimation()
+	{
+		if (mesh->getTrackCount() == 0) {
+			static_cast<void>(addAnimation());
+		}
+		assert(mesh->getTrackCount() == 1);
+		return getAnimation(0);
+	}
+
 private:
 
 	void topoSortJoints();

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -52,8 +52,6 @@ public:
 	//! Important for legacy reasons pertaining to different mesh loader behavior.
 	SourceFormat getSourceFormat() const { return SrcFormat; }
 
-	u16 getTrackCount() const override { return animations.size(); }
-
 	std::optional<u16> getTrackNumber(const std::string &track_name) const override;
 
 	f32 getMaxFrameNumber(u16 track_nr) const override;
@@ -128,8 +126,10 @@ public:
 	/** E.g. used for bump mapping. */
 	void convertMeshToTangents();
 
-	//! Does the mesh have no animation
-	bool isStatic() const { return !HasAnimation; }
+	//! How many animation tracks the mesh has
+	u16 getTrackCount() const override { return animations.size(); }
+	//! Is the mesh not animatable (no weights, no animation tracks)?
+	bool isStatic() const { return !IsAnimatable; }
 	//! Does the mesh have skinning weights?
 	bool hasWeights() const { return HasWeights; }
 
@@ -373,7 +373,7 @@ protected:
 	//! Bounding box of the mesh in static pose
 	core::aabbox3df StaticPoseBox{{0, 0, 0}};
 
-	bool HasAnimation = false;
+	bool IsAnimatable = false;
 	bool HasWeights = false;
 	bool PreparedForSkinning = false;
 	bool UseSwSkinning = false;

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -52,7 +52,6 @@ IAnimatedMesh *CB3DMeshFileLoader::createMesh(io::IReadFile *file)
 
 	B3DFile = file;
 	AnimatedMesh = scene::SkinnedMeshBuilder(SkinnedMesh::SourceFormat::B3D);
-	AnimatedMesh.addAnimation();
 	ShowWarning = true; // If true a warning is issued if too many textures are used
 	VerticesStart = 0;
 
@@ -606,7 +605,7 @@ bool CB3DMeshFileLoader::readChunkKEYS(SkinnedMesh::SJoint *inJoint)
 	}
 
 	B3dStack.erase(B3dStack.size() - 1);
-	auto &anim = AnimatedMesh.getAnimation(0);
+	auto &anim = AnimatedMesh.getSingleAnimation();
 	anim.joint_keys.emplace_back(SkinnedMesh::Animation::JointKeys{
 			inJoint->JointID, std::move(keys)});
 	return true;

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -65,7 +65,6 @@ IAnimatedMesh *CXMeshFileLoader::createMesh(io::IReadFile *file)
 #endif
 
 	AnimatedMesh = SkinnedMeshBuilder(SkinnedMesh::SourceFormat::X);
-	AnimatedMesh.addAnimation();
 
 	SkinnedMesh *res = nullptr;
 	if (load(file)) {
@@ -1883,7 +1882,7 @@ SkinnedMesh::SJoint *CXMeshFileLoader::addJoint(SkinnedMesh::SJoint *parent, std
 
 void CXMeshFileLoader::addKeys(u16 joint_id, SkinnedMesh::Keys &&keys)
 {
-	auto &animation = AnimatedMesh.getAnimation(0);
+	auto &animation = AnimatedMesh.getSingleAnimation();
 	auto &joint_keys_idx = JointKeysIdx.at(joint_id);
 	if (joint_keys_idx) {
 		animation.joint_keys.at(*joint_keys_idx).keys.append(keys);

--- a/irr/src/SkinnedMesh.cpp
+++ b/irr/src/SkinnedMesh.cpp
@@ -83,7 +83,7 @@ std::vector<VariantTransform> SkinnedMesh::animateMesh(
 		const std::vector<AnimationProgress> &progresses,
 		const std::vector<std::optional<core::Transform>> &old_transforms) const
 {
-	assert(HasAnimation);
+	assert(IsAnimatable);
 
 	std::vector<bool> animated_joints(AllJoints.size(), false);
 	std::vector<VariantTransform> result(AllJoints.size());
@@ -177,7 +177,7 @@ void SkinnedMesh::rigidAnimation(const std::vector<core::matrix4> &global_matric
 
 void SkinnedMesh::skinMesh(const std::vector<core::matrix4> &global_matrices)
 {
-	if (!HasAnimation)
+	if (!IsAnimatable)
 		return;
 
 	// Premultiply with global inversed matrices, if present
@@ -301,8 +301,8 @@ void SkinnedMesh::prepareForSkinning()
 {
 	HasWeights = checkForWeights();
 	// Meshes with weights are animatable (e.g. with bone overrides)
-	HasAnimation = HasWeights || checkForKeys();
-	if (!HasAnimation || PreparedForSkinning)
+	IsAnimatable = HasWeights || checkForKeys();
+	if (!IsAnimatable || PreparedForSkinning)
 		return;
 
 	PreparedForSkinning = true;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -833,8 +833,8 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		}
 	}
 
-	for (auto &&[track_name, anim] : deferred_set_animation_cmds) {
-		applyTrackAnimation(std::move(track_name), anim);
+	for (auto &&[track_id, anim] : deferred_set_animation_cmds) {
+		applyTrackAnimation(std::move(track_id), anim);
 	}
 	deferred_set_animation_cmds.clear();
 }
@@ -1517,7 +1517,7 @@ static scene::TrackId readTrackIdentifier(std::istringstream &is)
 	return deSerializeString16(is);
 }
 
-std::optional<u16> GenericCAO::resolveTrackId(const scene::TrackId &track_id)
+std::optional<u16> GenericCAO::resolveTrackId(const scene::TrackId &track_id, bool lax)
 {
 	if (!m_animated_meshnode)
 		return std::nullopt;
@@ -1534,9 +1534,16 @@ std::optional<u16> GenericCAO::resolveTrackId(const scene::TrackId &track_id)
 	u16 track_nr = std::get<u16>(track_id);
 	u16 max_track_nr = mesh->getTrackCount();
 	if (track_nr >= max_track_nr) {
-		// 1-indexed track number for consistency with Lua API
-		warningstream << "Track number " << (track_nr + 1) << " out of bounds for mesh " << m_prop.mesh
-			<< " (max: " << max_track_nr << ")" << std::endl;
+		if (!lax) {
+			if (track_nr == 0) {
+				warningstream << "Tried to change animation of mesh " << m_prop.mesh
+					<< ", but mesh has no predefined animations" << std::endl;
+			} else {
+				// 1-indexed track number for consistency with Lua API
+				warningstream << "Track number " << (track_nr + 1) << " out of bounds for mesh "
+					<< m_prop.mesh << " (max: " << max_track_nr << ")" << std::endl;
+			}
+		}
 		return std::nullopt;
 	}
 
@@ -1545,15 +1552,18 @@ std::optional<u16> GenericCAO::resolveTrackId(const scene::TrackId &track_id)
 
 void GenericCAO::applyTrackAnimation(scene::TrackId &&track_id, scene::TrackAnimSpec anim)
 {
-	auto *track_name = std::get_if<std::string>(&track_id);
-	if (track_name && !m_smgr) {
+	if (!m_smgr) {
 		// Not added to scene yet, mesh has not been resolved.
-		// Defer resolving the track name to after the scene node has been set up.
-		deferred_set_animation_cmds.emplace_back(std::move(*track_name), anim);
+		// Defer resolving the track id to after the scene node has been set up.
+		deferred_set_animation_cmds.emplace_back(std::move(track_id), anim);
 		return;
 	}
 
-	const auto track_nr = resolveTrackId(track_id);
+	// HACK pre-5.17.0 servers send such animations unconditionally for objects at init,
+	// including static objects
+	const bool lax = anim.min_frame == 0.0f && anim.max_frame == 0.0f &&
+			track_id == scene::TrackId((u16) 0);
+	const auto track_nr = resolveTrackId(track_id, lax);
 	if (!track_nr)
 		return;
 
@@ -1741,6 +1751,7 @@ void GenericCAO::processMessage(const std::string &data)
 		// Also clamps cur_frame & max_frame to the track max frame number in the mesh
 		applyTrackAnimation(std::move(track_id), anim);
 	} else if (cmd == AO_CMD_SET_ANIMATION_SPEED) {
+		// Note: Init message list never contains this command, so it need not apply to deferred animations
 		f32 new_fps = readF32(is);
 		scene::TrackId track_id = (u16) 0;
 		if (canRead(is)) {

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1069,8 +1069,14 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		addToScene(m_client->tsrc(), m_smgr);
 
 		if (m_animated_meshnode && m_animated_meshnode->getMesh()) {
-			for (auto &[track_nr, track] : m_animation.tracks) {
-				track.clamp(m_animated_meshnode->getMesh()->getMaxFrameNumber(track_nr));
+			for (auto it = m_animation.tracks.begin(); it != m_animation.tracks.end();) {
+				const auto track_nr = it->first;
+				if (track_nr < m_animated_meshnode->getMesh()->getTrackCount()) {
+					it->second.clamp(m_animated_meshnode->getMesh()->getMaxFrameNumber(track_nr));
+					++it;
+				} else {
+					it = m_animation.tracks.erase(it);
+				}
 			}
 			m_animated_meshnode->getAnimation() = m_animation; // Restore animation
 		}
@@ -1397,7 +1403,7 @@ void GenericCAO::updateAnimation(u16 track_nr)
 
 void GenericCAO::setLocalPlayerAnimation(LocalPlayerAnimation local_anim, float speed)
 {
-	if (!m_animated_meshnode)
+	if (!m_animated_meshnode || m_animated_meshnode->getMesh()->getTrackCount() > 0)
 		return;
 
 	assert(m_is_local_player);

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -134,7 +134,7 @@ private:
 	/// See also LocalPlayerAnimation (player.h), LocalPlayer::last_animation (localplayer.h).
 	bool m_local_player_animation = false;
 	/// Deferred set animation commands, to be run once the scene node exists
-	std::vector<std::pair<std::string, scene::TrackAnimSpec>> deferred_set_animation_cmds;
+	std::vector<std::pair<scene::TrackId, scene::TrackAnimSpec>> deferred_set_animation_cmds;
 
 	void applyTrackAnimation(scene::TrackId &&track_id, scene::TrackAnimSpec anim);
 
@@ -298,8 +298,8 @@ public:
 	void updateAnimation(u16 track_nr);
 	void setLocalPlayerAnimation(LocalPlayerAnimation local_anim, float speed);
 
-	/// @note logs a warning for invalid IDs
-	std::optional<u16> resolveTrackId(const scene::TrackId &id);
+	/// @param lax if false, logs a warning for invalid IDs
+	std::optional<u16> resolveTrackId(const scene::TrackId &id, bool lax = false);
 
 	void processMessage(const std::string &data) override;
 


### PR DESCRIPTION
- Do not raise warnings for "zero" anims sent by pre-5.17.0 servers (fixes #17373)
- Don't drop animations using a track number in init (defer them as well)
and some nits

## How to test

Connect with a 5.17.0 client to a 5.16.0 server that sends you static objects.
(For the second one: Animated objects, with an animation that has already been playing when the object was sent to you.)

---

Claude Opus 5 was used for local pre-review.