### PR TITLE
[no squash] Don't copy ContentFeatures to use unique_ptr for NodeVisuals

### DIFF
--- a/src/benchmark/benchmark_lighting.cpp
+++ b/src/benchmark/benchmark_lighting.cpp
@@ -21,7 +21,7 @@ TEST_CASE("benchmark_lighting")
 	{
 		ContentFeatures f;
 		f.name = "stone";
-		content_wall = ndef->set(f.name, f);
+		content_wall = ndef->set(f.name, std::move(f));
 	}
 
 	content_t content_light;
@@ -31,7 +31,7 @@ TEST_CASE("benchmark_lighting")
 		f.param_type = CPT_LIGHT;
 		f.light_propagates = true;
 		f.light_source = 14;
-		content_light = ndef->set(f.name, f);
+		content_light = ndef->set(f.name, std::move(f));
 	}
 
 	// Make a platform with a light below it.

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -108,7 +108,7 @@ void MapblockMeshGenerator::getSpecialTile(int index, TileSpec *tile_ret, bool a
 			continue;
 		top_layer = layer;
 		if (!layer->has_color)
-			f.visuals->getColor(cur_node.n.param2, &layer->color);
+			f.visuals->getColor(&f, cur_node.n.param2, &layer->color);
 	}
 
 	if (apply_crack)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -108,7 +108,7 @@ void MapblockMeshGenerator::getSpecialTile(int index, TileSpec *tile_ret, bool a
 			continue;
 		top_layer = layer;
 		if (!layer->has_color)
-			f.visuals->getColor(&f, cur_node.n.param2, &layer->color);
+			layer->color = f.visuals->getColor(f, cur_node.n.param2);
 	}
 
 	if (apply_crack)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -340,7 +340,7 @@ void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, 
 		if (layer.empty())
 			continue;
 		if (!layer.has_color)
-			f.visuals->getColor(&f, mn.param2, &(layer.color));
+			layer.color = f.visuals->getColor(f, mn.param2);
 		// Apply temporary crack
 		if (has_crack)
 			layer.material_flags |= MATERIAL_FLAG_CRACK;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -340,7 +340,7 @@ void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, 
 		if (layer.empty())
 			continue;
 		if (!layer.has_color)
-			f.visuals->getColor(mn.param2, &(layer.color));
+			f.visuals->getColor(&f, mn.param2, &(layer.color));
 		// Apply temporary crack
 		if (has_crack)
 			layer.material_flags |= MATERIAL_FLAG_CRACK;

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -415,7 +415,7 @@ void Minimap::blitMinimapPixelsToImageSurface(
 		} else if (overlay.name.empty() && tile.has_color) {
 			tilecolor = tile.color;
 		} else {
-			f.visuals->getColor(mmpixel->n.param2, &tilecolor);
+			f.visuals->getColor(&f, mmpixel->n.param2, &tilecolor);
 		}
 		// Multiply with pre-generated "color of texture"
 		video::SColor &minimap_color = f.visuals->minimap_color;

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -415,7 +415,7 @@ void Minimap::blitMinimapPixelsToImageSurface(
 		} else if (overlay.name.empty() && tile.has_color) {
 			tilecolor = tile.color;
 		} else {
-			f.visuals->getColor(&f, mmpixel->n.param2, &tilecolor);
+			tilecolor = f.visuals->getColor(f, mmpixel->n.param2);
 		}
 		// Multiply with pre-generated "color of texture"
 		video::SColor &minimap_color = f.visuals->minimap_color;

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -576,8 +576,7 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	/* collect all textures we might use */
 	std::unordered_set<std::string> pool;
 	ndef->applyFunction([&](ContentFeatures &f) {
-		assert(!f.visuals);
-		f.visuals = new NodeVisuals(&f);
+		f.createVisuals();
 		f.visuals->preUpdateTextures(tsrc, pool, tsettings);
 	});
 
@@ -639,7 +638,7 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	/* final step */
 	u32 progress = 0;
 	ndef->applyFunction([&](ContentFeatures &f) {
-		auto *v = f.visuals;
+		auto &v = f.visuals;
 		v->updateTextures(tsrc, shdsrc, client, &plt, tsettings);
 		v->updateMesh(client, tsettings);
 		v->collectMaterials(ndef->m_leaves_materials);
@@ -656,3 +655,8 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	plt.printStats(infostream);
 	tsrc->setImageCaching(false);
 }
+
+void NodeVisuals::create(ContentFeatures *features)
+{
+	features->visuals = std::unique_ptr<NodeVisuals>(new NodeVisuals(features));
+};

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -217,7 +217,7 @@ NodeVisuals::~NodeVisuals()
 		mesh_ptr->drop();
 }
 
-void NodeVisuals::preUpdateTextures(const ContentFeatures *f, ITextureSource *tsrc,
+void NodeVisuals::preUpdateTextures(const ContentFeatures &f, ITextureSource *tsrc,
 		std::unordered_set<std::string> &pool, const TextureSettings &tsettings)
 {
 	// Find out the exact texture strings this node might use, and put them into the pool
@@ -229,7 +229,7 @@ void NodeVisuals::preUpdateTextures(const ContentFeatures *f, ITextureSource *ts
 	std::string append_overlay = append, append_special = append;
 	bool use = true, use_overlay = true, use_special = true;
 
-	if (f->drawtype == NDT_ALLFACES_OPTIONAL) {
+	if (f.drawtype == NDT_ALLFACES_OPTIONAL) {
 		use_special = (tsettings.leaves_style == LEAVES_SIMPLE);
 		use = !use_special;
 		if (tsettings.leaves_style == LEAVES_OPAQUE)
@@ -246,32 +246,32 @@ void NodeVisuals::preUpdateTextures(const ContentFeatures *f, ITextureSource *ts
 
 	for (u32 j = 0; j < 6; j++) {
 		if (use)
-			consider_tile(f->tiledef[j], append);
+			consider_tile(f.tiledef[j], append);
 	}
 	for (u32 j = 0; j < 6; j++) {
 		if (use_overlay)
-			consider_tile(f->tiledef_overlay[j], append_overlay);
+			consider_tile(f.tiledef_overlay[j], append_overlay);
 	}
 	for (u32 j = 0; j < CF_SPECIAL_COUNT; j++) {
 		if (use_special)
-			consider_tile(f->tiledef_special[j], append_special);
+			consider_tile(f.tiledef_special[j], append_special);
 	}
 }
 
-void NodeVisuals::updateTextures(ContentFeatures *f, ITextureSource *tsrc,
-		IShaderSource *shdsrc, Client *client,
-		PreLoadedTextures *texture_pool, const TextureSettings &tsettings)
+void NodeVisuals::updateTextures(ContentFeatures &f, ITextureSource *tsrc,
+		IShaderSource *shdsrc, Client *client, PreLoadedTextures *texture_pool,
+		const TextureSettings &tsettings)
 {
 	// Things needed form ContentFeatures
-	auto &alpha = f->alpha;
-	auto &drawtype = f->drawtype;
-	const auto &tiledef = f->tiledef;
-	const auto &tiledef_overlay = f->tiledef_overlay;
-	const auto &tiledef_special = f->tiledef_special;
-	const auto &waving = f->waving;
-	const auto &color = f->color;
-	const auto &param_type_2 = f->param_type_2;
-	const auto &palette_name = f->palette_name;
+	auto &alpha = f.alpha;
+	auto &drawtype = f.drawtype;
+	const auto &tiledef = f.tiledef;
+	const auto &tiledef_overlay = f.tiledef_overlay;
+	const auto &tiledef_special = f.tiledef_special;
+	const auto &waving = f.waving;
+	const auto &color = f.color;
+	const auto &param_type_2 = f.param_type_2;
+	const auto &palette_name = f.palette_name;
 
 	// Figure out the actual tiles to use
 	TileDef tdef[6];
@@ -488,14 +488,13 @@ void NodeVisuals::updateTextures(ContentFeatures *f, ITextureSource *tsrc,
 		palette = tsrc->getPalette(palette_name);
 }
 
-void NodeVisuals::updateMesh(const ContentFeatures *f, Client *client,
-		const TextureSettings &tsettings)
+void NodeVisuals::updateMesh(const std::string &mesh, float visual_scale,
+		Client *client, const TextureSettings &tsettings)
 {
 	auto *manip = client->getSceneManager()->getMeshManipulator();
 	(void)tsettings;
 
-	const auto &mesh = f->mesh;
-	if (f->drawtype != NDT_MESH || mesh.empty())
+	if (mesh.empty())
 		return;
 
 	bool need_copy;
@@ -526,7 +525,7 @@ void NodeVisuals::updateMesh(const ContentFeatures *f, Client *client,
 		}
 		src_mesh = nullptr;
 
-		scaleMesh(mesh_ptr, v3f((apply_bs ? BS : 1.0f) * f->visual_scale));
+		scaleMesh(mesh_ptr, v3f((apply_bs ? BS : 1.0f) * visual_scale));
 		recalculateBoundingBox(mesh_ptr);
 		if (!checkMeshNormals(mesh_ptr)) {
 			// TODO this should be done consistently when the mesh is loaded
@@ -540,11 +539,8 @@ void NodeVisuals::updateMesh(const ContentFeatures *f, Client *client,
 	}
 }
 
-void NodeVisuals::collectMaterials(const ContentFeatures *f, std::vector<u32> &leaves_materials)
+void NodeVisuals::collectMaterials(std::vector<u32> &leaves_materials)
 {
-	if (f->drawtype == NDT_AIRLIKE)
-		return;
-
 	for (u16 j = 0; j < 6; j++) {
 		auto &l = tiles[j].layers;
 		if (!l[0].empty() && l[0].material_type == TILE_MATERIAL_WAVING_LEAVES)
@@ -554,13 +550,12 @@ void NodeVisuals::collectMaterials(const ContentFeatures *f, std::vector<u32> &l
 	}
 }
 
-void NodeVisuals::getColor(const ContentFeatures *f, u8 param2, video::SColor *color) const
+video::SColor NodeVisuals::getColor(const ContentFeatures &f, u8 param2) const
 {
 	if (palette) {
-		*color = (*palette)[param2];
-		return;
+		return (*palette)[param2];
 	}
-	*color = f->color;
+	return f.color;
 }
 
 void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *progress_callback_args)
@@ -579,7 +574,7 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	std::unordered_set<std::string> pool;
 	ndef->applyFunction([&](ContentFeatures &f) {
 		f.visuals = std::make_unique<NodeVisuals>();
-		f.visuals->preUpdateTextures(&f, tsrc, pool, tsettings);
+		f.visuals->preUpdateTextures(f, tsrc, pool, tsettings);
 	});
 
 	/* texture pre-loading stage */
@@ -641,9 +636,13 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	u32 progress = 0;
 	ndef->applyFunction([&](ContentFeatures &f) {
 		auto &v = f.visuals;
-		v->updateTextures(&f, tsrc, shdsrc, client, &plt, tsettings);
-		v->updateMesh(&f, client, tsettings);
-		v->collectMaterials(&f, ndef->m_leaves_materials);
+		v->updateTextures(f, tsrc, shdsrc, client, &plt, tsettings);
+
+		if (f.drawtype == NDT_MESH)
+			v->updateMesh(f.mesh, f.visual_scale, client, tsettings);
+
+		if (f.drawtype != NDT_AIRLIKE)
+			v->collectMaterials(ndef->m_leaves_materials);
 
 		client->showUpdateProgressTexture(progress_callback_args,
 				0.66666f + 0.33333f * progress / size);

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -217,7 +217,7 @@ NodeVisuals::~NodeVisuals()
 		mesh_ptr->drop();
 }
 
-void NodeVisuals::preUpdateTextures(ITextureSource *tsrc,
+void NodeVisuals::preUpdateTextures(const ContentFeatures *f, ITextureSource *tsrc,
 		std::unordered_set<std::string> &pool, const TextureSettings &tsettings)
 {
 	// Find out the exact texture strings this node might use, and put them into the pool
@@ -258,7 +258,8 @@ void NodeVisuals::preUpdateTextures(ITextureSource *tsrc,
 	}
 }
 
-void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Client *client,
+void NodeVisuals::updateTextures(ContentFeatures *f, ITextureSource *tsrc,
+		IShaderSource *shdsrc, Client *client,
 		PreLoadedTextures *texture_pool, const TextureSettings &tsettings)
 {
 	// Things needed form ContentFeatures
@@ -487,7 +488,8 @@ void NodeVisuals::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Cl
 		palette = tsrc->getPalette(palette_name);
 }
 
-void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
+void NodeVisuals::updateMesh(const ContentFeatures *f, Client *client,
+		const TextureSettings &tsettings)
 {
 	auto *manip = client->getSceneManager()->getMeshManipulator();
 	(void)tsettings;
@@ -538,7 +540,7 @@ void NodeVisuals::updateMesh(Client *client, const TextureSettings &tsettings)
 	}
 }
 
-void NodeVisuals::collectMaterials(std::vector<u32> &leaves_materials)
+void NodeVisuals::collectMaterials(const ContentFeatures *f, std::vector<u32> &leaves_materials)
 {
 	if (f->drawtype == NDT_AIRLIKE)
 		return;
@@ -552,7 +554,7 @@ void NodeVisuals::collectMaterials(std::vector<u32> &leaves_materials)
 	}
 }
 
-void NodeVisuals::getColor(u8 param2, video::SColor *color) const
+void NodeVisuals::getColor(const ContentFeatures *f, u8 param2, video::SColor *color) const
 {
 	if (palette) {
 		*color = (*palette)[param2];
@@ -576,8 +578,8 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	/* collect all textures we might use */
 	std::unordered_set<std::string> pool;
 	ndef->applyFunction([&](ContentFeatures &f) {
-		f.createVisuals();
-		f.visuals->preUpdateTextures(tsrc, pool, tsettings);
+		f.visuals = std::make_unique<NodeVisuals>();
+		f.visuals->preUpdateTextures(&f, tsrc, pool, tsettings);
 	});
 
 	/* texture pre-loading stage */
@@ -639,9 +641,9 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	u32 progress = 0;
 	ndef->applyFunction([&](ContentFeatures &f) {
 		auto &v = f.visuals;
-		v->updateTextures(tsrc, shdsrc, client, &plt, tsettings);
-		v->updateMesh(client, tsettings);
-		v->collectMaterials(ndef->m_leaves_materials);
+		v->updateTextures(&f, tsrc, shdsrc, client, &plt, tsettings);
+		v->updateMesh(&f, client, tsettings);
+		v->collectMaterials(&f, ndef->m_leaves_materials);
 
 		client->showUpdateProgressTexture(progress_callback_args,
 				0.66666f + 0.33333f * progress / size);
@@ -655,8 +657,3 @@ void NodeVisuals::fillNodeVisuals(NodeDefManager *ndef, Client *client, void *pr
 	plt.printStats(infostream);
 	tsrc->setImageCaching(false);
 }
-
-void NodeVisuals::create(ContentFeatures *features)
-{
-	features->visuals = std::unique_ptr<NodeVisuals>(new NodeVisuals(features));
-};

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -36,10 +36,11 @@ struct NodeVisuals
 	// alpha stays in ContentFeatures due to compatibility code that is necessary,
 	// because it was part of the node definition table in the past.
 
+	NodeVisuals() = default;
 	~NodeVisuals();
 
 	// Get color from palette or content features
-	void getColor(u8 param2, video::SColor *color) const;
+	void getColor(const ContentFeatures *f, u8 param2, video::SColor *color) const;
 
 	/*!
 	 * Creates NodeVisuals for every content feature in the passed NodeDefManager.
@@ -53,27 +54,19 @@ struct NodeVisuals
 	static void fillNodeVisuals(NodeDefManager *ndef, Client *client,
 			void *progress_callback_args);
 
-	/*!
-	 * Creates default constructed NodeVisuals for a single content feature object.
-	 * @param features the content will be coupled together
-	 */
-	static void create(ContentFeatures *features);
-
 	DISABLE_CLASS_COPY(NodeVisuals);
 
 private:
-	NodeVisuals(ContentFeatures *features) : f{features} {}
-
-	ContentFeatures *f = nullptr;
-
 	// Functions needed for initialisation
-	void preUpdateTextures(ITextureSource *tsrc,
+	void preUpdateTextures(const ContentFeatures *f, ITextureSource *tsrc,
 			std::unordered_set<std::string> &pool, const TextureSettings &tsettings);
 	// May override the alpha and drawtype of the content features
-	void updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc, Client *client,
+	void updateTextures(ContentFeatures *f, ITextureSource *tsrc,
+			IShaderSource *shdsrc,Client *client,
 			PreLoadedTextures *texture_pool, const TextureSettings &tsettings);
-	void updateMesh(Client *client, const TextureSettings &tsettings);
-	void collectMaterials(std::vector<u32> &leaves_materials);
+	void updateMesh(const ContentFeatures *f, Client *client,
+			const TextureSettings &tsettings);
+	void collectMaterials(const ContentFeatures *f, std::vector<u32> &leaves_materials);
 };
 
 /**

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -40,7 +40,7 @@ struct NodeVisuals
 	~NodeVisuals();
 
 	// Get color from palette or content features
-	void getColor(const ContentFeatures *f, u8 param2, video::SColor *color) const;
+	video::SColor getColor(const ContentFeatures &f, u8 param2) const;
 
 	/*!
 	 * Creates NodeVisuals for every content feature in the passed NodeDefManager.
@@ -57,16 +57,19 @@ struct NodeVisuals
 	DISABLE_CLASS_COPY(NodeVisuals);
 
 private:
+
 	// Functions needed for initialisation
-	void preUpdateTextures(const ContentFeatures *f, ITextureSource *tsrc,
+	void preUpdateTextures(const ContentFeatures &f, ITextureSource *tsrc,
 			std::unordered_set<std::string> &pool, const TextureSettings &tsettings);
+
 	// May override the alpha and drawtype of the content features
-	void updateTextures(ContentFeatures *f, ITextureSource *tsrc,
-			IShaderSource *shdsrc,Client *client,
-			PreLoadedTextures *texture_pool, const TextureSettings &tsettings);
-	void updateMesh(const ContentFeatures *f, Client *client,
+	void updateTextures(ContentFeatures &f, ITextureSource *tsrc,
+			IShaderSource *shdsrc, Client *client, PreLoadedTextures *texture_pool,
 			const TextureSettings &tsettings);
-	void collectMaterials(const ContentFeatures *f, std::vector<u32> &leaves_materials);
+
+	void updateMesh(const std::string &mesh, float visual_scale, Client *client,
+			const TextureSettings &tsettings);
+	void collectMaterials(std::vector<u32> &leaves_materials);
 };
 
 /**

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -35,6 +35,7 @@ struct NodeVisuals
 
 	// alpha stays in ContentFeatures due to compatibility code that is necessary,
 	// because it was part of the node definition table in the past.
+
 	~NodeVisuals();
 
 	// Get color from palette or content features
@@ -52,11 +53,16 @@ struct NodeVisuals
 	static void fillNodeVisuals(NodeDefManager *ndef, Client *client,
 			void *progress_callback_args);
 
+	/*!
+	 * Creates default constructed NodeVisuals for a single content feature object.
+	 * @param features the content will be coupled together
+	 */
+	static void create(ContentFeatures *features);
+
 	DISABLE_CLASS_COPY(NodeVisuals);
 
 private:
 	NodeVisuals(ContentFeatures *features) : f{features} {}
-	friend class DummyGameDef; // Unittests need constructor
 
 	ContentFeatures *f = nullptr;
 

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -908,7 +908,7 @@ bool ParticleManager::getNodeParticleParams(Client *client, const MapNode &n,
 	if (tile.has_color)
 		*color = tile.color;
 	else
-		f.visuals->getColor(n.param2, color);
+		f.visuals->getColor(&f, n.param2, color);
 
 	return true;
 }

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -908,7 +908,7 @@ bool ParticleManager::getNodeParticleParams(Client *client, const MapNode &n,
 	if (tile.has_color)
 		*color = tile.color;
 	else
-		f.visuals->getColor(&f, n.param2, color);
+		*color = f.visuals->getColor(f, n.param2);
 
 	return true;
 }

--- a/src/dummygamedef.h
+++ b/src/dummygamedef.h
@@ -66,18 +66,4 @@ protected:
 	NodeDefManager *m_nodedef = nullptr;
 	ICraftDefManager *m_craftdef = nullptr;
 	ModStorageDatabase *m_mod_storage_database = nullptr;
-
-#if CHECK_CLIENT_BUILD()
-	static std::unique_ptr<NodeVisuals> constructNodeVisuals(ContentFeatures *f)
-	{
-		return std::unique_ptr<NodeVisuals>(new NodeVisuals(f));
-	}
-	static void setNodeVisuals(ContentFeatures &f, std::unique_ptr<NodeVisuals> v = nullptr)
-	{
-		if (v == nullptr)
-			v = constructNodeVisuals(&f);
-		v->f = &f;
-		f.visuals = v.release(); // Destructed by ~ContentFeatures
-	}
-#endif
 };

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -309,12 +309,15 @@ ContentFeatures::ContentFeatures()
 	reset();
 }
 
-ContentFeatures::~ContentFeatures()
-{
+// Defined here, since NodeVisuals is not a complete type in the header
+ContentFeatures::~ContentFeatures() = default;
+
 #if CHECK_CLIENT_BUILD()
-	delete visuals;
-#endif
+void ContentFeatures::createVisuals()
+{
+	NodeVisuals::create(this);
 }
+#endif
 
 void ContentFeatures::reset()
 {
@@ -690,10 +693,10 @@ void NodeDefManager::clear()
 			f.tiledef[t].name = "unknown_node.png";
 		// Insert directly into containers
 		content_t c = CONTENT_UNKNOWN;
-		m_content_features[c] = f;
 		for (u32 ci = 0; ci <= CONTENT_MAX; ci++)
 			m_content_lighting_flag_cache[ci] = f.getLightingFlags();
 		addNameIdMapping(c, f.name);
+		m_content_features[c] = std::move(f);
 	}
 
 	// Set CONTENT_AIR
@@ -712,9 +715,9 @@ void NodeDefManager::clear()
 		f.is_ground_content   = true;
 		// Insert directly into containers
 		content_t c = CONTENT_AIR;
-		m_content_features[c] = f;
 		m_content_lighting_flag_cache[c] = f.getLightingFlags();
 		addNameIdMapping(c, f.name);
+		m_content_features[c] = std::move(f);
 	}
 
 	// Set CONTENT_IGNORE
@@ -732,9 +735,9 @@ void NodeDefManager::clear()
 		f.is_ground_content   = true;
 		// Insert directly into containers
 		content_t c = CONTENT_IGNORE;
-		m_content_features[c] = f;
 		m_content_lighting_flag_cache[c] = f.getLightingFlags();
 		addNameIdMapping(c, f.name);
+		m_content_features[c] = std::move(f);
 	}
 }
 
@@ -964,16 +967,12 @@ void NodeDefManager::eraseIdFromGroups(content_t id)
 
 
 // IWritableNodeDefManager
-content_t NodeDefManager::set(const std::string &name, const ContentFeatures &def)
+content_t NodeDefManager::set(const std::string &name, ContentFeatures &&def)
 {
 	// Pre-conditions
 	assert(!name.empty());
 	assert(name != "ignore");
 	assert(name == def.name);
-#if CHECK_CLIENT_BUILD()
-	// The ContentFeatures default copy constructor is only valid if visuals is null
-	assert(!def.visuals);
-#endif
 
 	content_t id = CONTENT_IGNORE;
 	if (!m_name_id_mapping.getId(name, id)) { // ignore aliases
@@ -991,17 +990,19 @@ content_t NodeDefManager::set(const std::string &name, const ContentFeatures &de
 	// Clear old groups in case of re-registration
 	eraseIdFromGroups(id);
 
-	m_content_features[id] = def;
-	m_content_features[id].floats = itemgroup_get(def.groups, "float") != 0;
-	m_content_lighting_flag_cache[id] = def.getLightingFlags();
-	verbosestream << "NodeDefManager: registering content id " << id
-		<< ": name=\"" << def.name << "\"" << std::endl;
+	m_content_features[id] = std::move(def);
+	ContentFeatures &f = m_content_features[id];
 
-	getNodeBoxUnion(def.selection_box, def, &m_selection_box_union);
+	f.floats = itemgroup_get(f.groups, "float") != 0;
+	m_content_lighting_flag_cache[id] = f.getLightingFlags();
+	verbosestream << "NodeDefManager: registering content id " << id
+		<< ": name=\"" << f.name << "\"" << std::endl;
+
+	getNodeBoxUnion(f.selection_box, f, &m_selection_box_union);
 	fixSelectionBoxIntUnion();
 
 	// Add this content to the list of all groups it belongs to
-	for (const auto &group : def.groups) {
+	for (const auto &group : f.groups) {
 		const std::string &group_name = group.first;
 		m_group_to_items[group_name].push_back(id);
 	}
@@ -1015,7 +1016,7 @@ content_t NodeDefManager::allocateDummy(const std::string &name)
 	assert(!name.empty());	// Pre-condition
 	ContentFeatures f;
 	f.name = name;
-	return set(name, f);
+	return set(name, std::move(f));
 }
 
 
@@ -1144,14 +1145,15 @@ void NodeDefManager::deSerialize(std::istream &is, u16 protocol_version)
 
 	u16 count = readU16(is);
 	std::istringstream is2(deSerializeString32(is), std::ios::binary);
-	ContentFeatures f;
+	ContentFeatures new_f;
 	for (u16 n = 0; n < count; n++) {
 		u16 i = readU16(is2);
 
 		// Read it from the string wrapper
 		std::string wrapper = deSerializeString16(is2);
 		std::istringstream wrapper_is(wrapper, std::ios::binary);
-		f.deSerialize(wrapper_is, protocol_version);
+		ContentFeatures *f = &new_f;
+		f->deSerialize(wrapper_is, protocol_version);
 
 		// Check error conditions
 		if (i == CONTENT_IGNORE || i == CONTENT_AIR || i == CONTENT_UNKNOWN) {
@@ -1159,7 +1161,7 @@ void NodeDefManager::deSerialize(std::istream &is, u16 protocol_version)
 				"not changing builtin node " << i << std::endl;
 			continue;
 		}
-		if (f.name.empty()) {
+		if (f->name.empty()) {
 			warningstream << "NodeDefManager::deSerialize(): "
 				"received empty name" << std::endl;
 			continue;
@@ -1167,22 +1169,24 @@ void NodeDefManager::deSerialize(std::istream &is, u16 protocol_version)
 
 		// Ignore aliases
 		u16 existing_id;
-		if (m_name_id_mapping.getId(f.name, existing_id) && i != existing_id) {
+		if (m_name_id_mapping.getId(f->name, existing_id) && i != existing_id) {
 			warningstream << "NodeDefManager::deSerialize(): "
-				"already defined with different ID: " << f.name << std::endl;
+				"already defined with different ID: " << f->name << std::endl;
 			continue;
 		}
 
 		// All is ok, add node definition with the requested ID
 		if (i >= m_content_features.size())
 			m_content_features.resize((size_t)(i) + 1);
-		m_content_features[i] = f;
-		m_content_features[i].floats = itemgroup_get(f.groups, "float") != 0;
-		m_content_lighting_flag_cache[i] = f.getLightingFlags();
-		addNameIdMapping(i, f.name);
-		TRACESTREAM(<< "NodeDef: deserialized " << f.name << std::endl);
+		m_content_features[i] = std::move(*f);
+		f = &m_content_features[i];
 
-		getNodeBoxUnion(f.selection_box, f, &m_selection_box_union);
+		f->floats = itemgroup_get(f->groups, "float") != 0;
+		m_content_lighting_flag_cache[i] = f->getLightingFlags();
+		addNameIdMapping(i, f->name);
+		TRACESTREAM(<< "NodeDef: deserialized " << f->name << std::endl);
+
+		getNodeBoxUnion(f->selection_box, *f, &m_selection_box_union);
 		fixSelectionBoxIntUnion();
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -316,24 +316,6 @@ ContentFeatures::~ContentFeatures()
 #endif
 }
 
-#if CHECK_CLIENT_BUILD()
-ContentFeaturesSSCSM ContentFeatures::copyWithoutVisuals() const
-{
-	ContentFeaturesSSCSM result;
-	result.cf = *this;
-	// Null this out before anything else runs, so the shallow copy
-	// above never gets a chance to double-delete visuals.
-	result.cf.visuals = nullptr;
-	result.had_visuals = visuals != nullptr;
-	if (visuals) {
-		result.minimap_color = visuals->minimap_color;
-		if (visuals->palette)
-			result.palette = *visuals->palette;
-	}
-	return result;
-}
-#endif
-
 void ContentFeatures::reset()
 {
 	/*

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -312,13 +312,6 @@ ContentFeatures::ContentFeatures()
 // Defined here, since NodeVisuals is not a complete type in the header
 ContentFeatures::~ContentFeatures() = default;
 
-#if CHECK_CLIENT_BUILD()
-void ContentFeatures::createVisuals()
-{
-	NodeVisuals::create(this);
-}
-#endif
-
 void ContentFeatures::reset()
 {
 	/*

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -26,7 +26,6 @@ class TestSchematic;
 #endif
 #if CHECK_CLIENT_BUILD()
 struct NodeVisuals;
-struct ContentFeaturesSSCSM;
 #endif
 
 enum ContentParamType : u8
@@ -489,30 +488,11 @@ struct ContentFeatures
 		return itemgroup_get(groups, group);
 	}
 
-#if CHECK_CLIENT_BUILD()
-	// Copies everything except visuals, which is GPU/mesh state that isn't
-	// safe to copy. Named explicitly since it's not a full copy.
-	ContentFeaturesSSCSM copyWithoutVisuals() const;
-#endif
-
 private:
 	void setAlphaFromLegacy(u8 legacy_alpha);
 
 	u8 getAlphaForLegacy() const;
 };
-
-#if CHECK_CLIENT_BUILD()
-// Result of ContentFeatures::copyWithoutVisuals(). cf.visuals is always
-// nullptr; minimap_color/palette are carried alongside instead.
-struct ContentFeaturesSSCSM
-{
-	ContentFeatures cf;
-	// Whether cf.visuals was set at copy time; if false, ignore the fields below.
-	bool had_visuals = false;
-	video::SColor minimap_color;
-	std::vector<video::SColor> palette;
-};
-#endif
 
 /*!
  * @brief This class is for getting the actual properties of nodes from their

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -350,9 +350,6 @@ struct ContentFeatures
 	// The Client class fills this for its NodeDefManager using fillNodeVisuals,
 	// thus for ContentFeatures of a Client it is not a nullptr.
 	std::unique_ptr<NodeVisuals> visuals;
-
-	// Default initializes them.
-	void createVisuals();
 #endif
 
 	// --- LIGHTING-RELATED ---

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -349,7 +349,10 @@ struct ContentFeatures
 #if CHECK_CLIENT_BUILD()
 	// The Client class fills this for its NodeDefManager using fillNodeVisuals,
 	// thus for ContentFeatures of a Client it is not a nullptr.
-	NodeVisuals *visuals = nullptr;
+	std::unique_ptr<NodeVisuals> visuals;
+
+	// Default initializes them.
+	void createVisuals();
 #endif
 
 	// --- LIGHTING-RELATED ---
@@ -435,6 +438,11 @@ struct ContentFeatures
 
 	ContentFeatures();
 	~ContentFeatures();
+	ContentFeatures(ContentFeatures&&) = default;
+	ContentFeatures& operator=(ContentFeatures&&) = default;
+
+	DISABLE_CLASS_COPY(ContentFeatures);
+
 	void reset();
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is, u16 protocol_version);
@@ -622,7 +630,7 @@ public:
 	 * @return ID of the registered node or @ref CONTENT_IGNORE if
 	 * the function could not allocate an ID.
 	 */
-	content_t set(const std::string &name, const ContentFeatures &def);
+	content_t set(const std::string &name, ContentFeatures &&def);
 
 	/*!
 	 * Allocates a blank node ID for the given name.

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1252,25 +1252,6 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "liquid_move_physics");
 }
 
-#if CHECK_CLIENT_BUILD()
-/******************************************************************************/
-void push_content_features_sscsm(lua_State *L, const ContentFeaturesSSCSM &c)
-{
-	push_content_features(L, c.cf);
-	// c.cf.visuals is always nullptr, see ContentFeaturesSSCSM
-	// push minimap_color and palette from the fields instead
-	int idx = lua_gettop(L);
-	if (c.had_visuals) {
-		push_ARGB8(L, c.minimap_color);
-		lua_setfield(L, idx, "minimap_color");
-		if (!c.cf.palette_name.empty()) {
-			push_palette(L, &c.palette);
-			lua_setfield(L, idx, "palette");
-		}
-	}
-}
-#endif
-
 /******************************************************************************/
 void push_nodebox(lua_State *L, const NodeBox &box)
 {

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -36,9 +36,6 @@ class ServerActiveObject;
 
 struct CollisionMoveResult;
 struct ContentFeatures;
-#if CHECK_CLIENT_BUILD()
-struct ContentFeaturesSSCSM;
-#endif
 struct DigParams;
 struct EnumString;
 struct FlagDesc;
@@ -70,9 +67,6 @@ extern const std::array<const char *, 36> object_property_keys;
 
 void read_content_features(lua_State *L, ContentFeatures &f, int index);
 void push_content_features(lua_State *L, const ContentFeatures &c);
-#if CHECK_CLIENT_BUILD()
-void push_content_features_sscsm(lua_State *L, const ContentFeaturesSSCSM &c);
-#endif
 
 void push_nodebox(lua_State *L, const NodeBox &box);
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette);

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -68,8 +68,8 @@ void ScriptApiSSCSM::after_content_received()
 		lua_pop(L, 2); // def, name
 	}
 
-	for (const ContentFeaturesSSCSM &node_def : answer.nodes) {
-		lua_pushstring(L, node_def.cf.name.c_str());
+	for (const ContentFeatures *f : answer.nodes) {
+		lua_pushstring(L, f->name.c_str());
 		lua_gettable(L, idx_registered_nodes);
 		if (lua_isnil(L, -1)) {
 			// registered as a node but not as an item (e.g. CONTENT_UNKNOWN);
@@ -79,7 +79,7 @@ void ScriptApiSSCSM::after_content_received()
 		}
 		int idx_existing = lua_gettop(L);
 
-		push_content_features_sscsm(L, node_def);
+		push_content_features(L, *f);
 		int idx_extra = lua_gettop(L);
 
 		// merge node-only fields into the existing item def table

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -615,13 +615,13 @@ int ModApiItem::l_register_item_raw(lua_State *L)
 		if (f.name.empty())
 			throw LuaError("Cannot register node with empty name");
 
-		content_t id = ndef->set(f.name, f);
+		content_t id = ndef->set(f.name, std::move(f));
 
 		// CONTENT_IGNORE is returned if we're somehow already at the hard limit
 		if (id == CONTENT_IGNORE || id >= MAX_REGISTERED_CONTENT) {
 			throw LuaError("Number of registerable nodes (about "
 					+ itos(MAX_REGISTERED_CONTENT)
-					+ ") exceeded: " + f.name);
+					+ ") exceeded: " + name);
 		}
 	}
 

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -116,7 +116,9 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 	struct Answer final : public ISSCSMAnswer
 	{
 		std::vector<ItemDefinition> items;
-		std::vector<ContentFeaturesSSCSM> nodes;
+		// TODO: ContentFeatures may need to be copied,
+		// or direct store a serialized version
+		std::vector<const ContentFeatures*> nodes;
 	};
 
 	SerializedSSCSMAnswer exec(Client *client) override
@@ -124,12 +126,10 @@ struct SSCSMRequestGetItemDefs final : public ISSCSMRequest
 		Answer answer{};
 
 		client->idef()->getDefinitions(answer.items);
-
 		const NodeDefManager *ndef = client->ndef();
 		answer.nodes.reserve(ndef->size());
 		for (u32 c = 0; c < ndef->size(); c++) {
-			const ContentFeatures &cf = ndef->get(c);
-			answer.nodes.push_back(cf.copyWithoutVisuals());
+			answer.nodes.push_back(&ndef->get(c));
 		}
 
 		return serializeSSCSMAnswer(std::move(answer));

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -81,7 +81,7 @@ void TestGameDef::defineSomeNodes()
 		tiledef.name = "default_stone.png";
 	f.is_ground_content = true;
 	idef->registerItem(itemdef);
-	t_CONTENT_STONE = ndef->set(f.name, f);
+	t_CONTENT_STONE = ndef->set(f.name, std::move(f));
 
 	//// Grass
 	itemdef = ItemDefinition();
@@ -101,7 +101,7 @@ void TestGameDef::defineSomeNodes()
 		f.tiledef[i].name = "default_dirt.png^default_grass_side.png";
 	f.is_ground_content = true;
 	idef->registerItem(itemdef);
-	t_CONTENT_GRASS = ndef->set(f.name, f);
+	t_CONTENT_GRASS = ndef->set(f.name, std::move(f));
 
 	//// Torch (minimal definition for lighting tests)
 	itemdef = ItemDefinition();
@@ -114,7 +114,7 @@ void TestGameDef::defineSomeNodes()
 	f.sunlight_propagates = true;
 	f.light_source = LIGHT_MAX-1;
 	idef->registerItem(itemdef);
-	t_CONTENT_TORCH = ndef->set(f.name, f);
+	t_CONTENT_TORCH = ndef->set(f.name, std::move(f));
 
 	//// Water
 	itemdef = ItemDefinition();
@@ -137,7 +137,7 @@ void TestGameDef::defineSomeNodes()
 	for (TileDef &tiledef : f.tiledef)
 		tiledef.name = "default_water.png";
 	idef->registerItem(itemdef);
-	t_CONTENT_WATER = ndef->set(f.name, f);
+	t_CONTENT_WATER = ndef->set(f.name, std::move(f));
 
 	//// Lava
 	itemdef = ItemDefinition();
@@ -159,7 +159,7 @@ void TestGameDef::defineSomeNodes()
 	for (TileDef &tiledef : f.tiledef)
 		tiledef.name = "default_lava.png";
 	idef->registerItem(itemdef);
-	t_CONTENT_LAVA = ndef->set(f.name, f);
+	t_CONTENT_LAVA = ndef->set(f.name, std::move(f));
 
 
 	//// Brick
@@ -178,7 +178,7 @@ void TestGameDef::defineSomeNodes()
 		tiledef.name = "default_brick.png";
 	f.is_ground_content = true;
 	idef->registerItem(itemdef);
-	t_CONTENT_BRICK = ndef->set(f.name, f);
+	t_CONTENT_BRICK = ndef->set(f.name, std::move(f));
 }
 
 bool TestGameDef::joinModChannel(const std::string &channel)

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -26,17 +26,11 @@ public:
 		return const_cast<NodeDefManager *>(m_nodedef);
 	}
 
-	content_t registerNode(const ItemDefinition &itemdef, const ContentFeatures &nodedef,
-			std::unique_ptr<NodeVisuals> visuals) {
+	content_t registerNode(const ItemDefinition &itemdef, ContentFeatures &&nodedef) {
 		item_mgr()->registerItem(itemdef);
 
 		NodeDefManager *mgr = node_mgr();
-		content_t id = mgr->set(nodedef.name, nodedef);
-
-		// mgr->set cannot add ContentFeatures that already contain visuals
-		// We set them manually instead of calling NodeVisuals::fillNodeVisuals
-		ContentFeatures &f = const_cast<ContentFeatures&>(mgr->get(id));
-		setNodeVisuals(f, std::move(visuals));
+		content_t id = mgr->set(nodedef.name, std::move(nodedef));
 
 		return id;
 	}
@@ -47,7 +41,7 @@ public:
 		// Need to fill node visuals for predefined nodes
 		node_mgr()->applyFunction([] (ContentFeatures &f) {
 			if (!f.visuals)
-				setNodeVisuals(f);
+				f.createVisuals();
 		});
 	}
 
@@ -73,17 +67,17 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		auto visuals = constructNodeVisuals(&f);
+		f.createVisuals();
 		f.name = itemdef.name;
 		f.drawtype = NDT_NORMAL;
-		visuals->solidness = 2;
+		f.visuals->solidness = 2;
 		f.alpha = ALPHAMODE_OPAQUE;
 		for (TileDef &tiledef : f.tiledef)
 			tiledef.name = name + ".png";
-		for (TileSpec &tile : visuals->tiles)
+		for (TileSpec &tile : f.visuals->tiles)
 			tile.layers[0].texture_id = texture;
 
-		return registerNode(itemdef, f, std::move(visuals));
+		return registerNode(itemdef, std::move(f));
 	}
 
 	content_t addLiquidSource(std::string name, u32 texture)
@@ -94,10 +88,10 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		auto visuals = constructNodeVisuals(&f);
+		f.createVisuals();
 		f.name = itemdef.name;
 		f.drawtype = NDT_LIQUID;
-		visuals->solidness = 1;
+		f.visuals->solidness = 1;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;
@@ -108,10 +102,10 @@ public:
 		f.liquid_alternative_flowing = "test:" + name + "_flowing";
 		for (TileDef &tiledef : f.tiledef)
 			tiledef.name = name + ".png";
-		for (TileSpec &tile : visuals->tiles)
+		for (TileSpec &tile : f.visuals->tiles)
 			tile.layers[0].texture_id = texture;
 
-		return registerNode(itemdef, f, std::move(visuals));
+		return registerNode(itemdef, std::move(f));
 	}
 
 	content_t addLiquidFlowing(std::string name, u32 texture_top, u32 texture_side)
@@ -122,10 +116,10 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		auto visuals = constructNodeVisuals(&f);
+		f.createVisuals();
 		f.name = itemdef.name;
 		f.drawtype = NDT_FLOWINGLIQUID;
-		visuals->solidness = 0;
+		f.visuals->solidness = 0;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;
@@ -136,10 +130,10 @@ public:
 		f.liquid_alternative_flowing = "test:" + name + "_flowing";
 		f.tiledef_special[0].name = name + "_top.png";
 		f.tiledef_special[1].name = name + "_side.png";
-		visuals->special_tiles[0].layers[0].texture_id = texture_top;
-		visuals->special_tiles[1].layers[0].texture_id = texture_side;
+		f.visuals->special_tiles[0].layers[0].texture_id = texture_top;
+		f.visuals->special_tiles[1].layers[0].texture_id = texture_side;
 
-		return registerNode(itemdef, f, std::move(visuals));
+		return registerNode(itemdef, std::move(f));
 	}
 };
 

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -41,7 +41,7 @@ public:
 		// Need to fill node visuals for predefined nodes
 		node_mgr()->applyFunction([] (ContentFeatures &f) {
 			if (!f.visuals)
-				f.createVisuals();
+				f.visuals = std::make_unique<NodeVisuals>();
 		});
 	}
 
@@ -67,7 +67,7 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		f.createVisuals();
+		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_NORMAL;
 		f.visuals->solidness = 2;
@@ -88,7 +88,7 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		f.createVisuals();
+		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_LIQUID;
 		f.visuals->solidness = 1;
@@ -116,7 +116,7 @@ public:
 		itemdef.description = name;
 
 		ContentFeatures f;
-		f.createVisuals();
+		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_FLOWINGLIQUID;
 		f.visuals->solidness = 0;


### PR DESCRIPTION
- Commit 0: Removes the ContentFeatures copy from SSCSM
- Commit 1: Uses a `unique_ptr` for the visuals pointer and removes all `ContentFeatures` copies.
- Commit 2: Removes ContentFeatures pointer from NodeVisuals
- Commit 3: Some refactoring after removing the pointer

I wanted to use move semantics before especially for `NodeDefManager::set` but never got to it

## To do

Ready for Review.

## How to test

It compiles, also with `BUILD_CLIENT=FALSE` and `BUILD_BENCHMARKS=TRUE`
