### PR TITLE
Use std::filesystem to fix TestFileSys unittests on MSVC

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -724,7 +724,7 @@ std::string MakePathRelativeTo(const std::string &child, const std::string &pare
 
 	std::error_code ec;
 	auto p_rel = std::filesystem::relative(p_child, p_parent, ec);
-	if (ec) {
+	if (ec || p_rel.empty()) {
 		return ""; // error
 	}
 

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <filesystem>
 #include <fstream>
 #include <atomic>
 #include <memory>
@@ -718,22 +719,16 @@ bool PathStartsWith(const std::string &path, const std::string &prefix)
 
 std::string MakePathRelativeTo(const std::string &child, const std::string &parent)
 {
-	std::string child_abs = fs::AbsolutePathPartial(child);
-	std::string parent_abs = fs::AbsolutePathPartial(parent);
-	if (child.empty() || parent.empty())
+	auto p_child = std::filesystem::path(child, std::filesystem::path::format::native_format);
+	auto p_parent = std::filesystem::path(parent, std::filesystem::path::format::native_format);
+
+	std::error_code ec;
+	auto p_rel = std::filesystem::relative(p_child, p_parent, ec);
+	if (ec) {
 		return ""; // error
-
-	if (!fs::PathStartsWith(child_abs, parent_abs))
-		return ""; // not child
-
-	if (child_abs.size() == parent_abs.size()) {
-		assert(child_abs == parent_abs);
-		return ".";
-	} else {
-		assert(child_abs.size() >= parent_abs.size() + 1);
-		assert(child_abs[parent_abs.size()] == DIR_DELIM_CHAR);
-		return std::move(child_abs).substr(parent_abs.size() + 1);
 	}
+
+	return p_rel.native();
 }
 
 std::string RemoveLastPathComponent(const std::string &path,

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -719,14 +719,17 @@ bool PathStartsWith(const std::string &path, const std::string &prefix)
 
 std::string MakePathRelativeTo(const std::string &child, const std::string &parent)
 {
-	auto p_child = std::filesystem::path(child, std::filesystem::path::format::native_format);
-	auto p_parent = std::filesystem::path(parent, std::filesystem::path::format::native_format);
-
-	std::error_code ec;
-	auto p_rel = std::filesystem::relative(p_child, p_parent, ec);
-	if (ec || p_rel.empty()) {
+	// Note: Do not use weakly_canonical directly, it doesn't make the path absolute
+	// if no prefix exists.
+	auto child_abs = AbsolutePathPartial(child);
+	auto parent_abs = AbsolutePathPartial(parent);
+	if (child_abs.empty() || parent_abs.empty())
 		return ""; // error
-	}
+
+	auto p_child_abs = std::filesystem::path(child_abs, std::filesystem::path::format::native_format);
+	auto p_parent_abs = std::filesystem::path(parent_abs, std::filesystem::path::format::native_format);
+
+	auto p_rel = p_child_abs.lexically_relative(p_parent_abs);
 
 	return p_rel.string();
 }
@@ -843,6 +846,28 @@ std::string AbsolutePath(const std::string &path)
 
 std::string AbsolutePathPartial(const std::string &path)
 {
+	/*
+	if (path.empty())
+		return "";
+
+	auto p_path = std::filesystem::path(path, std::filesystem::path::format::native_format);
+
+	std::error_code ec;
+
+	if (p_path.is_relative()) {
+		p_path = "." / p_path;
+	}
+
+	p_path = std::filesystem::weakly_canonical(p_path, ec);
+	if (ec) {
+		return ""; // error
+	}
+	p_path /= "a";
+	p_path = p_path.lexically_normal();
+
+	return p_path.string();
+	*/
+
 	if (path.empty())
 		return "";
 	// Try to determine absolute path

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -729,6 +729,7 @@ std::string MakePathRelativeTo(const std::string &child, const std::string &pare
 	auto p_child_abs = std::filesystem::path(child_abs, std::filesystem::path::format::native_format);
 	auto p_parent_abs = std::filesystem::path(parent_abs, std::filesystem::path::format::native_format);
 
+	// this removes trailing "/"s
 	auto p_rel = p_child_abs.lexically_relative(p_parent_abs);
 
 	return p_rel.string();
@@ -846,28 +847,6 @@ std::string AbsolutePath(const std::string &path)
 
 std::string AbsolutePathPartial(const std::string &path)
 {
-	/*
-	if (path.empty())
-		return "";
-
-	auto p_path = std::filesystem::path(path, std::filesystem::path::format::native_format);
-
-	std::error_code ec;
-
-	if (p_path.is_relative()) {
-		p_path = "." / p_path;
-	}
-
-	p_path = std::filesystem::weakly_canonical(p_path, ec);
-	if (ec) {
-		return ""; // error
-	}
-	p_path /= "a";
-	p_path = p_path.lexically_normal();
-
-	return p_path.string();
-	*/
-
 	if (path.empty())
 		return "";
 	// Try to determine absolute path

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -728,7 +728,7 @@ std::string MakePathRelativeTo(const std::string &child, const std::string &pare
 		return ""; // error
 	}
 
-	return p_rel.native();
+	return p_rel.string();
 }
 
 std::string RemoveLastPathComponent(const std::string &path,

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -115,8 +115,9 @@ bool PathStartsWith(const std::string &path, const std::string &prefix);
 // the part of child that is relative to parent.
 // Symlinks and "." and ".." components are removed.
 // If child and parent are (absolute) the same, the result is ".". (Otherwise it
-// never starts with '.'.)
-// Returns "" if child is not in parent, also returns "" on failure.
+// never starts with a single '.'.)
+// Returns a relative path starting with ".." components if child is not in parent.
+// Returns "" on failure.
 std::string MakePathRelativeTo(const std::string &child, const std::string &parent);
 
 // Remove last path component and the dir delimiter before and/or after it.

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -701,7 +701,7 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 	do {
 		assert(path != nullptr);
 		auto path_local = fs::MakePathRelativeTo(path, Server::getBuiltinLuaPath());
-		if (path_local.empty() )
+		if (path_local.empty())
 			break; // error
 		if (str_starts_with(path_local, ".."))
 			break; // not in builtin

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -701,7 +701,9 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 	do {
 		assert(path != nullptr);
 		auto path_local = fs::MakePathRelativeTo(path, Server::getBuiltinLuaPath());
-		if (path_local.empty())
+		if (path_local.empty() )
+			break; // error
+		if (str_starts_with(path_local, ".."))
 			break; // not in builtin
 
 		auto it = g_builtin_file_sha256_map.find(path_local);

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -204,8 +204,8 @@ void TestFileSys::testMakePathRelativeTo()
 	UASSERTEQ(auto, rel("d1/", "d1"), p("."));
 	UASSERTEQ(auto, rel("d1", "d1/."), p("."));
 	UASSERTEQ(auto, rel("d1/./d2", "d1/."), p("d2"));
-	UASSERTEQ(auto, rel("d1/..", "d1"), "..");
-	UASSERTEQ(auto, rel("d1/../d12", "d1"), "../d12");
+	UASSERTEQ(auto, rel("d1/..", "d1"), p(".."));
+	UASSERTEQ(auto, rel("d1/../d12", "d1"), p("../d12"));
 	UASSERTEQ(auto, rel("d1/../d1/d2/", "d1"), p("d2"));
 }
 

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -204,8 +204,8 @@ void TestFileSys::testMakePathRelativeTo()
 	UASSERTEQ(auto, rel("d1/", "d1"), p("."));
 	UASSERTEQ(auto, rel("d1", "d1/."), p("."));
 	UASSERTEQ(auto, rel("d1/./d2", "d1/."), p("d2"));
-	UASSERTEQ(auto, rel("d1/..", "d1"), "");
-	UASSERTEQ(auto, rel("d1/../d12", "d1"), "");
+	UASSERTEQ(auto, rel("d1/..", "d1"), "..");
+	UASSERTEQ(auto, rel("d1/../d12", "d1"), "../d12");
 	UASSERTEQ(auto, rel("d1/../d1/d2/", "d1"), p("d2"));
 }
 
@@ -340,9 +340,6 @@ void TestFileSys::testAbsolutePath()
 		fs::CreateDir(dir_path2);
 		UASSERTCMP(auto, !=, fs::AbsolutePath(dir_path2), ""); // now it does
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + DIR_DELIM ".."), fs::AbsolutePath(dir_path));
-		// excess . and / are removed
-		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + p("//..")), fs::AbsolutePath(dir_path));
-		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + p("/./.././//")), fs::AbsolutePath(dir_path));
 	}
 
 	/* AbsolutePathPartial */


### PR DESCRIPTION
* Alternative to #17355. But I'm no longer sure if it's better.
* Fixes parts of #17354.
* testAbsolutePath: new requirement that doesn't hold (ends with no /) is removed
  (std::filesystem doesn't consider trailing / for normalization. maybe we should just make all our code robust against this. or implement our own even-more-normal-ize function)
* testMakePathRelativeTo: MakePathRelativeTo is implemented with std::filesystem
  Note: only MakePathRelativeTo, which is new, so this PR is very unlikely to break anything
* MakePathRelativeTo now constructs paths starting with `..` if child is not in parent. => it's more general

## To do

This PR is Ready for Review.

## How to test

* `./bin/luanti --run-unittests --test-module TestFileSys`
* Start the game and look for builtin sha warnings. There should be none.
* Look at the CI output of MSVC