### PR TITLE
Hotfix memory safety issues in Irrlicht ZIP reader

### DIFF
--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -5,10 +5,11 @@
 #include "CZipReader.h"
 
 #include "os.h"
-
 #include "CFileList.h"
 #include "CReadFile.h"
 #include "coreutil.h"
+
+#include <string>
 
 #include <zlib.h> // use system lib
 
@@ -150,14 +151,11 @@ bool CZipReader::scanZipHeader(bool ignoreGPBits)
 
 	// read filename
 	{
-		const u16 len = entry.header.FilenameLength;
-		c8 *tmp = new c8[((u32) len) + 2];
-		const bool ok = try_read(File, tmp, len);
-		tmp[len] = 0;
-		ZipFileName = tmp;
-		delete[] tmp;
-		if (!ok)
+		std::string tmp;
+		tmp.resize(entry.header.FilenameLength);
+		if (!try_read(File, tmp.data(), tmp.size()))
 			return false;
+		ZipFileName = std::move(tmp);
 	}
 
 	if (entry.header.ExtraFieldLength)

--- a/irr/src/CZipReader.cpp
+++ b/irr/src/CZipReader.cpp
@@ -12,6 +12,11 @@
 
 #include <zlib.h> // use system lib
 
+[[nodiscard]] static bool try_read(io::IReadFile *file, void *ptr, size_t len)
+{
+	return file->read(ptr, len) == len;
+}
+
 namespace io
 {
 
@@ -71,14 +76,15 @@ IFileArchive *CArchiveLoaderZIP::createArchive(io::IReadFile *file, bool ignoreC
 \return True if file seems to be loadable. */
 bool CArchiveLoaderZIP::isALoadableFileFormat(io::IReadFile *file) const
 {
-	SZIPFileHeader header;
+	u32 sig;
 
-	file->read(&header.Sig, 4);
+	if (!try_read(file, &sig, 4))
+		return false;
 #ifdef __BIG_ENDIAN__
-	header.Sig = os::Byteswap::byteswap(header.Sig);
+	sig = os::Byteswap::byteswap(sig);
 #endif
 
-	return header.Sig == 0x04034b50; // ZIP
+	return sig == 0x04034b50; // ZIP
 }
 
 // -----------------------------------------------------------------------------
@@ -144,11 +150,14 @@ bool CZipReader::scanZipHeader(bool ignoreGPBits)
 
 	// read filename
 	{
-		c8 *tmp = new c8[entry.header.FilenameLength + 2];
-		File->read(tmp, entry.header.FilenameLength);
-		tmp[entry.header.FilenameLength] = 0;
+		const u16 len = entry.header.FilenameLength;
+		c8 *tmp = new c8[((u32) len) + 2];
+		const bool ok = try_read(File, tmp, len);
+		tmp[len] = 0;
 		ZipFileName = tmp;
 		delete[] tmp;
+		if (!ok)
+			return false;
 	}
 
 	if (entry.header.ExtraFieldLength)
@@ -187,7 +196,8 @@ bool CZipReader::scanZipHeader(bool ignoreGPBits)
 			}
 			File->seek(-seek, true);
 		}
-		File->read(&dirEnd, sizeof(dirEnd));
+		if (!found || !try_read(File, &dirEnd, sizeof(dirEnd)))
+			return false;
 #ifdef __BIG_ENDIAN__
 		dirEnd.NumberDisk = os::Byteswap::byteswap(dirEnd.NumberDisk);
 		dirEnd.NumberStart = os::Byteswap::byteswap(dirEnd.NumberStart);
@@ -221,7 +231,8 @@ bool CZipReader::scanCentralDirectoryHeader()
 {
 	io::path ZipFileName = "";
 	SZIPFileCentralDirFileHeader entry;
-	File->read(&entry, sizeof(SZIPFileCentralDirFileHeader));
+	if (!try_read(File, &entry, sizeof(entry)))
+		return false;
 
 #ifdef __BIG_ENDIAN__
 	entry.Sig = os::Byteswap::byteswap(entry.Sig);
@@ -248,13 +259,16 @@ bool CZipReader::scanCentralDirectoryHeader()
 
 	const long pos = File->getPos();
 	File->seek(entry.RelativeOffsetOfLocalHeader);
-	scanZipHeader(true);
+	// only on success did scanZipHeader append to both lists
+	const bool added = scanZipHeader(true);
 	File->seek(pos + entry.FilenameLength + entry.ExtraFieldLength + entry.FileCommentLength);
-	auto &lastInfo = FileInfo.back();
-	lastInfo.header.DataDescriptor.CompressedSize = entry.CompressedSize;
-	lastInfo.header.DataDescriptor.UncompressedSize = entry.UncompressedSize;
-	lastInfo.header.DataDescriptor.CRC32 = entry.CRC32;
-	Files.getLast().Size = entry.UncompressedSize;
+	if (added) {
+		auto &lastInfo = FileInfo.back();
+		lastInfo.header.DataDescriptor.CompressedSize = entry.CompressedSize;
+		lastInfo.header.DataDescriptor.UncompressedSize = entry.UncompressedSize;
+		lastInfo.header.DataDescriptor.CRC32 = entry.CRC32;
+		Files.getLast().Size = entry.UncompressedSize;
+	}
 	return true;
 }
 
@@ -291,9 +305,15 @@ IReadFile *CZipReader::createAndOpenFile(u32 index)
 	// 98 - PPMd - Compression Method, WinZip 10
 	// 99 - AES encryption, WinZip 9
 
-	const SZipFileEntry &e = FileInfo[Files[index].ID];
+	if (index >= Files.size())
+		return nullptr;
+	const u32 id = Files[index].ID;
+	if (id >= FileInfo.size())
+		return nullptr;
+
+	const SZipFileEntry &e = FileInfo[id];
 	char buf[64];
-	s16 actualCompressionMethod = e.header.CompressionMethod;
+	u16 actualCompressionMethod = e.header.CompressionMethod;
 	IReadFile *decrypted = 0;
 	u8 *decryptedBuf = 0;
 	u32 decryptedSize = e.header.DataDescriptor.CompressedSize;
@@ -328,7 +348,13 @@ IReadFile *CZipReader::createAndOpenFile(u32 index)
 
 			// memset(pcData, 0, decryptedSize);
 			File->seek(e.Offset);
-			File->read(pcData, decryptedSize);
+			if (!try_read(File, pcData, decryptedSize)) {
+				snprintf_irr(buf, 64, "Truncated data for %s", Files[index].FullName.c_str());
+				os::Printer::log(buf, ELL_ERROR);
+				delete[] pBuf;
+				delete[] pcData;
+				return nullptr;
+			}
 		}
 
 		// Setup the inflate stream.
@@ -345,11 +371,9 @@ IReadFile *CZipReader::createAndOpenFile(u32 index)
 		// Perform inflation. wbits < 0 indicates no zlib header inside the data.
 		err = inflateInit2(&stream, -MAX_WBITS);
 		if (err == Z_OK) {
-			err = inflate(&stream, Z_FINISH);
-			inflateEnd(&stream);
-			if (err == Z_STREAM_END)
-				err = Z_OK;
-			err = Z_OK;
+			inflate(&stream, Z_FINISH);
+			// Zero what inflate did not write
+			memset(pBuf + stream.total_out, 0, uncompressedSize - stream.total_out);
 			inflateEnd(&stream);
 		}
 

--- a/irr/src/CZipReader.h
+++ b/irr/src/CZipReader.h
@@ -16,7 +16,7 @@ namespace io
 
 // the fields crc-32, compressed size and uncompressed size are set to
 // zero in the local header
-static constexpr s16 ZIP_INFO_IN_DATA_DESCRIPTOR = 0x0008;
+static constexpr u16 ZIP_INFO_IN_DATA_DESCRIPTOR = 0x0008;
 
 // byte-align structures
 #include "irrpack.h"
@@ -28,17 +28,19 @@ struct SZIPFileDataDescriptor
 	u32 UncompressedSize;
 } PACK_STRUCT;
 
+// These must be unsigned: a signed length read off disk can be negative, which
+// turns the allocations and bounds checks derived from it into overflows.
 struct SZIPFileHeader
 {
 	u32 Sig; // 'PK0304' little endian (0x04034b50)
-	s16 VersionToExtract;
-	s16 GeneralBitFlag;
-	s16 CompressionMethod;
-	s16 LastModFileTime;
-	s16 LastModFileDate;
+	u16 VersionToExtract;
+	u16 GeneralBitFlag;
+	u16 CompressionMethod;
+	u16 LastModFileTime;
+	u16 LastModFileDate;
 	SZIPFileDataDescriptor DataDescriptor;
-	s16 FilenameLength;
-	s16 ExtraFieldLength;
+	u16 FilenameLength;
+	u16 ExtraFieldLength;
 	// filename (variable size)
 	// extra field (variable size )
 } PACK_STRUCT;


### PR DESCRIPTION
Does what the title says. #17343 will obsolete this for 5.17.0+, but for 5.17.0 a hotfix is the safer route.

Generated using Claude Opus, then reviewed and edited by me.

Ready for review.
