### PR TITLE
macOS: fix OpenGL3 driver falling back to legacy 2.1 (blank menu/world under Core profile)

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -700,7 +700,14 @@ bool CIrrDeviceSDL::createWindowWithContext()
 	case video::EDT_OPENGL3:
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+#ifdef __APPLE__
+		// macOS never implemented a compatibility profile above 2.1; only
+		// core profile is available for GL 3.2+, so requesting
+		// COMPATIBILITY here makes context creation fail outright (#16041).
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+#else
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+#endif
 		break;
 	case video::EDT_OGLES2:
 	case video::EDT_WEBGL1:

--- a/irr/src/COpenGLCoreTexture.h
+++ b/irr/src/COpenGLCoreTexture.h
@@ -397,12 +397,19 @@ public:
 		const COpenGLCoreTexture *prevTexture = cache.get(0);
 		cache.set(0, this);
 
+#ifndef __APPLE__
+		// GL_GENERATE_MIPMAP_HINT is valid on GLES and under a Compatibility
+		// profile, but is not a legal enum under a Core profile context
+		// (the only kind macOS's OpenGL3 driver uses, see CIrrDeviceSDL.cpp)
+		// and raises GL_INVALID_ENUM there. It's purely a quality hint for
+		// glGenerateMipmap() below, safe to just skip.
 		if (Driver->getTextureCreationFlag(ETCF_OPTIMIZED_FOR_SPEED))
 			GL.Hint(GL_GENERATE_MIPMAP_HINT, GL_FASTEST);
 		else if (Driver->getTextureCreationFlag(ETCF_OPTIMIZED_FOR_QUALITY))
 			GL.Hint(GL_GENERATE_MIPMAP_HINT, GL_NICEST);
 		else
 			GL.Hint(GL_GENERATE_MIPMAP_HINT, GL_DONT_CARE);
+#endif
 
 		Driver->irrGlGenerateMipmap(TextureType);
 		TEST_GL_ERROR(Driver);

--- a/irr/src/OpenGL/BufferObject.cpp
+++ b/irr/src/OpenGL/BufferObject.cpp
@@ -13,26 +13,28 @@ namespace video
 void OGLBufferObject::upload(const void *data, size_t size, size_t offset,
 		GLenum usage, bool mustShrink)
 {
-	bool newBuffer = false;
 	assert(!(mustShrink && offset > 0)); // forbidden usage
 	if (!m_name) {
 		GL.GenBuffers(1, &m_name);
 		if (!m_name)
 			return;
-		newBuffer = true;
-	} else if (size > m_size || mustShrink) {
-		newBuffer = size != m_size;
 	}
 
 	GL.BindBuffer(m_target, m_name);
 
-	if (newBuffer) {
-		assert(offset == 0);
-		GL.BufferData(m_target, size, data, usage);
-		m_size = size;
-	} else {
-		GL.BufferSubData(m_target, offset, size, data);
-	}
+	// Every caller replaces the buffer's entire contents on every call
+	// (offset is always 0 in practice), so always re-specify storage via
+	// BufferData rather than BufferSubData into the existing allocation.
+	// BufferSubData can force the driver to stall the CPU until the GPU is
+	// done reading the old contents; BufferData (even at an unchanged size)
+	// instead orphans the old storage and hands back a fresh allocation,
+	// letting the GPU keep draining the old one asynchronously. This matters
+	// most for buffers re-uploaded every frame or even multiple times per
+	// frame (joint transforms, streamed/dynamic meshes, the Core-profile
+	// client-array scratch buffers).
+	assert(offset == 0);
+	GL.BufferData(m_target, size, data, usage);
+	m_size = size;
 
 	GL.BindBuffer(m_target, 0);
 }

--- a/irr/src/OpenGL/BufferObject.cpp
+++ b/irr/src/OpenGL/BufferObject.cpp
@@ -11,30 +11,31 @@ namespace video
 {
 
 void OGLBufferObject::upload(const void *data, size_t size, size_t offset,
-		GLenum usage, bool mustShrink)
+		GLenum usage, bool mustShrink, bool orphan)
 {
 	assert(!(mustShrink && offset > 0)); // forbidden usage
+	assert(!(orphan && offset > 0)); // forbidden usage
+	bool newBuffer = false;
 	if (!m_name) {
 		GL.GenBuffers(1, &m_name);
 		if (!m_name)
 			return;
+		newBuffer = true;
+	} else if (orphan) {
+		newBuffer = true;
+	} else if (size > m_size || mustShrink) {
+		newBuffer = size != m_size;
 	}
 
 	GL.BindBuffer(m_target, m_name);
 
-	// Every caller replaces the buffer's entire contents on every call
-	// (offset is always 0 in practice), so always re-specify storage via
-	// BufferData rather than BufferSubData into the existing allocation.
-	// BufferSubData can force the driver to stall the CPU until the GPU is
-	// done reading the old contents; BufferData (even at an unchanged size)
-	// instead orphans the old storage and hands back a fresh allocation,
-	// letting the GPU keep draining the old one asynchronously. This matters
-	// most for buffers re-uploaded every frame or even multiple times per
-	// frame (joint transforms, streamed/dynamic meshes, the Core-profile
-	// client-array scratch buffers).
-	assert(offset == 0);
-	GL.BufferData(m_target, size, data, usage);
-	m_size = size;
+	if (newBuffer) {
+		assert(offset == 0);
+		GL.BufferData(m_target, size, data, usage);
+		m_size = size;
+	} else {
+		GL.BufferSubData(m_target, offset, size, data);
+	}
 
 	GL.BindBuffer(m_target, 0);
 }

--- a/irr/src/OpenGL/BufferObject.h
+++ b/irr/src/OpenGL/BufferObject.h
@@ -16,6 +16,7 @@ public:
 	enum Target : GLenum {
 		TARGET_VBO = GL_ARRAY_BUFFER,
 		TARGET_UBO = GL_UNIFORM_BUFFER,
+		TARGET_EBO = GL_ELEMENT_ARRAY_BUFFER,
 	};
 
 	/// @note does not create on GL side

--- a/irr/src/OpenGL/BufferObject.h
+++ b/irr/src/OpenGL/BufferObject.h
@@ -44,10 +44,19 @@ public:
 	 * @param offset offset to upload at
 	 * @param usage usage pattern passed to GL (only if buffer is new)
 	 * @param mustShrink force re-create of buffer if it became smaller
+	 * @param orphan force re-specifying (orphaning) the GL storage via
+	 *   BufferData instead of reusing the existing allocation via
+	 *   BufferSubData, even if the size is unchanged. Only valid with
+	 *   `offset == 0`. BufferSubData can make the driver stall the CPU
+	 *   until the GPU is done reading the old contents; orphaning avoids
+	 *   that at the cost of a fresh allocation. Only worth it for buffers
+	 *   whose *entire* contents are replaced on every upload and that are
+	 *   uploaded frequently (e.g. every frame or draw call) -- pass this
+	 *   explicitly per call site, don't flip the default.
 	 * @note modifies GL_ARRAY_BUFFER binding
 	 */
 	void upload(const void *data, size_t size, size_t offset,
-		GLenum usage, bool mustShrink = false);
+		GLenum usage, bool mustShrink = false, bool orphan = false);
 
 	/**
 	 * Free buffer in GL.

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -683,7 +683,7 @@ void COpenGL3DriverBase::drawVertexPrimitiveList(const void *vertices, u32 verte
 
 	setRenderStates3DMode();
 
-	drawGeneric(vertices, indexList, primitiveCount, vType, pType, iType);
+	drawGeneric(vertices, vertexCount, indexList, primitiveCount, vType, pType, iType);
 }
 
 //! draws a vertex primitive list in 2d
@@ -719,7 +719,7 @@ void COpenGL3DriverBase::draw2DVertexPrimitiveList(const void *vertices, u32 ver
 		have_texture_alpha
 	);
 
-	drawGeneric(vertices, indexList, primitiveCount, vType, pType, iType);
+	drawGeneric(vertices, vertexCount, indexList, primitiveCount, vType, pType, iType);
 }
 
 void COpenGL3DriverBase::draw2DImage(const video::ITexture *texture, const core::position2d<s32> &destPos,
@@ -1002,6 +1002,19 @@ uintptr_t COpenGL3DriverBase::uploadClientVertexData(const VertexType &vertexTyp
 	return 0;
 }
 
+uintptr_t COpenGL3DriverBase::uploadClientIndexData(const void *indexList, u32 indexCount, GLenum indexType)
+{
+	if (Version.Spec != OpenGLSpec::Core)
+		return reinterpret_cast<uintptr_t>(indexList);
+
+	size_t elemSize = (indexType == GL_UNSIGNED_SHORT) ? sizeof(u16) : sizeof(u32);
+	ScratchEBO.upload(indexList, static_cast<size_t>(indexCount) * elemSize, 0, GL_STREAM_DRAW);
+	// OGLBufferObject::upload() unbinds GL_ELEMENT_ARRAY_BUFFER when it's
+	// done, so re-bind for the draw call about to use it.
+	GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, ScratchEBO.getName());
+	return 0;
+}
+
 void COpenGL3DriverBase::drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount)
 {
 	beginDraw(vertexType, uploadClientVertexData(vertexType, vertices, vertexCount));
@@ -1020,12 +1033,15 @@ void COpenGL3DriverBase::drawElements(GLenum primitiveType, const VertexType &ve
 		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void COpenGL3DriverBase::drawGeneric(const void *vertices, const void *indexList,
+void COpenGL3DriverBase::drawGeneric(const void *vertices, u32 vertexCount, const void *indexList,
 		u32 primitiveCount,
 		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType)
 {
 	auto &vTypeDesc = getVertexTypeDescription(vType);
-	beginDraw(vTypeDesc, reinterpret_cast<uintptr_t>(vertices));
+	uintptr_t verticesBase = vertices
+		? uploadClientVertexData(vTypeDesc, vertices, vertexCount)
+		: reinterpret_cast<uintptr_t>(vertices);
+	beginDraw(vTypeDesc, verticesBase);
 	GLenum indexSize = 0;
 
 	switch (iType) {
@@ -1037,34 +1053,65 @@ void COpenGL3DriverBase::drawGeneric(const void *vertices, const void *indexList
 		break;
 	}
 
+	// Precompute how many indices this draw will read, so a client-side
+	// indexList (see uploadClientIndexData) can be sized and uploaded once,
+	// before dispatching on primitive type below.
+	u32 indexCount = 0;
+	switch (pType) {
+	case scene::EPT_LINE_STRIP:
+		indexCount = primitiveCount + 1;
+		break;
+	case scene::EPT_LINE_LOOP:
+		indexCount = primitiveCount;
+		break;
+	case scene::EPT_LINES:
+		indexCount = primitiveCount * 2;
+		break;
+	case scene::EPT_TRIANGLE_STRIP:
+	case scene::EPT_TRIANGLE_FAN:
+		indexCount = primitiveCount + 2;
+		break;
+	case scene::EPT_TRIANGLES:
+		indexCount = primitiveCount * 3;
+		break;
+	default:
+		break;
+	}
+	if (indexList && indexCount)
+		indexList = reinterpret_cast<const void *>(uploadClientIndexData(indexList, indexCount, indexSize));
+
 	switch (pType) {
 	case scene::EPT_POINTS:
 	case scene::EPT_POINT_SPRITES:
 		GL.DrawArrays(GL_POINTS, 0, primitiveCount);
 		break;
 	case scene::EPT_LINE_STRIP:
-		GL.DrawElements(GL_LINE_STRIP, primitiveCount + 1, indexSize, indexList);
+		GL.DrawElements(GL_LINE_STRIP, indexCount, indexSize, indexList);
 		break;
 	case scene::EPT_LINE_LOOP:
-		GL.DrawElements(GL_LINE_LOOP, primitiveCount, indexSize, indexList);
+		GL.DrawElements(GL_LINE_LOOP, indexCount, indexSize, indexList);
 		break;
 	case scene::EPT_LINES:
-		GL.DrawElements(GL_LINES, primitiveCount * 2, indexSize, indexList);
+		GL.DrawElements(GL_LINES, indexCount, indexSize, indexList);
 		break;
 	case scene::EPT_TRIANGLE_STRIP:
-		GL.DrawElements(GL_TRIANGLE_STRIP, primitiveCount + 2, indexSize, indexList);
+		GL.DrawElements(GL_TRIANGLE_STRIP, indexCount, indexSize, indexList);
 		break;
 	case scene::EPT_TRIANGLE_FAN:
-		GL.DrawElements(GL_TRIANGLE_FAN, primitiveCount + 2, indexSize, indexList);
+		GL.DrawElements(GL_TRIANGLE_FAN, indexCount, indexSize, indexList);
 		break;
 	case scene::EPT_TRIANGLES:
-		GL.DrawElements(GL_TRIANGLES, primitiveCount * 3, indexSize, indexList);
+		GL.DrawElements(GL_TRIANGLES, indexCount, indexSize, indexList);
 		break;
 	default:
 		break;
 	}
 
 	endDraw(vTypeDesc);
+	if (Version.Spec == OpenGLSpec::Core) {
+		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	}
 }
 
 void COpenGL3DriverBase::beginDraw(const VertexType &vertexType, uintptr_t verticesBase)

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -496,7 +496,8 @@ void COpenGL3DriverBase::setTransform(E_TRANSFORMATION_STATE state, const core::
 void COpenGL3DriverBase::setJointTransforms(const std::vector<core::matrix4> &jointMatrices)
 {
 	assert(jointMatrices.size() <= getMaxJointTransforms());
-	JointTransformsUBO.upload(jointMatrices.data(), jointMatrices.size() * sizeof(core::matrix4), 0, GL_DYNAMIC_DRAW);
+	JointTransformsUBO.upload(jointMatrices.data(), jointMatrices.size() * sizeof(core::matrix4), 0, GL_DYNAMIC_DRAW,
+		/*mustShrink:*/ false, /*orphan:*/ true);
 	GL.BindBufferBase(GL_UNIFORM_BUFFER, 0, JointTransformsUBO.getName());
 	TEST_GL_ERROR(this);
 }
@@ -995,7 +996,8 @@ uintptr_t COpenGL3DriverBase::uploadClientVertexData(const VertexType &vertexTyp
 	if (Version.Spec != OpenGLSpec::Core)
 		return reinterpret_cast<uintptr_t>(vertices);
 
-	ScratchVBO.upload(vertices, static_cast<size_t>(vertexCount) * vertexType.VertexSize, 0, GL_STREAM_DRAW);
+	ScratchVBO.upload(vertices, static_cast<size_t>(vertexCount) * vertexType.VertexSize, 0, GL_STREAM_DRAW,
+		/*mustShrink:*/ false, /*orphan:*/ true);
 	// OGLBufferObject::upload() unbinds GL_ARRAY_BUFFER when it's done, so
 	// re-bind for the VertexAttribPointer calls beginDraw() is about to make.
 	GL.BindBuffer(GL_ARRAY_BUFFER, ScratchVBO.getName());
@@ -1008,7 +1010,8 @@ uintptr_t COpenGL3DriverBase::uploadClientIndexData(const void *indexList, u32 i
 		return reinterpret_cast<uintptr_t>(indexList);
 
 	size_t elemSize = (indexType == GL_UNSIGNED_SHORT) ? sizeof(u16) : sizeof(u32);
-	ScratchEBO.upload(indexList, static_cast<size_t>(indexCount) * elemSize, 0, GL_STREAM_DRAW);
+	ScratchEBO.upload(indexList, static_cast<size_t>(indexCount) * elemSize, 0, GL_STREAM_DRAW,
+		/*mustShrink:*/ false, /*orphan:*/ true);
 	// OGLBufferObject::upload() unbinds GL_ELEMENT_ARRAY_BUFFER when it's
 	// done, so re-bind for the draw call about to use it.
 	GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, ScratchEBO.getName());

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -986,18 +986,38 @@ void COpenGL3DriverBase::drawQuad(const VertexType &vertexType, const S3DVertex 
 	drawArrays(GL_TRIANGLE_FAN, vertexType, vertices, 4);
 }
 
+uintptr_t COpenGL3DriverBase::uploadClientVertexData(const VertexType &vertexType, const void *vertices, int vertexCount)
+{
+	// Core profile rejects glVertexAttribPointer calls that reference client
+	// (CPU-side) memory: the pointer argument is only valid as an offset into
+	// whatever's bound to GL_ARRAY_BUFFER. Compatibility profile has no such
+	// restriction, so leave its (already working) client-array path alone.
+	if (Version.Spec != OpenGLSpec::Core)
+		return reinterpret_cast<uintptr_t>(vertices);
+
+	ScratchVBO.upload(vertices, static_cast<size_t>(vertexCount) * vertexType.VertexSize, 0, GL_STREAM_DRAW);
+	// OGLBufferObject::upload() unbinds GL_ARRAY_BUFFER when it's done, so
+	// re-bind for the VertexAttribPointer calls beginDraw() is about to make.
+	GL.BindBuffer(GL_ARRAY_BUFFER, ScratchVBO.getName());
+	return 0;
+}
+
 void COpenGL3DriverBase::drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount)
 {
-	beginDraw(vertexType, reinterpret_cast<uintptr_t>(vertices));
+	beginDraw(vertexType, uploadClientVertexData(vertexType, vertices, vertexCount));
 	GL.DrawArrays(primitiveType, 0, vertexCount);
 	endDraw(vertexType);
+	if (Version.Spec == OpenGLSpec::Core)
+		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void COpenGL3DriverBase::drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount)
 {
-	beginDraw(vertexType, reinterpret_cast<uintptr_t>(vertices));
+	beginDraw(vertexType, uploadClientVertexData(vertexType, vertices, vertexCount));
 	GL.DrawRangeElements(primitiveType, 0, vertexCount - 1, indexCount, GL_UNSIGNED_SHORT, indices);
 	endDraw(vertexType);
+	if (Version.Spec == OpenGLSpec::Core)
+		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void COpenGL3DriverBase::drawGeneric(const void *vertices, const void *indexList,

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -326,6 +326,47 @@ void COpenGL3DriverBase::printTextureFormats()
 	}
 }
 
+namespace
+{
+void replaceAll(std::string &s, const std::string &from, const std::string &to)
+{
+	size_t pos = 0;
+	while ((pos = s.find(from, pos)) != std::string::npos) {
+		s.replace(pos, from.length(), to);
+		pos += to.length();
+	}
+}
+
+// client/shaders/Irrlicht/*.vsh|.fsh (Irrlicht's built-in fixed-function-emulation
+// material shaders, used for e.g. draw2DImage()) are written in GLSL ES 1.00 for
+// the GLES2/GLES3 driver. Desktop Core profile GLSL starts at #version 150 and
+// dropped `attribute`/`varying`/`gl_FragColor`/`texture2D`/`precision` -- some
+// Core-profile compilers tolerate the ES 1.00 syntax anyway, but that isn't
+// spec-guaranteed, so translate it the same way generateShader() does for
+// Luanti's own shaders in src/client/shader.cpp. Only called for these built-in
+// files (see loadShaderData() below); Luanti's own shaders already emit a
+// Core-appropriate header directly and never pass through here.
+c8 *patchBuiltInShaderForCoreProfile(c8 *data, bool isFragmentShader)
+{
+	std::string src(data);
+	delete[] data;
+
+	replaceAll(src, "#version 100", "#version 150");
+	replaceAll(src, "precision mediump float;\n", "");
+	replaceAll(src, "attribute ", "in ");
+	replaceAll(src, "varying ", isFragmentShader ? "in " : "out ");
+	replaceAll(src, "texture2D(", "texture(");
+	if (isFragmentShader && src.find("gl_FragColor") != std::string::npos) {
+		replaceAll(src, "gl_FragColor", "outFragColor");
+		src.insert(src.find('\n') + 1, "out vec4 outFragColor;\n");
+	}
+
+	c8 *out = new c8[src.size() + 1];
+	memcpy(out, src.c_str(), src.size() + 1);
+	return out;
+}
+}
+
 void COpenGL3DriverBase::loadShaderData(const io::path &vertexShaderName, const io::path &fragmentShaderName, c8 **vertexShaderData, c8 **fragmentShaderData)
 {
 	io::path vsPath(OGLES2ShaderPath);
@@ -383,6 +424,13 @@ void COpenGL3DriverBase::loadShaderData(const io::path &vertexShaderName, const 
 
 	vsFile->drop();
 	fsFile->drop();
+
+	if (Version.Spec == OpenGLSpec::Core) {
+		if (*vertexShaderData)
+			*vertexShaderData = patchBuiltInShaderForCoreProfile(*vertexShaderData, false);
+		if (*fragmentShaderData)
+			*fragmentShaderData = patchBuiltInShaderForCoreProfile(*fragmentShaderData, true);
+	}
 }
 
 void COpenGL3DriverBase::createMaterialRenderers()
@@ -398,32 +446,40 @@ void COpenGL3DriverBase::createMaterialRenderers()
 	// Create built-in materials.
 	// The addition order must be the same as in the E_MATERIAL_TYPE enumeration. Thus the
 
-	const core::stringc VertexShader = OGLES2ShaderPath + "Solid.vsh";
+	// Routed through loadShaderData() (rather than the path-based
+	// addHighLevelShaderMaterialFromFiles()) so these built-in GLSL ES 1.00
+	// shaders get the same Core-profile patch-up applied to the 2D material
+	// renderers below.
+	auto addBuiltInMaterial = [this](const io::path &vertexShaderName, const io::path &fragmentShaderName,
+			const char *name, IShaderConstantSetCallBack *cb, E_MATERIAL_TYPE baseMaterial) {
+		c8 *vsData = 0, *fsData = 0;
+		loadShaderData(vertexShaderName, fragmentShaderName, &vsData, &fsData);
+		addHighLevelShaderMaterial(vsData, fsData, nullptr, name,
+				scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, cb, baseMaterial, 0);
+		delete[] vsData;
+		delete[] fsData;
+	};
+
+	const io::path VertexShader("Solid.vsh");
 
 	// EMT_SOLID
-	core::stringc FragmentShader = OGLES2ShaderPath + "Solid.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "Solid",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, SolidCB, EMT_SOLID, 0);
+	addBuiltInMaterial(VertexShader, io::path("Solid.fsh"), "Solid", SolidCB, EMT_SOLID);
 
 	// EMT_TRANSPARENT_ALPHA_CHANNEL
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannel.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentAlphaChannel",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
+	addBuiltInMaterial(VertexShader, io::path("TransparentAlphaChannel.fsh"), "TransparentAlphaChannel",
+			TransparentAlphaChannelCB, EMT_TRANSPARENT_ALPHA_CHANNEL);
 
 	// EMT_TRANSPARENT_ALPHA_CHANNEL_REF
-	FragmentShader = OGLES2ShaderPath + "TransparentAlphaChannelRef.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentAlphaChannelRef",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentAlphaChannelRefCB, EMT_SOLID, 0);
+	addBuiltInMaterial(VertexShader, io::path("TransparentAlphaChannelRef.fsh"), "TransparentAlphaChannelRef",
+			TransparentAlphaChannelRefCB, EMT_SOLID);
 
 	// EMT_TRANSPARENT_VERTEX_ALPHA
-	FragmentShader = OGLES2ShaderPath + "TransparentVertexAlpha.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "TransparentVertexAlpha",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, TransparentVertexAlphaCB, EMT_TRANSPARENT_ALPHA_CHANNEL, 0);
+	addBuiltInMaterial(VertexShader, io::path("TransparentVertexAlpha.fsh"), "TransparentVertexAlpha",
+			TransparentVertexAlphaCB, EMT_TRANSPARENT_ALPHA_CHANNEL);
 
 	// EMT_ONETEXTURE_BLEND
-	FragmentShader = OGLES2ShaderPath + "OneTextureBlend.fsh";
-	addHighLevelShaderMaterialFromFiles(VertexShader, FragmentShader, "", "OneTextureBlend",
-			scene::EPT_TRIANGLES, scene::EPT_TRIANGLE_STRIP, 0, OneTextureBlendCB, EMT_ONETEXTURE_BLEND, 0);
+	addBuiltInMaterial(VertexShader, io::path("OneTextureBlend.fsh"), "OneTextureBlend",
+			OneTextureBlendCB, EMT_ONETEXTURE_BLEND);
 
 	// Drop callbacks.
 

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -296,6 +296,7 @@ protected:
 	virtual void setJointTransforms(const std::vector<core::matrix4> &jointMatrices) override;
 
 	void drawQuad(const VertexType &vertexType, const S3DVertex (&vertices)[4]);
+	uintptr_t uploadClientVertexData(const VertexType &vertexType, const void *vertices, int vertexCount);
 	void drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount);
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount);
 
@@ -355,6 +356,13 @@ private:
 
 	OGLBufferObject QuadIndexVBO = OGLBufferObject(OGLBufferObject::TARGET_VBO);
 	void initQuadsIndices(u32 max_vertex_count = 65536);
+
+	// Core profile forbids vertex attribute pointers into client (CPU-side)
+	// memory; every glVertexAttribPointer call must reference an offset into
+	// a bound GL_ARRAY_BUFFER. drawArrays()/drawElements() are handed plain
+	// client-side arrays (e.g. by draw2DImage/draw2DRectangle/draw3DLine), so
+	// under Core profile they first copy that data into this scratch VBO.
+	OGLBufferObject ScratchVBO = OGLBufferObject(OGLBufferObject::TARGET_VBO);
 
 	u16 MaxJointTransforms = 0;
 	void initMaxJointTransforms();

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -297,10 +297,11 @@ protected:
 
 	void drawQuad(const VertexType &vertexType, const S3DVertex (&vertices)[4]);
 	uintptr_t uploadClientVertexData(const VertexType &vertexType, const void *vertices, int vertexCount);
+	uintptr_t uploadClientIndexData(const void *indexList, u32 indexCount, GLenum indexType);
 	void drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount);
 	void drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount);
 
-	void drawGeneric(const void *vertices, const void *indexList, u32 primitiveCount,
+	void drawGeneric(const void *vertices, u32 vertexCount, const void *indexList, u32 primitiveCount,
 		E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);
 
 	void beginDraw(const VertexType &vertexType, uintptr_t verticesBase);
@@ -359,10 +360,14 @@ private:
 
 	// Core profile forbids vertex attribute pointers into client (CPU-side)
 	// memory; every glVertexAttribPointer call must reference an offset into
-	// a bound GL_ARRAY_BUFFER. drawArrays()/drawElements() are handed plain
-	// client-side arrays (e.g. by draw2DImage/draw2DRectangle/draw3DLine), so
-	// under Core profile they first copy that data into this scratch VBO.
+	// a bound GL_ARRAY_BUFFER. drawArrays()/drawElements()/drawGeneric() are
+	// sometimes handed plain client-side arrays (e.g. by draw2DImage,
+	// draw2DRectangle, draw3DLine, draw2DVertexPrimitiveList, and dynamic
+	// meshes with no hardware buffer cache), so under Core profile they
+	// first copy that data into these scratch buffers. Same restriction
+	// applies to element/index data and GL_ELEMENT_ARRAY_BUFFER.
 	OGLBufferObject ScratchVBO = OGLBufferObject(OGLBufferObject::TARGET_VBO);
+	OGLBufferObject ScratchEBO = OGLBufferObject(OGLBufferObject::TARGET_EBO);
 
 	u16 MaxJointTransforms = 0;
 	void initMaxJointTransforms();

--- a/irr/src/OpenGL3/DriverGL3.cpp
+++ b/irr/src/OpenGL3/DriverGL3.cpp
@@ -33,9 +33,26 @@ OpenGLVersion COpenGL3Driver::getVersionFromOpenGL() const
 
 void COpenGL3Driver::initFeatures()
 {
+#ifdef __APPLE__
+	// macOS never implemented a compatibility profile above 2.1, so
+	// CIrrDeviceSDL requests (and we must accept) a core profile there
+	// instead. Core profile forbids draws with no VAO bound; this driver
+	// re-specifies vertex attribute pointers before every draw rather than
+	// caching them in a VAO, so binding one throwaway VAO for the lifetime
+	// of the context is enough to satisfy that requirement.
+	if (Version.Spec != OpenGLSpec::Core && Version.Spec != OpenGLSpec::Compat) {
+		throw std::runtime_error("OpenGL 3 driver requires Core or Compatibility context");
+	}
+	if (Version.Spec == OpenGLSpec::Core) {
+		GLuint vao = 0;
+		GL.GenVertexArrays(1, &vao);
+		GL.BindVertexArray(vao);
+	}
+#else
 	if (Version.Spec != OpenGLSpec::Compat) {
 		throw std::runtime_error("OpenGL 3 driver requires Compatibility context");
 	}
+#endif
 	if (!isVersionAtLeast(3, 2)) {
 		throw std::runtime_error("OpenGL 3 driver requires OpenGL >= 3.2");
 	}

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -711,6 +711,17 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 		if (use_glsl3) {
 			shaders_header << "#define ATTRIBUTE_(n) layout(location = n) in\n"
 				"#define texture2D texture\n";
+		} else if (use_glsl15) {
+			// GLSL 1.5 doesn't have `layout(location=...)` without an ARB
+			// extension, but attribute indices are already assigned by name
+			// via glBindAttribLocation() before linking (see
+			// COpenGL3MaterialRenderer::init), so plain `in` is enough.
+			// Unlike `attribute`, `in` also works under a Core profile
+			// context (used on macOS, see CIrrDeviceSDL.cpp), whereas
+			// `attribute` is a Compatibility-profile-only keyword.
+			// `texture2D()` was likewise removed from GLSL 1.30+ core.
+			shaders_header << "#define ATTRIBUTE_(n) in\n"
+				"#define texture2D texture\n";
 		} else {
 			shaders_header << "#define ATTRIBUTE_(n) attribute\n";
 		}
@@ -755,7 +766,14 @@ void ShaderSource::generateShader(ShaderInfo &shaderinfo)
 				"#define gl_FragColor outFragColor\n"
 				"layout(location = 0) out vec4 outFragColor;\n";
 		} else if (use_glsl15) {
-			fragment_header += "#define VARYING_ in\n";
+			// `gl_FragColor` is a Compatibility-profile-only builtin; under
+			// a Core profile context (macOS) it doesn't exist, so declare
+			// our own output. With a single fragment output and no explicit
+			// layout qualifier it's implicitly bound to color number 0,
+			// same as GLSL 1.5 doesn't have `layout(location=...)` above.
+			fragment_header += "#define VARYING_ in\n"
+				"#define gl_FragColor outFragColor\n"
+				"out vec4 outFragColor;\n";
 		} else {
 			fragment_header += "#define VARYING_ varying\n";
 		}


### PR DESCRIPTION
## Summary

Fixes #16041 — on macOS, selecting `video_driver = opengl3` silently falls back to the legacy OpenGL 2.1 driver instead of actually using OpenGL 3+.

**Root cause:** macOS has never implemented an OpenGL Compatibility profile above 2.1 — only legacy 2.1 (no profile) or Core 3.2+ contexts exist there. `CIrrDeviceSDL` unconditionally requests `SDL_GL_CONTEXT_PROFILE_COMPATIBILITY` for the OpenGL3 driver, so context creation always fails on macOS and Irrlicht falls back to the 2.1 driver without any hard error — which matches exactly what's reported in #16041 ("window says opengl 2.1 is in use" despite `video_driver = opengl3`).

This PR requests a Core profile on `__APPLE__` instead, and does the extra work that turned out to require, discovered incrementally since each layer only became reachable — and testable — once the one below it actually worked:

1. **`irr/src/CIrrDeviceSDL.cpp`** — request `SDL_GL_CONTEXT_PROFILE_CORE` instead of `COMPATIBILITY` when creating the OpenGL3 context on macOS.
2. **`irr/src/OpenGL3/DriverGL3.cpp`** — Core profile forbids draw calls with no VAO bound (Compatibility profile allows an implicit default VAO 0). The driver had no VAO management anywhere. Rather than a broader refactor, this binds one throwaway VAO for the lifetime of the context when running under Core profile — sufficient because the existing draw path already re-specifies vertex attribute pointers before every single draw call rather than caching them in a VAO.
3. **`src/client/shader.cpp`** — getting an actual Core context exposed a second, previously-unexercised bug: the GLSL 1.5 shader header for the desktop OpenGL3 path used `attribute`, `gl_FragColor`, and `texture2D` — all Compatibility-profile-only / pre-1.30 builtins that Core profile GLSL rejects outright. Switched to `in`, a self-declared fragment output (implicitly bound to color 0 as the sole output), and `texture()`. No `layout(location=n)` qualifiers were needed — attribute indices are already assigned by name via the existing pre-link `glBindAttribLocation()` call in `COpenGL3MaterialRenderer::init`, regardless of profile.
4. **`irr/src/OpenGL/Driver.cpp` / `.h`** — with the 3D scene now actually rendering, the 2D UI (menus, HUD, formspecs) turned out to be silently broken: `draw2DImage`, `draw2DImageBatch`, `draw2DRectangle`, and `draw3DLine` all call `glVertexAttribPointer` with a plain client-side (CPU) array pointer and no `GL_ARRAY_BUFFER` bound. Compatibility profile allows this; Core profile rejects it with `GL_INVALID_OPERATION` on every single draw call (confirmed with `opengl_debug = true`), so the geometry was silently dropped — window and 3D world rendered fine, but the entire GUI layer was blank. Added a small reusable scratch VBO that these draws upload their client-side vertex data into under Core profile only; Compatibility profile keeps the exact same path as before.
5. **`irr/src/COpenGLCoreTexture.h`** — `GL_GENERATE_MIPMAP_HINT` is valid on GLES/Compatibility but not a legal enum under Core, raising `GL_INVALID_ENUM` on every texture that regenerates mipmaps. It has no effect on the `glGenerateMipmap()` call that follows it regardless of profile, so it's simply skipped on `__APPLE__`.
6. **`irr/src/OpenGL/Driver.cpp` / `.h` / `BufferObject.h`** — even with (4) fixed, the 3D world itself still failed to render at all (blank/sky-only view, HUD and wielded item fine). Root cause: two more call sites — `draw2DVertexPrimitiveList()`, and `drawVertexPrimitiveList()` for meshes with no hardware buffer cache — hand a raw client-side pointer straight to `drawGeneric()`, bypassing the scratch-buffer fix in (4) entirely (that fix only covered callers of `drawArrays()`/`drawElements()`). Confirmed via `glGetError()` polling that one of these failing every frame was leaving `GL_ARRAY_BUFFER`/`GL_ELEMENT_ARRAY_BUFFER` unbound, which then broke the *next* draw call in the same frame too — including perfectly correct, hardware-buffer-backed terrain mesh draws. Extended the same scratch-buffer approach into `drawGeneric()` itself (threading a vertex count through, plus a new `GL_ELEMENT_ARRAY_BUFFER`-targeted scratch buffer for client-side index data) so every draw path is now covered.

7. **`irr/src/OpenGL/BufferObject.cpp` / `.h`** — the scratch buffers added in (4)/(6) fixed correctness but introduced a real performance regression: `OGLBufferObject::upload()` reuses `glBufferSubData` into the existing allocation whenever the size matches the previous call, which can force the driver to stall the CPU until the GPU finishes reading the old contents from that same memory. For the 2D scratch buffers (re-uploaded on every single UI draw call, same size each time) this was visible as stuttery scrolling in menus with a lot of draw calls per frame — confirmed by testing. Rather than changing `upload()`'s default behavior for every caller (which would have silently broken its documented `offset`-based partial-update contract for any future caller, and applied a stall-avoidance tradeoff to buffers that never asked for it), added an explicit `orphan` opt-in parameter: when set, `upload()` always calls `BufferData` (orphaning the old storage and getting a fresh allocation back) instead of `BufferSubData`. Only the call sites that are genuinely re-uploaded at high frequency with their entire contents replaced every time opt in — `JointTransformsUBO` (per skinned-mesh draw) and the two Core-profile client-array scratch buffers from (4)/(6). `QuadIndexVBO` and the generic hardware mesh buffer upload path are unaffected and keep their original grow/shrink + `BufferSubData` behavior.

8. **`irr/src/OpenGL/Driver.cpp`** — `client/shaders/Irrlicht/*.vsh`/`*.fsh` (Irrlicht's own built-in fixed-function-emulation material renderers — Solid, TransparentAlphaChannel(Ref), TransparentVertexAlpha, OneTextureBlend, and Renderer2D, the last of which backs `draw2DImage()`/`draw2DRectangle()` and therefore most of the GUI) are written in GLSL ES 1.00 for the GLES2/GLES3 driver and were being fed unmodified into whatever GLSL compiler the active context has — this PR didn't originally touch them at all. That happens to compile on the hardware/driver this was tested on, but it isn't spec-guaranteed: desktop Core profile GLSL starts at `#version 150` and dropped `attribute`/`varying`/`gl_FragColor`/`texture2D`/`precision`, so relying on a specific compiler's leniency toward ES 1.00 syntax under Core is fragile across GPU vendors/driver versions. Routed the built-in Solid-family materials through the same `loadShaderData()` path already used for the 2D renderers, and added a translation step there — applied only when `Version.Spec == OpenGLSpec::Core` — doing the same `attribute`/`varying`/`gl_FragColor`/`texture2D` → `in`/`out`/custom-output/`texture()` rewrite that (3) already does for Luanti's own generated shaders. Compatibility and GLES contexts are untouched (the rewrite never triggers for them).

All of the above are gated on `__APPLE__` or `Version.Spec == OpenGLSpec::Core` (except (7), which is a general fix, opt-in per call site, and not gated on platform or profile) and are no-ops under the Compatibility contexts still used on Linux/Windows.

### Known limitation

Core profile only guarantees a line width of 1.0 (`glLineWidth` for values >1 is deprecated/unsupported under Core, unlike Compatibility). This means selection-box line thickness can no longer be controlled on macOS under this driver. There's no straightforward fix for this without a geometry-based line renderer, and the visual impact is minor, so it's left as-is for this PR.

## Testing

Built and ran locally on macOS 27.0 (Apple M4). Before this change, the window title bar showed the driver falling back to legacy 2.1. After, in-game it reports:

```
Luanti ... [Singleplayer] [4.1 Metal - 91.7]
```

i.e. a real Core 4.1 context (the max macOS exposes) instead of the 2.1 fallback. Verified with `opengl_debug = true` that no GL errors are logged anywhere in the main menu or in a singleplayer world with shadows/waving liquids/dynamic shadows/a couple dozen content mods installed, and visually confirmed by screenshot that:
- the main menu (tabs, world list, buttons, mod icons) renders correctly, not just the 3D background behind it, and
- an actual singleplayer world renders fully and correctly — terrain, lighting, dug-out holes, HUD, wielded item — not just sky and HUD.

Also confirmed that scrolling a long settings list is smooth, not stuttery, after (7). After (8), confirmed no shader-compile errors are logged for the built-in Solid/TransparentAlphaChannel/OneTextureBlend/Renderer2D materials and that the menu (which exercises Renderer2D on every draw call) still renders correctly.

### Note for other macOS + Homebrew users

Separately from this patch, if you build locally on macOS via Homebrew: Homebrew's `sdl2` formula is now an alias for `sdl2-compat` (a shim wrapping SDL3 — real standalone SDL2 was retired from homebrew-core). `sdl2-compat` dlopen's its SDL3 dependency relative to its own load path at library-init time. If you copy `libSDL2-2.0.0.dylib` into an app bundle's `Contents/Frameworks/` (as the normal macOS bundling/install step does) without also bundling `libSDL3.dylib` alongside it, the app aborts on launch with SIGABRT inside `dllinit`/`error_dialog` ("Failed loading SDL3 library") before any Luanti code runs — before `main()`, even. This is a packaging issue in the macOS bundling step, not something fixable in the engine source, so it's not part of this diff, but it's easy to hit while testing this PR locally and worth flagging: the fix is to also copy the real `libSDL3.dylib` (e.g. from `$(brew --prefix)/opt/sdl3/lib/libSDL3.0.dylib`) into `Contents/Frameworks/libSDL3.dylib`.
