### PR TITLE
[no squash] Fix pushing non existing palette to Lua and rename fields

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -903,8 +903,8 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
     alpha = number,                 -- Raw AlphaMode enum ordinal (0=blend, 1=clip, 2=opaque)
     use_texture_alpha = string,     -- "blend", "clip" or "opaque"
     color = <Color>,                -- Color of node *May not exist*
-    palette_name = <string>,        -- Filename of palette *May not exist*
-    palette = <{                    -- List of colors
+    palette = <string>,             -- Filename of palette *May not exist*
+    palette_colors = <{             -- List of colors or nil if not available
         Color,
         Color
     }>,

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1158,12 +1158,12 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 		lua_setfield(L, -2, "color");
 
 		lua_pushstring(L, c.palette_name.c_str());
-		lua_setfield(L, -2, "palette_name");
+		lua_setfield(L, -2, "palette");
 
 #if CHECK_CLIENT_BUILD()
 		if (c.visuals) {
 			push_palette(L, c.visuals->palette);
-			lua_setfield(L, -2, "palette");
+			lua_setfield(L, -2, "palette_colors");
 		}
 #endif
 	}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1307,6 +1307,10 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 /******************************************************************************/
 void push_palette(lua_State *L, const std::vector<video::SColor> *palette)
 {
+	if (!palette) {
+		lua_pushnil(L);
+		return;
+	}
 	lua_createtable(L, palette->size(), 0);
 	int newTable = lua_gettop(L);
 	int index = 1;


### PR DESCRIPTION
Fixes #17403

The segfault happens if the palette string is not empty for a node that doesn't use it.
See testcode.

This problem was exposed by #17326 but existed long before in CPCSM.
By using `core.get_node_def(nodename)` on a bad node.

Note that the definitions get pushed even if SSCSM is turned off.
See: https://github.com/luanti-org/luanti/pull/17326#discussion_r3669371441


## To do

Ready for Review.

## How to test

``` Lua
core.register_node(":default:cobble2", {
	description = "Cobblestone2",
	tiles = {"default_cobble.png"},
	is_ground_content = false,
	groups = {cracky = 3, stone = 2},
	--paramtype2 = "color",
	palette = "palette.png",
})
```

To see it in SSCSM you could also add the following to the string in `Client::loadSSCSM()`.
``` Lua
print(dump(core.registered_nodes["default:cobble2"]))
```