### PR TITLE
Allow OS screen saver while window is minimized

### DIFF
--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -171,6 +171,13 @@ public:
 	/** \return True if window is minimized. */
 	virtual bool isWindowMinimized() const = 0;
 
+	//! Allows or prevents the OS screen saver from starting
+	/** By default the screen saver is prevented from starting while the
+	device exists. Pass true to allow it to start again (e.g. while the
+	window is minimized), and false to prevent it (e.g. once the window
+	is restored). */
+	virtual void setScreenSaverEnabled(bool enabled) = 0;
+
 	//! Checks if the Irrlicht window is maximized
 	//! Only fully works on SDL. Returns false, or the last value set via
 	//! maximizeWindow() and restoreWindow(), on other backends.

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1490,6 +1490,15 @@ bool CIrrDeviceSDL::isWindowMinimized() const
 	return Window && (SDL_GetWindowFlags(Window) & SDL_WINDOW_MINIMIZED) != 0;
 }
 
+//! allows or prevents the OS screen saver from starting
+void CIrrDeviceSDL::setScreenSaverEnabled(bool enabled)
+{
+	if (enabled)
+		SDL_EnableScreenSaver();
+	else
+		SDL_DisableScreenSaver();
+}
+
 bool CIrrDeviceSDL::showErrorMessageBox(SDL_Window *window, const char *title, const char *message)
 {
 	auto ret = SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, message, window);

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -66,6 +66,9 @@ public:
 	//! returns if window is minimized.
 	bool isWindowMinimized() const override;
 
+	//! allows or prevents the OS screen saver from starting
+	void setScreenSaverEnabled(bool enabled) override;
+
 	//! notifies the device that it should close itself
 	void closeDevice() override;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -596,6 +596,14 @@ void Game::run()
 		if (m_does_lost_focus_pause_game && !device->isWindowFocused() && !isMenuActive()) {
 			m_game_formspec.showPauseMenu();
 		}
+
+		// Allow the screen saver to start while minimized, and suppress it
+		// again once the window is restored.
+		const bool is_minimized = device->isWindowMinimized();
+		if (is_minimized != m_was_minimized) {
+			device->setScreenSaverEnabled(is_minimized);
+			m_was_minimized = is_minimized;
+		}
 	}
 
 	framemarker.end();

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -384,6 +384,7 @@ private:
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 	bool m_game_focused = false;
+	bool m_was_minimized = false;
 
 	bool m_does_lost_focus_pause_game = false;
 


### PR DESCRIPTION
## Summary
- SDL disables the OS screen saver for the lifetime of the video subsystem by default, regardless of window focus or minimized state, so it never re-enabled itself while Luanti was minimized.
- Adds `IrrlichtDevice::setScreenSaverEnabled()`, implemented in `CIrrDeviceSDL` via `SDL_EnableScreenSaver()`/`SDL_DisableScreenSaver()`.
- `Game::run()` now toggles it on minimize/restore transitions.

## Test plan
- [x] Built successfully (`ninja luanti`)
- [x] Manually verify: minimize the window and confirm the OS screen saver/lock can now start; restore the window and confirm it's suppressed again during play